### PR TITLE
Show AMS slots as 1-based in status output

### DIFF
--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -365,7 +365,7 @@ def _cmd_status(args: argparse.Namespace) -> None:
     if ams_trays:
         print("  AMS:")
         for t in ams_trays:
-            print(f"    slot {t['phys_slot']}  {t['type']:<12}  #{t['color']}")
+            print(f"    slot {t['phys_slot'] + 1}  {t['type']:<12}  #{t['color']}")
 
 
 def _cmd_profiles(args: argparse.Namespace) -> None:


### PR DESCRIPTION
Matches the slot numbering shown in the Bambu app (1–4) rather than 0-based (0–3). Internal `phys_slot` values are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)