### PR TITLE
Fix Docker Hub image names to use fabprint org

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -81,8 +81,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            pzfreo/fabprint-cloud-bridge:latest
-            pzfreo/fabprint-cloud-bridge:${{ steps.version.outputs.version }}
+            fabprint/cloud-bridge:latest
+            fabprint/cloud-bridge:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -95,8 +95,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            pzfreo/fabprint-orca:latest
-            pzfreo/fabprint-orca:${{ steps.version.outputs.version }}
+            fabprint/fabprint:latest
+            fabprint/fabprint:${{ steps.version.outputs.version }}
           build-args: ORCA_VERSION=2.3.1
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Multi-stage build: OrcaSlicer CLI + fabprint
 #
 # Usage:
-#   docker build --build-arg ORCA_VERSION=2.3.1 -t fabprint:orca-2.3.1 .
-#   docker run --rm -v "$PWD:/project" fabprint:orca-2.3.1 slice fabprint.toml
+#   docker build --build-arg ORCA_VERSION=2.3.1 -t fabprint/fabprint:2.3.1 .
+#   docker run --rm -v "$PWD:/project" fabprint/fabprint:2.3.1 slice fabprint.toml
 
 # ---------------------------------------------------------------------------
 # Stage 1: Extract OrcaSlicer from AppImage (x86_64 only)

--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -34,7 +34,7 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 BRIDGE_NAME = "bambu_cloud_bridge"
-DOCKER_IMAGE = "pzfreo/fabprint-cloud-bridge"
+DOCKER_IMAGE = "fabprint/cloud-bridge"
 BASE_URL = "https://api.bambulab.com"
 
 # BambuConnect X.509 certificate ID and private key for signing print tasks.

--- a/src/fabprint/slicer.py
+++ b/src/fabprint/slicer.py
@@ -17,7 +17,7 @@ from fabprint.profiles import resolve_profile_data
 
 log = logging.getLogger(__name__)
 
-DOCKERHUB_REPO = "pzfreo/fabprint-orca"
+DOCKERHUB_REPO = "fabprint/fabprint"
 DEFAULT_DOCKER_IMAGE = f"{DOCKERHUB_REPO}:latest"
 
 

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -80,12 +80,12 @@ def test_apply_overrides():
 
 
 def test_docker_image_default():
-    assert _docker_image() == "pzfreo/fabprint-orca:latest"
+    assert _docker_image() == "fabprint/fabprint:latest"
 
 
 def test_docker_image_versioned():
-    assert _docker_image("2.3.1") == "pzfreo/fabprint-orca:2.3.1"
-    assert _docker_image("2.3.2") == "pzfreo/fabprint-orca:2.3.2"
+    assert _docker_image("2.3.1") == "fabprint/fabprint:2.3.1"
+    assert _docker_image("2.3.2") == "fabprint/fabprint:2.3.2"
 
 
 # --- _has_docker_image ---
@@ -240,7 +240,7 @@ def test_slice_plate_docker_fallback(tmp_path):
 
     cmd = mock_run.call_args[0][0]
     assert cmd[0] == "docker"
-    assert "pzfreo/fabprint-orca:latest" in cmd
+    assert "fabprint/fabprint:latest" in cmd
 
 
 def test_slice_plate_docker_explicit(tmp_path):
@@ -266,7 +266,7 @@ def test_slice_plate_docker_explicit(tmp_path):
 
     cmd = mock_run.call_args[0][0]
     assert cmd[0] == "docker"
-    assert "pzfreo/fabprint-orca:latest" in cmd
+    assert "fabprint/fabprint:latest" in cmd
 
 
 def test_slice_plate_docker_version(tmp_path):
@@ -292,7 +292,7 @@ def test_slice_plate_docker_version(tmp_path):
 
     cmd = mock_run.call_args[0][0]
     assert cmd[0] == "docker"
-    assert "pzfreo/fabprint-orca:2.3.1" in cmd
+    assert "fabprint/fabprint:2.3.1" in cmd
 
 
 def test_slice_plate_docker_image_missing(tmp_path):


### PR DESCRIPTION
## Summary
- Reverts Docker Hub image names from `pzfreo/` (personal account) back to `fabprint/` org
- Cloud bridge: `fabprint/cloud-bridge` (was `pzfreo/fabprint-cloud-bridge`)
- OrcaSlicer: `fabprint/fabprint` (was `pzfreo/fabprint-orca`)
- Updates workflow, source code constants, Dockerfile comments, and tests

## Test plan
- [x] `uv run ruff check src tests` — passes
- [x] `uv run ruff format --check src tests` — passes
- [x] `uv run pytest` — 131/133 pass (2 Docker integration tests fail because image not yet pushed to Hub under new name — expected)
- [x] No remaining `pzfreo/` or `fabprint-orca`/`fabprint-cloud-bridge` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)