### PR TITLE
Resolve symlinks in staging path for Docker on macOS

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -150,9 +150,9 @@ def _run_bridge(
         import shutil
         import tempfile
 
-        # Use /tmp explicitly: macOS tempfile defaults to /var/folders/ which is
-        # a symlink Docker may not resolve correctly. /tmp is always shared.
-        staging = tempfile.mkdtemp(prefix="fabprint_bridge_", dir="/tmp")
+        # Resolve symlinks: on macOS /tmp -> /private/tmp and /var/folders ->
+        # /private/var/folders. Docker Desktop shares /private, not the symlinks.
+        staging = os.path.realpath(tempfile.mkdtemp(prefix="fabprint_bridge_"))
         os.chmod(staging, 0o755)
         try:
             docker_args = []


### PR DESCRIPTION
## Summary

`/tmp` and `/var/folders` on macOS are symlinks to `/private/tmp` and `/private/var/folders`. Docker Desktop shares `/private`, not the symlink paths — bind-mounting a symlink path silently succeeds but the container can't read the files. Use `os.path.realpath()` on the staging dir to get the canonical `/private/...` path before passing to `docker run -v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)