### PR TITLE
Use GH_PAT for version bump push to bypass branch protection

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          token: ${{ secrets.GH_PAT }}
 
       - name: Bump patch version
         id: version


### PR DESCRIPTION
## Summary
`GITHUB_TOKEN` cannot push to protected branches on personal repos (no bypass allowances). Uses a PAT stored as `GH_PAT` secret for the checkout so the version bump commit can push directly to main.

## Setup required
Before merging: add a PAT with `repo` scope as a secret named `GH_PAT` in **Settings → Secrets → Actions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)