### PR TITLE
Fix bridge hang after successful print + fix 0g filament

### DIFF
--- a/scripts/bambu_cloud_bridge.cpp
+++ b/scripts/bambu_cloud_bridge.cpp
@@ -855,9 +855,15 @@ static int cmd_print(const std::string& token_json_raw, const std::string& devic
         std::this_thread::sleep_for(std::chrono::seconds(15));
     }
 
-    // Wait for completion
-    for (int i = 0; i < timeout_secs && !g_print_done; i++) {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+    // Wait up to timeout_secs for the library's completion callback.
+    // In practice the callback may never fire (printer accepts via MQTT but
+    // doesn't echo back), so we don't block the full timeout — if fp_start_print
+    // returned success (0 or -1) we exit as soon as the task is submitted.
+    if (ret != 0 && ret != -1) {
+        // Only wait for callback if start_print returned an unexpected code
+        for (int i = 0; i < timeout_secs && !g_print_done; i++) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
     }
 
     // Structured output
@@ -865,21 +871,22 @@ static int cmd_print(const std::string& token_json_raw, const std::string& devic
     int exit_code = 1;
     if (g_print_result == 0) { result_str = "success"; exit_code = 0; }
     else if (ret == 0 || ret == -1) {
-        // ret=0 means library returned success, ret=-1 might mean printer busy
-        // but task was likely created
         result_str = (ret == 0) ? "success" : "sent";
-        exit_code = (ret == 0) ? 0 : 0; // -1 often means task created but printer timeout
+        exit_code = 0;
     }
     else { result_str = "error"; }
 
     if (saved_out >= 0) { dup2(saved_out, STDOUT_FILENO); close(saved_out); }
+    fflush(stdout);
     printf("{\"result\":\"%s\",\"return_code\":%d,\"print_result\":%d,"
            "\"device_id\":\"%s\",\"file\":\"%s\"}\n",
            result_str, ret, g_print_result.load(),
            device_id.c_str(), file_3mf.c_str());
+    fflush(stdout);
 
-    cleanup();
-    return exit_code;
+    // destroy_agent and dlclose can hang indefinitely waiting for MQTT threads.
+    // Use _exit() to bypass atexit handlers and skip cleanup entirely.
+    _exit(exit_code);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/fabprint/gcode.py
+++ b/src/fabprint/gcode.py
@@ -25,12 +25,20 @@ def parse_gcode_metadata(gcode_path: Path) -> dict[str, str | float | int]:
         elif m := re.match(r";\s*estimated printing time.*?=\s*(.+)", line):
             stats["print_time"] = m.group(1).strip()
 
-    # Scan tail for filament stats
+    # Scan tail for filament stats. OrcaSlicer emits one line per slot
+    # (including 0.00 for unused slots) then sometimes a total line.
+    # Sum all values to get the true total; a single total line gives itself.
+    filament_g_total = 0.0
+    filament_cm3_total = 0.0
     for line in lines[-50:]:
         if m := re.match(r";\s*(?:total )?filament used \[g\]\s*=\s*([\d.]+)", line):
-            stats["filament_g"] = float(m.group(1))
+            filament_g_total += float(m.group(1))
         elif m := re.match(r";\s*(?:total )?filament used \[cm3\]\s*=\s*([\d.]+)", line):
-            stats["filament_cm3"] = float(m.group(1))
+            filament_cm3_total += float(m.group(1))
+    if filament_g_total > 0:
+        stats["filament_g"] = filament_g_total
+    if filament_cm3_total > 0:
+        stats["filament_cm3"] = filament_cm3_total
 
     # Convert time string like "1h 7m 32s" to seconds
     if "print_time" in stats:


### PR DESCRIPTION
## Summary

**Bridge hang fix:** `fp_start_print` returns 0 or -1 immediately when the task is submitted to Bambu Cloud. The completion callback rarely fires via MQTT, so the bridge was waiting the full `timeout_secs` (180s) before calling `cleanup()`, which then hung indefinitely on `destroy_agent`/`dlclose` MQTT threads. Fix: skip the wait when start_print succeeds, and use `_exit()` instead of cleanup to avoid the thread hang.

**0g filament fix:** OrcaSlicer emits one `filament used [g]` line per AMS slot, including `0.00` for unused slots. The parser was overwriting with each match so the last (unused slot) value won. Now sums all values for the correct total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)