### PR TITLE
Add cross-platform support, CI, and README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --extra dev
+      - run: uv run ruff check src tests
+      - run: uv run ruff format --check src tests
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --extra dev
+      - run: uv run pytest -v

--- a/README.md
+++ b/README.md
@@ -1,0 +1,152 @@
+# fabprint
+
+Headless 3D print pipeline: arrange parts on a build plate, slice to gcode, and print — all from a TOML config file.
+
+## Features
+
+- **Multi-format input** — STL, 3MF, and STEP files
+- **Automatic orientation** — flat, upright, side, or custom rotations
+- **Bin packing** — efficient 2D arrangement with configurable padding
+- **Part scaling** — uniform scale factor per part
+- **Multi-filament** — AMS slot assignment per part
+- **Slicer integration** — BambuStudio and OrcaSlicer CLI support
+- **Profile management** — discover, pin, and override slicer profiles
+- **Cross-platform** — macOS, Linux, and Windows
+
+## Installation
+
+Requires Python 3.11+.
+
+```bash
+pip install .
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv sync
+```
+
+Optional extras:
+
+```bash
+pip install ".[step]"   # STEP file support (build123d)
+pip install ".[cloud]"  # Bambu Cloud API
+pip install ".[all]"    # Everything
+pip install ".[dev]"    # pytest + ruff
+```
+
+## Quick start
+
+1. Create a `fabprint.toml` config:
+
+```toml
+[plate]
+size = [256, 256]
+padding = 5.0
+
+[slicer]
+engine = "orca"
+printer = "Bambu Lab P1S 0.4 nozzle"
+process = "0.20mm Standard @BBL X1C"
+filaments = ["Generic PLA @base"]
+
+[[parts]]
+file = "my_part.stl"
+copies = 4
+orient = "flat"
+filament = 1
+```
+
+2. Generate a build plate:
+
+```bash
+fabprint plate fabprint.toml -o plate.3mf
+```
+
+3. Slice to gcode:
+
+```bash
+fabprint slice fabprint.toml
+```
+
+## Config reference
+
+### `[plate]`
+
+| Key       | Type         | Default | Description              |
+|-----------|--------------|---------|--------------------------|
+| `size`    | `[w, h]`    | —       | Build plate size in mm   |
+| `padding` | `float`      | `5.0`   | Gap between parts in mm  |
+
+### `[slicer]`
+
+| Key         | Type       | Default   | Description                        |
+|-------------|------------|-----------|------------------------------------|
+| `engine`    | `string`   | `"orca"`  | `"orca"` or `"bambu"`              |
+| `printer`   | `string`   | —         | Printer profile name               |
+| `process`   | `string`   | —         | Process profile name               |
+| `filaments` | `[string]` | —         | Filament profiles (one per AMS slot) |
+
+### `[slicer.overrides]`
+
+Key-value pairs applied on top of the process profile:
+
+```toml
+[slicer.overrides]
+enable_support = 1
+wall_loops = 4
+```
+
+### `[[parts]]`
+
+| Key        | Type       | Default      | Description                          |
+|------------|------------|--------------|--------------------------------------|
+| `file`     | `string`   | —            | Path to mesh file (STL/3MF/STEP)     |
+| `copies`   | `int`      | `1`          | Number of copies                     |
+| `orient`   | `string`   | `"upright"`  | `"flat"`, `"upright"`, `"side"`, or `"custom"` |
+| `rotate`   | `[x,y,z]`  | `[0,0,0]`   | Custom rotation in degrees           |
+| `filament` | `int`      | `1`          | AMS filament slot (1-indexed)        |
+| `scale`    | `float`    | `1.0`        | Uniform scale factor                 |
+
+## CLI commands
+
+```
+fabprint plate <config>           # Arrange and export 3MF
+fabprint plate <config> --view    # Preview in viewer first
+fabprint slice <config>           # Arrange, export, and slice to gcode
+fabprint profiles list            # List available slicer profiles
+fabprint profiles pin <config>    # Pin profiles for reproducible builds
+```
+
+## Profile management
+
+fabprint resolves slicer profiles in this order:
+
+1. Direct file path (if the name contains `/` or `\`)
+2. Pinned profiles in `<project>/profiles/<category>/`
+3. Slicer system directory
+
+Pin profiles to lock your build against slicer updates:
+
+```bash
+fabprint profiles pin fabprint.toml
+```
+
+## Platform support
+
+fabprint auto-detects slicer paths per platform:
+
+| Platform | BambuStudio | OrcaSlicer |
+|----------|-------------|------------|
+| macOS    | `/Applications/BambuStudio.app/...` | `/Applications/OrcaSlicer.app/...` |
+| Linux    | `/usr/bin/bambu-studio` | `/usr/bin/orca-slicer` |
+| Windows  | `C:\Program Files\BambuStudio\...` | `C:\Program Files\OrcaSlicer\...` |
+
+Slicers on PATH are also detected (Flatpak, Snap, custom installs).
+
+Profile directories follow platform conventions (`~/Library/Application Support/` on macOS, `~/.config/` on Linux, `%APPDATA%` on Windows).
+
+## License
+
+Apache 2.0

--- a/src/fabprint/profiles.py
+++ b/src/fabprint/profiles.py
@@ -4,16 +4,36 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from pathlib import Path
 
 log = logging.getLogger(__name__)
 
 CATEGORIES = ("machine", "process", "filament")
 
-SYSTEM_DIRS: dict[str, Path] = {
-    "bambu": Path.home() / "Library/Application Support/BambuStudio/system/BBL",
-    "orca": Path.home() / "Library/Application Support/OrcaSlicer/system/BBL",
-}
+
+def _system_dirs() -> dict[str, Path]:
+    """Return slicer system profile directories for the current platform."""
+    if sys.platform == "darwin":
+        return {
+            "bambu": Path.home() / "Library/Application Support/BambuStudio/system/BBL",
+            "orca": Path.home() / "Library/Application Support/OrcaSlicer/system/BBL",
+        }
+    elif sys.platform == "win32":
+        appdata = Path.home() / "AppData/Roaming"
+        return {
+            "bambu": appdata / "BambuStudio/system/BBL",
+            "orca": appdata / "OrcaSlicer/system/BBL",
+        }
+    else:  # Linux and other Unix
+        config = Path.home() / ".config"
+        return {
+            "bambu": config / "BambuStudio/system/BBL",
+            "orca": config / "OrcaSlicer/system/BBL",
+        }
+
+
+SYSTEM_DIRS = _system_dirs()
 
 
 def _is_path(value: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,8 +5,12 @@ from pathlib import Path
 import pytest
 
 from fabprint.cli import main
+from fabprint.profiles import SYSTEM_DIRS
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+_orca_system = SYSTEM_DIRS.get("orca")
+_has_orca = _orca_system is not None and _orca_system.is_dir()
 
 
 def _write_config(tmp_path: Path, engine: str = "orca") -> Path:
@@ -65,6 +69,7 @@ def test_profiles_list():
     main(["profiles", "list", "--engine", "orca", "--category", "machine"])
 
 
+@pytest.mark.skipif(not _has_orca, reason="OrcaSlicer not installed")
 def test_profiles_pin(tmp_path):
     config = tmp_path / "fabprint.toml"
     config.write_text(f"""

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,22 +1,22 @@
 """Tests for profile discovery, resolution, and pinning."""
 
 import json
-from pathlib import Path
 
 import pytest
 
 from fabprint.profiles import (
+    SYSTEM_DIRS,
     discover_profiles,
     pin_profiles,
     resolve_profile,
     resolve_profile_data,
 )
 
-ORCA_SYSTEM = Path.home() / "Library/Application Support/OrcaSlicer/system/BBL"
+ORCA_SYSTEM = SYSTEM_DIRS.get("orca")
 
 
 def _has_orca():
-    return ORCA_SYSTEM.is_dir()
+    return ORCA_SYSTEM is not None and ORCA_SYSTEM.is_dir()
 
 
 @pytest.mark.skipif(not _has_orca(), reason="OrcaSlicer not installed")

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -1,26 +1,22 @@
 """Tests for slicer module."""
 
 import json
-from pathlib import Path
 
 import pytest
 
-from fabprint.slicer import _apply_overrides, find_slicer, parse_gcode_stats
-
-BAMBU_PATH = Path("/Applications/BambuStudio.app/Contents/MacOS/BambuStudio")
-ORCA_PATH = Path("/Applications/OrcaSlicer.app/Contents/MacOS/OrcaSlicer")
+from fabprint.slicer import SLICER_PATHS, _apply_overrides, find_slicer, parse_gcode_stats
 
 
 def test_find_bambu():
-    if not BAMBU_PATH.exists():
+    if not SLICER_PATHS["bambu"].exists():
         pytest.skip("BambuStudio not installed")
-    assert find_slicer("bambu") == BAMBU_PATH
+    assert find_slicer("bambu") == SLICER_PATHS["bambu"]
 
 
 def test_find_orca():
-    if not ORCA_PATH.exists():
+    if not SLICER_PATHS["orca"].exists():
         pytest.skip("OrcaSlicer not installed")
-    assert find_slicer("orca") == ORCA_PATH
+    assert find_slicer("orca") == SLICER_PATHS["orca"]
 
 
 def test_find_unknown():


### PR DESCRIPTION
## Summary
- **Cross-platform paths**: Replace hardcoded macOS slicer/profile paths with platform-aware detection for macOS, Linux, and Windows. `find_slicer()` now falls back to PATH lookup for AppImage, Flatpak, and custom installs.
- **CI pipeline**: Add GitHub Actions workflow with ruff lint/format checks and a test matrix across 3 OS (ubuntu/macOS/Windows) x 3 Python versions (3.11/3.12/3.13).
- **README**: Add docs covering installation, quick start, full config reference, CLI commands, profile management, and platform support table.

Also fixes a pre-existing test bug where `test_profiles_pin` would fail in CI (missing skipif guard for OrcaSlicer not installed).

## Test plan
- [x] All 46 tests pass, 7 skipped (no slicer installed) — verified on Linux
- [ ] CI workflow runs on push to this PR branch
- [ ] Verify macOS tests still pass with OrcaSlicer installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)