### PR TITLE
Show bridge stderr on error + wire verbose flag

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -277,10 +277,17 @@ def cloud_print(
                 pass
 
     if result.stderr:
-        log.debug("Bridge stderr: %s", result.stderr.strip())
+        # Always show stderr on non-zero exit so errors are visible without --verbose
+        if result.returncode != 0:
+            log.warning("Bridge stderr:\n%s", result.stderr.strip())
+        else:
+            log.debug("Bridge stderr: %s", result.stderr.strip())
 
     try:
-        return json.loads(result.stdout.strip())
+        data = json.loads(result.stdout.strip())
+        if data.get("return_code", 0) != 0 and result.stderr:
+            log.warning("Bridge stderr:\n%s", result.stderr.strip())
+        return data
     except json.JSONDecodeError:
         raise RuntimeError(
             f"Bridge returned non-JSON output (exit {result.returncode}): "

--- a/src/fabprint/printer.py
+++ b/src/fabprint/printer.py
@@ -308,6 +308,7 @@ def _send_cloud_bridge(
     gcode_path: Path,
     serial: str | None = None,
     dry_run: bool = False,
+    verbose: bool = False,
 ) -> None:
     """Send gcode to printer via the bambu_cloud_bridge binary.
 
@@ -376,6 +377,7 @@ def _send_cloud_bridge(
         token_file=token_file,
         project_name=gcode_path.stem,
         ams_trays=ams_trays,
+        verbose=verbose,
     )
 
     status = result.get("result", "unknown")
@@ -505,6 +507,7 @@ def send_print(
             gcode_path,
             serial=creds["serial"],
             dry_run=dry_run,
+            verbose=log.isEnabledFor(logging.DEBUG),
         )
 
     elif creds["mode"] == "cloud-http":


### PR DESCRIPTION
- Always log bridge stderr at WARNING when `return_code != 0`, so errors are visible without `--verbose`
- Wire verbose flag through `send_print` → `_send_cloud_bridge` → `cloud_print` → bridge `-v` flag

This will let us diagnose the -3120 error by running `fabprint print ... --verbose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)