### PR TITLE
Document key extraction research and BC macOS findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ output/
 .DS_Store
 .coverage
 *.png
+scripts/bambu_cloud_bridge


### PR DESCRIPTION
## Summary
- Document 6 private key extraction approaches tried for pure Python cloud printing
- Add Bambu Connect macOS analysis revealing per-installation key architecture
- Add `send-mqtt` and `install-cert` commands to cloud bridge
- Gitignore compiled bridge binary

## Key Finding
Each Bambu Connect / library installation generates its own RSA key pair and certificate. The Jan 2025 "leaked" key was per-installation, not global. Our Linux library's key (`b04ef6650000`) must be extracted specifically.

## Test plan
- [x] Research doc renders correctly in markdown
- [x] Bridge compiles with new commands
- [x] No sensitive credentials in committed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)