### PR TITLE
Add slicer version pinning and filament CLI overrides

### DIFF
--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -25,7 +25,9 @@ def main(argv: list[str] | None = None) -> None:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
     common.add_argument(
-        "--scale", type=float, default=None,
+        "--scale",
+        type=float,
+        default=None,
         help="Scale all parts by this factor (multiplies per-part scale)",
     )
 
@@ -42,42 +44,49 @@ def main(argv: list[str] | None = None) -> None:
         "slice", parents=[common], help="Arrange, export, and slice to gcode"
     )
     slice_cmd.add_argument("config", type=Path, help="Path to fabprint.toml")
-    slice_cmd.add_argument(
-        "-o", "--output-dir", type=Path, default=None, help="Output directory"
-    )
+    slice_cmd.add_argument("-o", "--output-dir", type=Path, default=None, help="Output directory")
     slice_cmd.add_argument(
         "--view", action="store_true", help="Show plate in viewer before slicing"
     )
     slice_cmd.add_argument(
-        "--docker", action="store_true",
+        "--docker",
+        action="store_true",
         help="Force slicing via Docker (even if local slicer is available)",
     )
     slice_cmd.add_argument(
-        "--docker-version", type=str, default=None,
+        "--docker-version",
+        type=str,
+        default=None,
         help="Use a specific OrcaSlicer Docker image version (e.g. 2.3.1)",
     )
     slice_cmd.add_argument(
-        "--filament-type", type=str, default=None,
+        "--filament-type",
+        type=str,
+        default=None,
         help="Override filament profile name (e.g. 'Generic PLA @base')",
     )
     slice_cmd.add_argument(
-        "--filament-slot", type=int, default=1,
+        "--filament-slot",
+        type=int,
+        default=1,
         help="AMS slot for --filament-type (default: 1)",
     )
 
     # profiles subcommand
-    profiles_cmd = sub.add_parser(
-        "profiles", parents=[common], help="List or pin slicer profiles"
-    )
+    profiles_cmd = sub.add_parser("profiles", parents=[common], help="List or pin slicer profiles")
     profiles_sub = profiles_cmd.add_subparsers(dest="profiles_command")
 
     list_cmd = profiles_sub.add_parser("list", help="List available profiles")
     list_cmd.add_argument(
-        "--engine", default="orca", choices=["orca", "bambu"],
+        "--engine",
+        default="orca",
+        choices=["orca", "bambu"],
         help="Slicer engine (default: orca)",
     )
     list_cmd.add_argument(
-        "--category", default=None, choices=["machine", "process", "filament"],
+        "--category",
+        default=None,
+        choices=["machine", "process", "filament"],
         help="Filter by category",
     )
 
@@ -147,9 +156,7 @@ def _generate_plate(
     if getattr(args, "view", False):
         from fabprint.viewer import show_plate
 
-        show_plate(
-            [p.mesh for p in placements], [p.name for p in placements], cfg.plate.size
-        )
+        show_plate([p.mesh for p in placements], [p.name for p in placements], cfg.plate.size)
 
     scene = build_plate(placements, cfg.plate.size)
     export_plate(scene, output)
@@ -157,7 +164,9 @@ def _generate_plate(
 
 
 def _print_summary(
-    part_info: list[tuple], total: int, plate_size: tuple[float, float],
+    part_info: list[tuple],
+    total: int,
+    plate_size: tuple[float, float],
 ) -> None:
     """Print a build summary table."""
     name_width = max(len(name) for name, *_ in part_info)

--- a/src/fabprint/config.py
+++ b/src/fabprint/config.py
@@ -85,9 +85,7 @@ def load_config(path: Path) -> FabprintConfig:
             raise ValueError(f"parts[{i}]: 'file' is required")
         orient = p.get("orient", "flat")
         if orient not in VALID_ORIENTS:
-            raise ValueError(
-                f"parts[{i}]: orient must be one of {VALID_ORIENTS}, got '{orient}'"
-            )
+            raise ValueError(f"parts[{i}]: orient must be one of {VALID_ORIENTS}, got '{orient}'")
         file_path = base_dir / p["file"]
         if not file_path.exists():
             raise FileNotFoundError(f"parts[{i}]: file not found: {file_path}")
@@ -105,13 +103,15 @@ def load_config(path: Path) -> FabprintConfig:
         scale = float(p.get("scale", 1.0))
         if scale <= 0:
             raise ValueError(f"parts[{i}]: scale must be > 0, got {scale}")
-        parts.append(PartConfig(
-            file=file_path,
-            copies=copies,
-            orient=orient,
-            rotate=rotate,
-            filament=filament,
-            scale=scale,
-        ))
+        parts.append(
+            PartConfig(
+                file=file_path,
+                copies=copies,
+                orient=orient,
+                rotate=rotate,
+                filament=filament,
+                scale=scale,
+            )
+        )
 
     return FabprintConfig(plate=plate, slicer=slicer, parts=parts, base_dir=base_dir)

--- a/src/fabprint/loader.py
+++ b/src/fabprint/loader.py
@@ -68,8 +68,7 @@ def extract_paint_colors(path: Path) -> list[str] | None:
             if "3D/3dmodel.model" in zf.namelist():
                 model_files.append("3D/3dmodel.model")
             model_files.extend(
-                n for n in zf.namelist()
-                if n.startswith("3D/Objects/") and n.endswith(".model")
+                n for n in zf.namelist() if n.startswith("3D/Objects/") and n.endswith(".model")
             )
             if not model_files:
                 return None

--- a/src/fabprint/plate.py
+++ b/src/fabprint/plate.py
@@ -87,9 +87,7 @@ def _inject_paint_data(output: Path, scene: trimesh.Scene) -> None:
     # Re-register all namespaces from the original XML so ET preserves
     # prefixes (avoids ns0: renames). Note: ET.tostring still drops
     # unused namespace declarations from the root element.
-    for _event, (prefix, uri) in ET.iterparse(
-        io.BytesIO(model_xml), events=["start-ns"]
-    ):
+    for _event, (prefix, uri) in ET.iterparse(io.BytesIO(model_xml), events=["start-ns"]):
         ET.register_namespace(prefix, uri)
 
     root = ET.fromstring(model_xml)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,9 @@ def _docker_orca_version() -> str | None:
     try:
         r = subprocess.run(
             ["docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}}"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         versions = []
         for line in r.stdout.splitlines():
@@ -67,12 +69,12 @@ padding = 5.0
 engine = "{engine}"
 
 [[parts]]
-file = "{_posix(FIXTURES / 'cube_10mm.stl')}"
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 copies = 2
 orient = "flat"
 
 [[parts]]
-file = "{_posix(FIXTURES / 'cylinder_5x20mm.stl')}"
+file = "{_posix(FIXTURES / "cylinder_5x20mm.stl")}"
 orient = "upright"
 """)
     return toml
@@ -123,7 +125,7 @@ process = "0.20mm Standard @BBL X1C"
 filaments = ["Generic PLA @base"]
 
 [[parts]]
-file = "{_posix(FIXTURES / 'cube_10mm.stl')}"
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 """)
     main(["profiles", "pin", str(config)])
     assert (tmp_path / "profiles" / "machine" / "Bambu Lab P1S 0.4 nozzle.json").exists()
@@ -157,7 +159,7 @@ process = "0.20mm Standard @BBL X1C"
 filaments = [{filament_toml}]
 
 [[parts]]
-file = "{_posix(FIXTURES / 'cube_10mm.stl')}"
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 copies = 1
 """)
     return toml
@@ -173,15 +175,20 @@ def test_slice_docker(tmp_path, monkeypatch):
     output_dir = work_dir / "output"
     monkeypatch.chdir(work_dir)
     try:
-        main([
-            "slice", str(config),
-            "-o", str(output_dir),
-        ])
+        main(
+            [
+                "slice",
+                str(config),
+                "-o",
+                str(output_dir),
+            ]
+        )
         gcode_files = list(output_dir.glob("*.gcode"))
         assert len(gcode_files) >= 1, "Expected at least one gcode file"
         assert gcode_files[0].stat().st_size > 0
     finally:
         import shutil
+
         shutil.rmtree(work_dir, ignore_errors=True)
 
 
@@ -198,17 +205,24 @@ def test_slice_docker_filament_override(tmp_path, monkeypatch):
     output_dir = work_dir / "output"
     monkeypatch.chdir(work_dir)
     try:
-        main([
-            "slice", str(config),
-            "-o", str(output_dir),
-            "--filament-type", "Generic PLA @base",
-            "--filament-slot", "1",
-        ])
+        main(
+            [
+                "slice",
+                str(config),
+                "-o",
+                str(output_dir),
+                "--filament-type",
+                "Generic PLA @base",
+                "--filament-slot",
+                "1",
+            ]
+        )
         gcode_files = list(output_dir.glob("*.gcode"))
         assert len(gcode_files) >= 1, "Expected at least one gcode file"
         assert gcode_files[0].stat().st_size > 0
     finally:
         import shutil
+
         shutil.rmtree(work_dir, ignore_errors=True)
 
 
@@ -221,10 +235,15 @@ def test_slice_docker_version_mismatch(tmp_path, monkeypatch):
     monkeypatch.chdir(work_dir)
     try:
         with pytest.raises(FileNotFoundError, match="Docker image"):
-            main([
-                "slice", str(config),
-                "-o", str(work_dir / "output"),
-            ])
+            main(
+                [
+                    "slice",
+                    str(config),
+                    "-o",
+                    str(work_dir / "output"),
+                ]
+            )
     finally:
         import shutil
+
         shutil.rmtree(work_dir, ignore_errors=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,9 @@ def _write_toml(tmp_path: Path, content: str, create_files: list[str] | None = N
 
 
 def test_valid_config(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [plate]
 size = [200, 200]
 padding = 3.0
@@ -40,7 +42,9 @@ filament = 1
 file = "cyl.stl"
 orient = "upright"
 filament = 2
-""", create_files=["cube.stl", "cyl.stl"])
+""",
+        create_files=["cube.stl", "cyl.stl"],
+    )
 
     cfg = load_config(path)
     assert cfg.plate.size == (200, 200)
@@ -59,10 +63,14 @@ filament = 2
 
 
 def test_defaults(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "cube.stl"
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
 
     cfg = load_config(path)
     assert cfg.plate.size == (256.0, 256.0)
@@ -73,117 +81,161 @@ file = "cube.stl"
 
 
 def test_missing_parts(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [plate]
 size = [200, 200]
-""")
+""",
+    )
     with pytest.raises(ValueError, match="At least one"):
         load_config(path)
 
 
 def test_bad_orient(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "cube.stl"
 orient = "diagonal"
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     with pytest.raises(ValueError, match="orient"):
         load_config(path)
 
 
 def test_bad_plate_size(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [plate]
 size = [-1, 200]
 
 [[parts]]
 file = "cube.stl"
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     with pytest.raises(ValueError, match="plate.size"):
         load_config(path)
 
 
 def test_missing_file(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "nonexistent.stl"
-""")
+""",
+    )
     with pytest.raises(FileNotFoundError, match="nonexistent.stl"):
         load_config(path)
 
 
 def test_filament_defaults_to_1(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "cube.stl"
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     cfg = load_config(path)
     assert cfg.parts[0].filament == 1
 
 
 def test_bad_filament(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "cube.stl"
 filament = 0
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     with pytest.raises(ValueError, match="filament"):
         load_config(path)
 
 
 def test_bad_copies(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "cube.stl"
 copies = 0
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     with pytest.raises(ValueError, match="copies"):
         load_config(path)
 
 
 def test_bad_engine(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [slicer]
 engine = "cura"
 
 [[parts]]
 file = "cube.stl"
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     with pytest.raises(ValueError, match="engine"):
         load_config(path)
 
 
 def test_scale(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "cube.stl"
 scale = 2.0
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     cfg = load_config(path)
     assert cfg.parts[0].scale == 2.0
 
 
 def test_scale_default(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "cube.stl"
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     cfg = load_config(path)
     assert cfg.parts[0].scale == 1.0
 
 
 def test_bad_scale(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "cube.stl"
 scale = 0
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     with pytest.raises(ValueError, match="scale"):
         load_config(path)
 
 
 def test_overrides(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [slicer]
 engine = "orca"
 
@@ -193,7 +245,9 @@ wall_loops = 3
 
 [[parts]]
 file = "cube.stl"
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     cfg = load_config(path)
     assert cfg.slicer.overrides == {
         "sparse_infill_density": "25%",
@@ -202,22 +256,30 @@ file = "cube.stl"
 
 
 def test_overrides_default_empty(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [[parts]]
 file = "cube.stl"
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     cfg = load_config(path)
     assert cfg.slicer.overrides == {}
 
 
 def test_version(tmp_path):
-    path = _write_toml(tmp_path, """
+    path = _write_toml(
+        tmp_path,
+        """
 [slicer]
 engine = "orca"
 version = "2.3.1"
 
 [[parts]]
 file = "cube.stl"
-""", create_files=["cube.stl"])
+""",
+        create_files=["cube.stl"],
+    )
     cfg = load_config(path)
     assert cfg.slicer.version == "2.3.1"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -58,9 +58,7 @@ def _make_painted_3mf(path, paint_colors):
     ET.register_namespace("", ns)
     with zipfile.ZipFile(path, "r") as zf:
         model_xml = zf.read("3D/3dmodel.model")
-        other_files = {
-            n: zf.read(n) for n in zf.namelist() if n != "3D/3dmodel.model"
-        }
+        other_files = {n: zf.read(n) for n in zf.namelist() if n != "3D/3dmodel.model"}
 
     root = ET.fromstring(model_xml)
     triangles = list(root.iter(f"{{{ns}}}triangle"))

--- a/tests/test_plate.py
+++ b/tests/test_plate.py
@@ -38,9 +38,9 @@ def test_build_and_export_3mf(tmp_path):
 
 
 def test_encode_paint_color():
-    assert _encode_paint_color(0) == "4"   # filament 1
-    assert _encode_paint_color(1) == "8"   # filament 2
-    assert _encode_paint_color(2) == "C"   # filament 3
+    assert _encode_paint_color(0) == "4"  # filament 1
+    assert _encode_paint_color(1) == "8"  # filament 2
+    assert _encode_paint_color(2) == "C"  # filament 3
     assert _encode_paint_color(3) == "10"  # filament 4
 
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -94,9 +94,7 @@ def test_resolve_profile_data_flattens_inheritance(tmp_path):
     child = {"from": "system", "inherits": "root", "wall_loops": 3}
     cat_dir.joinpath("child.json").write_text(json.dumps(child))
 
-    data = resolve_profile_data(
-        str(cat_dir / "child.json"), "orca", "process", tmp_path
-    )
+    data = resolve_profile_data(str(cat_dir / "child.json"), "orca", "process", tmp_path)
     # Child overrides wall_loops, inherits enable_support and infill from root
     assert data["wall_loops"] == 3
     assert data["enable_support"] == 0
@@ -108,9 +106,7 @@ def test_resolve_profile_data_flattens_inheritance(tmp_path):
 @pytest.mark.skipif(not _has_orca(), reason="OrcaSlicer not installed")
 def test_resolve_profile_data_real_process():
     """Verify real OrcaSlicer process profile resolves enable_support."""
-    data = resolve_profile_data(
-        "0.20mm Standard @BBL X1C", "orca", "process"
-    )
+    data = resolve_profile_data("0.20mm Standard @BBL X1C", "orca", "process")
     # Must have enable_support from the root of the chain
     assert "enable_support" in data
     # Must not have inherits (fully flattened)

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -61,10 +61,14 @@ def test_apply_overrides():
         "sparse_infill_density": "15%",
         "other_setting": "keep",
     }
-    result = _apply_overrides(data, {
-        "wall_loops": 4,
-        "sparse_infill_density": "25%",
-    }, "test_profile")
+    result = _apply_overrides(
+        data,
+        {
+            "wall_loops": 4,
+            "sparse_infill_density": "25%",
+        },
+        "test_profile",
+    )
 
     assert result["wall_loops"] == "4"
     assert result["sparse_infill_density"] == "25%"
@@ -93,7 +97,8 @@ def test_has_docker_true():
         assert _has_docker("fabprint:orca-2.3.1") is True
         mock_run.assert_called_once_with(
             ["docker", "image", "inspect", "fabprint:orca-2.3.1"],
-            capture_output=True, timeout=10,
+            capture_output=True,
+            timeout=10,
         )
 
 
@@ -128,8 +133,12 @@ def test_slice_via_docker_command(tmp_path):
     mock_result = MagicMock(returncode=0, stdout="", stderr="")
     with patch("fabprint.slicer.subprocess.run", return_value=mock_result) as mock_run:
         _slice_via_docker(
-            input_3mf, output_dir, profile_dir,
-            settings_arg, filament_arg, "fabprint:orca-2.3.1",
+            input_3mf,
+            output_dir,
+            profile_dir,
+            settings_arg,
+            filament_arg,
+            "fabprint:orca-2.3.1",
         )
 
     cmd = mock_run.call_args[0][0]
@@ -159,7 +168,12 @@ def test_slice_via_docker_failure(tmp_path):
     with patch("fabprint.slicer.subprocess.run", return_value=mock_result):
         with pytest.raises(RuntimeError, match="Docker slicer failed"):
             _slice_via_docker(
-                input_3mf, output_dir, profile_dir, None, None, "fabprint:latest",
+                input_3mf,
+                output_dir,
+                profile_dir,
+                None,
+                None,
+                "fabprint:latest",
             )
 
 
@@ -186,9 +200,13 @@ def test_slice_plate_local_command(tmp_path):
         patch("fabprint.slicer.subprocess.run", return_value=mock_result) as mock_run,
     ):
         slice_plate(
-            input_3mf, engine="orca", output_dir=output_dir,
-            printer="My Printer", process="My Process",
-            filaments=["PLA"], overrides={"wall_loops": 4},
+            input_3mf,
+            engine="orca",
+            output_dir=output_dir,
+            printer="My Printer",
+            process="My Process",
+            filaments=["PLA"],
+            overrides={"wall_loops": 4},
         )
 
     cmd = mock_run.call_args[0][0]
@@ -214,7 +232,9 @@ def test_slice_plate_docker_fallback(tmp_path):
         patch("fabprint.slicer.subprocess.run", return_value=mock_result) as mock_run,
     ):
         slice_plate(
-            input_3mf, engine="orca", output_dir=output_dir,
+            input_3mf,
+            engine="orca",
+            output_dir=output_dir,
             printer="My Printer",
         )
 
@@ -237,8 +257,11 @@ def test_slice_plate_docker_explicit(tmp_path):
         patch("fabprint.slicer.subprocess.run", return_value=mock_result) as mock_run,
     ):
         slice_plate(
-            input_3mf, engine="orca", output_dir=output_dir,
-            printer="My Printer", docker=True,
+            input_3mf,
+            engine="orca",
+            output_dir=output_dir,
+            printer="My Printer",
+            docker=True,
         )
 
     cmd = mock_run.call_args[0][0]
@@ -260,8 +283,11 @@ def test_slice_plate_docker_version(tmp_path):
         patch("fabprint.slicer.subprocess.run", return_value=mock_result) as mock_run,
     ):
         slice_plate(
-            input_3mf, engine="orca", output_dir=output_dir,
-            printer="My Printer", docker_version="2.3.1",
+            input_3mf,
+            engine="orca",
+            output_dir=output_dir,
+            printer="My Printer",
+            docker_version="2.3.1",
         )
 
     cmd = mock_run.call_args[0][0]
@@ -279,7 +305,9 @@ def test_slice_plate_docker_image_missing(tmp_path):
     ):
         with pytest.raises(FileNotFoundError, match="Docker image.*not found"):
             slice_plate(
-                input_3mf, engine="orca", docker_version="9.9.9",
+                input_3mf,
+                engine="orca",
+                docker_version="9.9.9",
             )
 
 


### PR DESCRIPTION
## Summary

- **Slicer version pinning**: New optional `version` field in `[slicer]` config (e.g. `version = "2.3.1"`). When set, fabprint uses the matching Docker image and fails if it's not available. For local slicer, detects version from `--help` output and fails on mismatch.
- **Filament CLI overrides**: `--filament-type "Generic PLA @base" --filament-slot 2` overrides config filaments with a single filament in a specific AMS slot. Useful as a workaround for the paint_color + multi-filament crash.
- **Version display**: Always prints `Slicer: OrcaSlicer X.Y.Z (Docker)` when slicing.
- **Docker integration tests**: Auto-detect latest stable `fabprint:orca-*` image using `packaging.Version`. Override with `FABPRINT_TEST_ORCA_VERSION` env var. Tests skip if Docker isn't running.

## Test plan

- [x] `uv run pytest tests/` — 79 tests pass
- [x] Docker slice test with version from config
- [x] Filament override test via Docker
- [x] Version mismatch test (missing Docker image fails)
- [ ] Manual: `fabprint slice fabprint.toml --filament-type "Generic PLA @base" --filament-slot 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)