### PR TITLE
Add fabprint status command + pre-print availability check

### DIFF
--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -144,6 +145,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     pin_cmd.add_argument("config", type=Path, help="Path to fabprint.toml")
 
+    # status subcommand
+    status_cmd = sub.add_parser("status", parents=[common], help="Query live printer status")
+    status_cmd.add_argument("config", type=Path, help="Path to fabprint.toml")
+
     args = parser.parse_args(argv)
 
     if args.command is None:
@@ -161,6 +166,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_slice(args)
     elif args.command == "print":
         _cmd_print(args)
+    elif args.command == "status":
+        _cmd_status(args)
     elif args.command == "profiles":
         _cmd_profiles(args)
 
@@ -321,6 +328,37 @@ def _cmd_print(args: argparse.Namespace) -> None:
         upload_only=args.upload_only,
         experimental=getattr(args, "experimental", False),
     )
+
+
+def _cmd_status(args: argparse.Namespace) -> None:
+    from fabprint.printer import get_printer_status
+
+    cfg = load_config(args.config)
+    if cfg.printer is None:
+        raise ValueError("No [printer] section in config.")
+
+    serial = cfg.printer.serial or os.environ.get("BAMBU_SERIAL")
+    if not serial:
+        raise ValueError("No serial in [printer] config or BAMBU_SERIAL env var.")
+
+    print(f"Querying printer {serial}...")
+    status = get_printer_status(serial)
+
+    state = status.get("gcode_state", "unknown")
+    percent = status.get("mc_percent", 0)
+    layer = status.get("layer_num", 0)
+    total_layers = status.get("total_layer_num", 0)
+    remaining = status.get("mc_remaining_time", 0)
+
+    print(f"  State:    {state}")
+    if state not in ("IDLE", "FINISH", "FAILED", ""):
+        print(f"  Progress: {percent}%", end="")
+        if total_layers:
+            print(f" (layer {layer}/{total_layers})", end="")
+        print()
+        if remaining:
+            h, m = divmod(int(remaining), 60)
+            print(f"  Remaining: {h}h {m}m" if h else f"  Remaining: {m}m")
 
 
 def _cmd_profiles(args: argparse.Namespace) -> None:

--- a/src/fabprint/printer.py
+++ b/src/fabprint/printer.py
@@ -283,6 +283,27 @@ def _send_bambu_connect(
     print("  Opened in Bambu Connect — confirm and print from there")
 
 
+def _get_token_file() -> Path:
+    token_file_str = os.environ.get("BAMBU_TOKEN_FILE")
+    return Path(token_file_str) if token_file_str else Path.home() / ".bambu_cloud_token"
+
+
+def get_printer_status(serial: str) -> dict:
+    """Query live printer status via the cloud bridge.
+
+    Returns a dict with keys like gcode_state, mc_percent, layer_num, etc.
+    Raises RuntimeError if the bridge fails.
+    """
+    from fabprint.cloud import cloud_status
+
+    token_file = _get_token_file()
+    if not token_file.exists():
+        raise FileNotFoundError(
+            f"Token file not found: {token_file}. Run 'python scripts/bambu_cloud_login.py' first."
+        )
+    return cloud_status(serial, token_file)
+
+
 def _send_cloud_bridge(
     gcode_path: Path,
     serial: str | None = None,
@@ -295,11 +316,7 @@ def _send_cloud_bridge(
     """
     from fabprint.cloud import cloud_print
 
-    token_file_str = os.environ.get("BAMBU_TOKEN_FILE")
-    if token_file_str:
-        token_file = Path(token_file_str)
-    else:
-        token_file = Path.home() / ".bambu_cloud_token"
+    token_file = _get_token_file()
 
     if not token_file.exists():
         raise FileNotFoundError(
@@ -313,6 +330,23 @@ def _send_cloud_bridge(
         raise ValueError(
             "cloud-bridge mode requires serial. Set in [printer] config or BAMBU_SERIAL env var."
         )
+
+    # Check printer availability before sending
+    if not dry_run:
+        try:
+            status = get_printer_status(serial)
+            gcode_state = status.get("gcode_state", "")
+            if gcode_state not in ("IDLE", "FINISH", "FAILED", ""):
+                raise RuntimeError(
+                    f"Printer is not ready (state: {gcode_state}). "
+                    "Wait for current job to finish or cancel it first."
+                )
+            if gcode_state:
+                print(f"  Printer ready (state: {gcode_state})")
+        except RuntimeError as e:
+            if "not ready" in str(e):
+                raise
+            log.debug("Status check failed (printer may be offline): %s", e)
 
     # Use the slicer's .gcode.3mf if available, otherwise wrap the gcode
     sliced_3mf = gcode_path.parent / "plate_sliced.gcode.3mf"


### PR DESCRIPTION
## Summary

- **`fabprint status <config>`** — queries live printer state via the cloud bridge (MQTT), displays:
  - Current state (IDLE, RUNNING, PAUSE, FINISH, FAILED)
  - Progress % and layer count (when printing)
  - Estimated remaining time
- **Pre-print check** — `_send_cloud_bridge` now queries printer status before submitting a job and raises a clear error if the printer isn't ready (e.g. already printing)
- **`_get_token_file()` helper** — extracted from `_send_cloud_bridge` to share with `get_printer_status`

## Usage
\`\`\`
fabprint status fabprint.toml
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)