### PR TITLE
Add 0.x.y versioning and version Docker images

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -14,6 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(python3 -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -32,6 +38,7 @@ jobs:
           push: true
           tags: |
             fabprint/fabprint-cloud-bridge:latest
+            fabprint/fabprint-cloud-bridge:${{ steps.version.outputs.version }}
             fabprint/fabprint-cloud-bridge:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -8,6 +8,7 @@ import os
 import sys
 from pathlib import Path
 
+from fabprint import __version__
 from fabprint.arrange import arrange
 from fabprint.config import FabprintConfig, load_config
 from fabprint.loader import extract_paint_colors, load_mesh
@@ -20,6 +21,7 @@ def main(argv: list[str] | None = None) -> None:
         prog="fabprint",
         description="Headless 3D print pipeline: arrange, slice, and print",
     )
+    parser.add_argument("--version", action="version", version=f"fabprint {__version__}")
     sub = parser.add_subparsers(dest="command")
 
     # Shared args for subcommands


### PR DESCRIPTION
## Summary
- Version source of truth: `pyproject.toml` (currently `0.1.0`)
- `__init__.py` already exports `__version__`
- CLI now supports `fabprint --version`
- `publish-cloud-bridge.yml` reads version from `pyproject.toml` and tags Docker images as `:latest`, `:<version>`, and `:<sha>`

**Convention:** bump `x` for interface/UX changes, bump `y` for internal fixes/bug fixes.

## Test plan
- [ ] `fabprint --version` prints `fabprint 0.1.0`
- [ ] CI build tags Docker image as `fabprint/fabprint-cloud-bridge:0.1.0` in addition to `:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)