### PR TITLE
Show active AMS slot in status output during printing

### DIFF
--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -363,9 +363,11 @@ def _cmd_status(args: argparse.Namespace) -> None:
 
     ams_trays = parse_ams_trays(status)
     if ams_trays:
+        tray_now_raw = int(status.get("ams", {}).get("tray_now", 255))
         print("  AMS:")
         for t in ams_trays:
-            print(f"    slot {t['phys_slot'] + 1}  {t['type']:<12}  #{t['color']}")
+            active = " <-- printing" if t["phys_slot"] == tray_now_raw else ""
+            print(f"    slot {t['phys_slot'] + 1}  {t['type']:<12}  #{t['color']}{active}")
 
 
 def _cmd_profiles(args: argparse.Namespace) -> None:


### PR DESCRIPTION
Uses \`tray_now\` from the printer's MQTT status to annotate which AMS slot is currently feeding filament:

\`\`\`
  AMS:
    slot 1  PLA           #FCECD6
    slot 2  ASA           #BCBCBC
    slot 3  PETG-CF       #2850E0 <-- printing
    slot 4  ABS           #161616
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)