### PR TITLE
Fix staged file permissions for Docker bridge on macOS

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -157,6 +157,7 @@ def _run_bridge(
                 if os.path.exists(arg):
                     dst = os.path.join(staging, os.path.basename(arg))
                     shutil.copy2(arg, dst)
+                    os.chmod(dst, 0o644)  # Docker runs as different user
                     docker_args.append(f"/data/{os.path.basename(arg)}")
                 else:
                     docker_args.append(arg)


### PR DESCRIPTION
## Summary

Token file (`~/.bambu_cloud_token`) has permissions `0600`. `shutil.copy2` preserves those, but the Docker container runs as a different user and gets "cannot read /data/.bambu_cloud_token". Fix: `chmod 0644` after copying to the staging directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)