### PR TITLE
Fix Docker/Rosetta path crash on macOS

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -144,21 +144,43 @@ def _run_bridge(
     use_docker = bridge is None or platform.system() == "Darwin"
 
     if use_docker:
-        # Fall back to Docker
-        cmd = [
-            "docker",
-            "run",
-            "--rm",
-            "--platform",
-            "linux/amd64",
-        ]
-        # Mount any file paths that appear in args
-        for i, arg in enumerate(args):
-            if os.path.exists(arg):
-                abs_path = os.path.abspath(arg)
-                cmd.extend(["-v", f"{abs_path}:{abs_path}:ro"])
-        cmd.append(DOCKER_IMAGE)
-        cmd.extend(args)
+        # Copy input files to a staging dir so Docker sees plain Linux paths.
+        # Bind-mounting macOS paths (e.g. /var/folders/...) into a Rosetta
+        # container triggers ENOSYS for statx() inside boost::filesystem.
+        import shutil
+        import tempfile
+
+        staging = tempfile.mkdtemp(prefix="fabprint_bridge_")
+        try:
+            docker_args = []
+            for arg in args:
+                if os.path.exists(arg):
+                    dst = os.path.join(staging, os.path.basename(arg))
+                    shutil.copy2(arg, dst)
+                    docker_args.append(f"/data/{os.path.basename(arg)}")
+                else:
+                    docker_args.append(arg)
+
+            cmd = [
+                "docker", "run", "--rm",
+                "--platform", "linux/amd64",
+                "-v", f"{staging}:/data",
+                DOCKER_IMAGE,
+            ] + docker_args
+
+            if verbose:
+                cmd.append("-v")
+
+            log.debug("Running: %s", " ".join(cmd))
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+        return result
     else:
         cmd = [bridge] + args
 


### PR DESCRIPTION
## Summary

Fixes a crash (`exit 139`, SIGSEGV) when running the cloud bridge via Docker on macOS Apple Silicon (Rosetta emulation).

**Root cause:** `boost::filesystem::file_size` calls `statx()` which returns `ENOSYS` when the path being stat'd is a macOS path (e.g. `/var/folders/...`) bind-mounted into a Rosetta x86_64 container.

**Fix:** Copy input files to a temporary staging directory and mount that as `/data` inside the container, so the bridge only sees clean Linux-style paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)