### PR TITLE
Create config 3MF temp file alongside source 3MF on macOS

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -243,7 +243,11 @@ def cloud_print(
         args.extend(["--config-3mf", str(config_3mf.resolve())])
     else:
         config_bytes = _strip_gcode_from_3mf(threemf_path)
-        tmp_config = tempfile.NamedTemporaryFile(suffix=".3mf", delete=False)
+        # Create alongside the source 3MF so it's under /Users — macOS
+        # /var/folders temp files cause statx() ENOSYS inside Docker/Rosetta.
+        tmp_config = tempfile.NamedTemporaryFile(
+            suffix=".3mf", delete=False, dir=threemf_path.parent
+        )
         tmp_config.write(config_bytes)
         tmp_config.close()
         args.extend(["--config-3mf", tmp_config.name])


### PR DESCRIPTION
## Summary

`tempfile.NamedTemporaryFile` defaults to `/var/folders/` on macOS. When this path is bind-mounted into the Docker/Rosetta container, `boost::filesystem::file_size` crashes with `ENOSYS` (statx syscall not implemented for that filesystem). Fix: create the temp config 3MF in `threemf_path.parent` (the output dir under `/Users/`) which Docker Desktop exposes without statx issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)