### PR TITLE
Fix staging dir permissions for Docker bridge on macOS

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -151,6 +151,7 @@ def _run_bridge(
         import tempfile
 
         staging = tempfile.mkdtemp(prefix="fabprint_bridge_")
+        os.chmod(staging, 0o755)  # mkdtemp creates 0700; Docker user needs traversal
         try:
             docker_args = []
             for arg in args:


### PR DESCRIPTION
## Summary

`tempfile.mkdtemp()` creates directories with mode `0700`. The Docker container user can't traverse into it even though the files inside are `0644`. Fix: `chmod 0755` on the staging dir so the container can access the mounted files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)