### PR TITLE
Add PyPI publish on every merge to main

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write  # required for PyPI trusted publishing
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,6 +39,19 @@ jobs:
             | grep -qE 'Dockerfile\.cloud-bridge|scripts/bambu_cloud_bridge\.cpp' \
             && echo "changed=true" >> "$GITHUB_OUTPUT" \
             || echo "changed=false" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build Python package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Log in to Docker Hub
         if: steps.bridge_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
Publishes `fabprint` to PyPI on every merge to main, using the already-bumped version.

Uses **PyPI Trusted Publishing** (OIDC) — no API token stored as a secret. PyPI issues a short-lived token automatically via GitHub's OIDC provider.

## One-time PyPI setup required before merging
1. Log in to PyPI → **Account Settings → Publishing**
2. **Add a new pending publisher**:
   - PyPI project name: `fabprint`
   - Owner: `pzfreo`
   - Repository: `fabprint`
   - Workflow name: `publish-cloud-bridge.yml`
   - Environment: *(leave blank)*
3. That's it — no secrets to add

After the first publish, the project will be created on PyPI automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)