### PR TITLE
Cap AMS mapping at loaded filament count

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -563,6 +563,12 @@ def _build_ams_mapping(
     if not filament_by_id:
         return result
 
+    # Cap at highest used filament id — OrcaSlicer may define extra default
+    # slots (e.g. 5 for P1S) that duplicate the last loaded filament.
+    max_loaded = max(filament_by_id.keys())
+    if total_slots > max_loaded:
+        total_slots = max_loaded
+
     log.debug(
         "3MF filament slots: plate=%s, total=%d, settings=%s",
         list(filament_by_id.keys()), total_slots, filament_setting_ids,


### PR DESCRIPTION
## Summary
OrcaSlicer P1S profile defines 5 filament slots but only 3 are loaded. The extra 2 slots default to the last filament type ("Generic PETG-CF @base"), producing `[3, 1, 2, 2, 2]` instead of `[3, 1, 2]`.

Fix: cap `total_slots` at `max(filament_by_id.keys())` to exclude phantom duplicates.

## Test plan
- [ ] Debug log shows `AMS slot mapping: [3, 1, 2]` (exactly 3 elements)
- [ ] No "Failed to get AMS mapping table" dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)