### PR TITLE
Use /tmp for Docker staging dir on macOS

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -150,8 +150,10 @@ def _run_bridge(
         import shutil
         import tempfile
 
-        staging = tempfile.mkdtemp(prefix="fabprint_bridge_")
-        os.chmod(staging, 0o755)  # mkdtemp creates 0700; Docker user needs traversal
+        # Use /tmp explicitly: macOS tempfile defaults to /var/folders/ which is
+        # a symlink Docker may not resolve correctly. /tmp is always shared.
+        staging = tempfile.mkdtemp(prefix="fabprint_bridge_", dir="/tmp")
+        os.chmod(staging, 0o755)
         try:
             docker_args = []
             for arg in args:


### PR DESCRIPTION
## Summary

macOS `tempfile.mkdtemp()` defaults to `/var/folders/` which is a symlink to `/private/var/folders/`. Docker Desktop may not resolve this symlink correctly, causing the container to fail reading bind-mounted files. Use `/tmp` explicitly as the staging dir parent — it's always directly shared by Docker Desktop with no symlink indirection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)