### PR TITLE
Fix AMS mapping: use -1 sentinels for unused slots

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -252,15 +252,11 @@ def cloud_print(
     if ams_trays:
         ams_data = _build_ams_mapping(threemf_path, ams_trays=ams_trays)
         raw = ams_data["amsMapping"]
-        if raw:
-            # Strip trailing 255s (unused slots) to keep the array compact,
-            # but keep leading 255s so slot indices stay correct.
-            bridge_mapping = raw[:]
-            while bridge_mapping and bridge_mapping[-1] == 255:
-                bridge_mapping.pop()
-            if bridge_mapping and any(v != 255 for v in bridge_mapping):
-                args.extend(["--ams-mapping", json.dumps(bridge_mapping)])
-                log.debug("AMS slot mapping: %s", bridge_mapping)
+        if raw and any(v >= 0 for v in raw):
+            # Pass full mapping including -1 sentinels for unused slots,
+            # matching BambuConnect's format: e.g. [-1, -1, 2, -1, -1]
+            args.extend(["--ams-mapping", json.dumps(raw)])
+            log.debug("AMS slot mapping: %s", raw)
 
     # Auto-generate config-only 3MF if not provided.
     # The v02.05 library requires a separate config_filename (3MF without gcode).
@@ -567,12 +563,6 @@ def _build_ams_mapping(
     if not filament_by_id:
         return result
 
-    # Cap at highest used filament id — OrcaSlicer may define extra default
-    # slots (e.g. 5 for P1S) that duplicate the last loaded filament.
-    max_loaded = max(filament_by_id.keys())
-    if total_slots > max_loaded:
-        total_slots = max_loaded
-
     log.debug(
         "3MF filament slots: plate=%s, total=%d, settings=%s",
         list(filament_by_id.keys()),
@@ -583,19 +573,11 @@ def _build_ams_mapping(
     # Physical slot assignment: use live AMS state when available, else sequential.
     phys_by_id = _build_ams_mapping_from_state(filament_by_id, total_slots, ams_trays or [])
 
-    # Build lookups from physical slot and filament type → AMS tray
+    # Build lookup from physical slot → AMS tray for targetColor resolution
     tray_by_phys = {t["phys_slot"]: t for t in (ams_trays or [])}
-    # Group AMS trays by type for matching against filament setting names
-    tray_by_type: dict[str, list[dict]] = {}
-    for t in ams_trays or []:
-        typ = t.get("type", "")
-        if typ:
-            tray_by_type.setdefault(typ, []).append(t)
-    # Sort type keys longest-first so "PETG-CF" matches before "PLA" etc.
-    type_keys_sorted = sorted(tray_by_type.keys(), key=len, reverse=True)
 
     # All arrays are full-length (one entry per virtual slot), matching BambuConnect's format.
-    # Unused slots get sentinel values: -1 / {255,255} / "" — not just the used filaments.
+    # Unused slots get sentinel -1 / {255,255} / "" — matching BC's captured payload.
     detail = []
     mapping = []
     mapping2 = []
@@ -628,53 +610,20 @@ def _build_ams_mapping(
             mapping2.append({"amsId": phys_slot // 4, "slotId": phys_slot % 4})
             setting_ids.append(tray_idx)
         else:
-            # Slot not used on this plate — try matching via filament_settings_id
-            # (e.g. "Generic ABS @base") so loaded-but-unused filaments still get
-            # correct physical slots. Without this, single-material prints produce
-            # an incomplete mapping that triggers "Failed to get AMS mapping table".
-            n = len(filament_setting_ids)
-            setting_id = filament_setting_ids[slot_idx] if slot_idx < n else ""
-            # Match by finding which AMS tray type appears in the setting name
-            tray = None
-            if setting_id:
-                for typ in type_keys_sorted:
-                    if typ in setting_id:
-                        candidates = tray_by_type[typ]
-                        tray = candidates[0]
-                        break
-            if tray:
-                phys_slot = tray["phys_slot"]
-                target_color = tray["color"] + "FF"
-                detail.append(
-                    {
-                        "ams": phys_slot,
-                        "amsId": phys_slot // 4,
-                        "slotId": phys_slot % 4,
-                        "nozzleId": 0,
-                        "sourceColor": target_color,
-                        "targetColor": target_color,
-                        "filamentType": tray.get("type", ""),
-                        "targetFilamentType": tray.get("type", ""),
-                        "filamentId": setting_id,
-                    }
-                )
-                mapping.append(phys_slot)
-                mapping2.append({"amsId": phys_slot // 4, "slotId": phys_slot % 4})
-                setting_ids.append(setting_id)
-            else:
-                detail.append(
-                    {
-                        "ams": -1,
-                        "amsId": 255,
-                        "slotId": 255,
-                        "filamentId": "",
-                        "filamentType": "",
-                        "targetColor": "",
-                    }
-                )
-                mapping.append(255)
-                mapping2.append({"amsId": 255, "slotId": 255})
-                setting_ids.append("")
+            # Unused slot — use -1 sentinel matching BambuConnect's format.
+            detail.append(
+                {
+                    "ams": -1,
+                    "amsId": 255,
+                    "slotId": 255,
+                    "filamentId": "",
+                    "filamentType": "",
+                    "targetColor": "",
+                }
+            )
+            mapping.append(-1)
+            mapping2.append({"amsId": 255, "slotId": 255})
+            setting_ids.append("")
 
     result["amsDetailMapping"] = detail
     result["amsMapping"] = mapping
@@ -725,11 +674,11 @@ def _build_ams_mapping_from_state(
 ) -> list[int]:
     """Match virtual filament slots to physical AMS trays.
 
-    Returns ams_mapping list of length total_slots (255 for unused slots).
+    Returns ams_mapping list of length total_slots (-1 for unused slots).
     Matches first by filament type, then by color if multiple candidates.
     Falls back to sequential slot 0, 1, 2… if no AMS state available.
     """
-    am = [255] * total_slots
+    am = [-1] * total_slots
     used = set()  # physical slots already assigned
 
     for seq_idx, filament_id in enumerate(sorted(filament_by_id.keys())):

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1,16 +1,23 @@
 """Tests for the cloud printing wrapper module."""
 
+import io
+import json
+import xml.etree.ElementTree as ET
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from fabprint.cloud import (
+    _build_ams_mapping,
+    _build_ams_mapping_from_state,
     _find_bridge,
     cloud_cancel,
     cloud_print,
     cloud_status,
     cloud_tasks,
+    parse_ams_trays,
 )
 
 
@@ -162,3 +169,321 @@ class TestCloudCancel:
             result = cloud_cancel("DEV123", token_file)
             assert result["sent"] is True
             assert result["device_id"] == "DEV123"
+
+
+# ---------------------------------------------------------------------------
+# AMS mapping tests
+# ---------------------------------------------------------------------------
+
+
+def _make_filament_xml(filaments: list[dict]) -> dict:
+    """Build filament_by_id dict of XML elements, matching how _build_ams_mapping parses them."""
+    parts = []
+    for f in filaments:
+        attrs = " ".join(f'{k}="{v}"' for k, v in f.items())
+        parts.append(f"<filament {attrs} />")
+    xml = f"<plate>{''.join(parts)}</plate>"
+    root = ET.fromstring(xml)
+    return {int(f.get("id", "1")): f for f in root.findall("filament")}
+
+
+def _make_ams_trays(trays: list[dict]) -> list[dict]:
+    """Build AMS tray list in the format returned by parse_ams_trays."""
+    result = []
+    for t in trays:
+        result.append(
+            {
+                "phys_slot": t.get("phys_slot", t.get("ams_id", 0) * 4 + t.get("slot_id", 0)),
+                "ams_id": t.get("ams_id", 0),
+                "slot_id": t.get("slot_id", 0),
+                "type": t["type"],
+                "color": t["color"],
+                "tray_info_idx": t.get("tray_info_idx", ""),
+            }
+        )
+    return result
+
+
+def _make_3mf(
+    tmp_path: Path,
+    filaments_xml: str,
+    filament_colours: list[str],
+    filament_settings_ids: list[str],
+    name: str = "test.3mf",
+) -> Path:
+    """Create a minimal 3MF with slice_info and project_settings for testing."""
+    slice_info = f"""<?xml version="1.0" encoding="UTF-8"?>
+<config>
+  <plate>
+    <metadata key="index" value="1"/>
+{filaments_xml}
+  </plate>
+</config>"""
+    project_settings = json.dumps(
+        {
+            "filament_colour": filament_colours,
+            "filament_settings_id": filament_settings_ids,
+        }
+    )
+    path = tmp_path / name
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("Metadata/slice_info.config", slice_info)
+        zf.writestr("Metadata/project_settings.config", project_settings)
+        zf.writestr("Metadata/model_settings.config", "<config/>")
+    path.write_bytes(buf.getvalue())
+    return path
+
+
+# --- Full 4-slot AMS fixture (matches P1S with mixed filaments) ---
+
+FULL_AMS_TRAYS = _make_ams_trays(
+    [
+        {"ams_id": 0, "slot_id": 0, "type": "PLA", "color": "FFFFFF", "tray_info_idx": "GFL99"},
+        {"ams_id": 0, "slot_id": 1, "type": "PLA", "color": "000000", "tray_info_idx": "GFL99"},
+        {"ams_id": 0, "slot_id": 2, "type": "PETG-CF", "color": "F2754E", "tray_info_idx": "GFG98"},
+        {"ams_id": 0, "slot_id": 3, "type": "PETG-CF", "color": "808080", "tray_info_idx": "GFG98"},
+    ]
+)
+
+
+class TestParseAmsTrays:
+    def test_full_4_slot_ams(self):
+        status = {
+            "ams": {
+                "ams": [
+                    {
+                        "id": "0",
+                        "tray": [
+                            {
+                                "id": "0",
+                                "tray_type": "PLA",
+                                "tray_color": "FFFFFFAA",
+                                "tray_info_idx": "GFL99",
+                            },
+                            {
+                                "id": "1",
+                                "tray_type": "PLA",
+                                "tray_color": "000000AA",
+                                "tray_info_idx": "GFL99",
+                            },
+                            {
+                                "id": "2",
+                                "tray_type": "PETG-CF",
+                                "tray_color": "F2754EAA",
+                                "tray_info_idx": "GFG98",
+                            },
+                            {
+                                "id": "3",
+                                "tray_type": "PETG-CF",
+                                "tray_color": "808080AA",
+                                "tray_info_idx": "GFG98",
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+        trays = parse_ams_trays(status)
+        assert len(trays) == 4
+        assert trays[0] == {
+            "phys_slot": 0,
+            "ams_id": 0,
+            "slot_id": 0,
+            "type": "PLA",
+            "color": "FFFFFF",
+            "tray_info_idx": "GFL99",
+        }
+        assert trays[2] == {
+            "phys_slot": 2,
+            "ams_id": 0,
+            "slot_id": 2,
+            "type": "PETG-CF",
+            "color": "F2754E",
+            "tray_info_idx": "GFG98",
+        }
+
+    def test_empty_trays_skipped(self):
+        status = {
+            "ams": {
+                "ams": [
+                    {
+                        "id": "0",
+                        "tray": [
+                            {"id": "0", "tray_type": "PLA", "tray_color": "FFFFFFAA"},
+                            {"id": "1", "tray_type": "", "tray_color": ""},  # empty
+                            {"id": "2", "tray_type": "PETG-CF", "tray_color": "F2754EAA"},
+                        ],
+                    }
+                ]
+            }
+        }
+        trays = parse_ams_trays(status)
+        assert len(trays) == 2
+        assert trays[0]["phys_slot"] == 0
+        assert trays[1]["phys_slot"] == 2
+
+    def test_empty_ams(self):
+        assert parse_ams_trays({}) == []
+        assert parse_ams_trays({"ams": {}}) == []
+        assert parse_ams_trays({"ams": {"ams": []}}) == []
+
+
+class TestBuildAmsMappingFromState:
+    def test_single_filament_type_and_color_match(self):
+        """Single PETG-CF filament (id=3) should map to physical slot 2 (type+color match)."""
+        filament_by_id = _make_filament_xml(
+            [{"id": "3", "type": "PETG-CF", "color": "#F2754E", "tray_info_idx": "GFG98"}]
+        )
+        result = _build_ams_mapping_from_state(filament_by_id, 3, FULL_AMS_TRAYS)
+        # Slots: [0]=unused, [1]=unused, [2]=filament id 3 → phys slot 2 (PETG-CF + color match)
+        assert result[2] == 2  # filament id 3 maps to phys slot 2 (exact match)
+        assert len(result) == 3
+
+    def test_single_filament_type_match_no_color(self):
+        """PETG-CF with different color should still match a PETG-CF tray."""
+        filament_by_id = _make_filament_xml(
+            [{"id": "1", "type": "PETG-CF", "color": "#123456", "tray_info_idx": "GFG98"}]
+        )
+        result = _build_ams_mapping_from_state(filament_by_id, 1, FULL_AMS_TRAYS)
+        assert result[0] in (2, 3)  # either PETG-CF slot
+
+    def test_multiple_filaments_different_types(self):
+        """PLA + PETG-CF should map to correct physical slots."""
+        filament_by_id = _make_filament_xml(
+            [
+                {"id": "1", "type": "PLA", "color": "#FFFFFF", "tray_info_idx": "GFL99"},
+                {"id": "2", "type": "PETG-CF", "color": "#F2754E", "tray_info_idx": "GFG98"},
+            ]
+        )
+        result = _build_ams_mapping_from_state(filament_by_id, 2, FULL_AMS_TRAYS)
+        assert result[0] == 0  # PLA white → phys 0
+        assert result[1] == 2  # PETG-CF orange → phys 2
+
+    def test_no_ams_trays_sequential_fallback(self):
+        """Without AMS data, slots map sequentially: 0, 1, 2..."""
+        filament_by_id = _make_filament_xml([{"id": "1", "type": "PLA", "color": "#FFFFFF"}])
+        result = _build_ams_mapping_from_state(filament_by_id, 1, [])
+        assert result == [0]
+
+    def test_no_type_match_sequential_fallback(self):
+        """Filament type not in AMS → falls back to sequential index."""
+        filament_by_id = _make_filament_xml([{"id": "1", "type": "ABS", "color": "#FF0000"}])
+        result = _build_ams_mapping_from_state(filament_by_id, 1, FULL_AMS_TRAYS)
+        assert result[0] == 0  # sequential fallback
+
+    def test_unused_slots_are_minus_one(self):
+        """Slots without filaments should be -1 (matching BambuConnect)."""
+        filament_by_id = _make_filament_xml([{"id": "3", "type": "PETG-CF", "color": "#F2754E"}])
+        result = _build_ams_mapping_from_state(filament_by_id, 3, FULL_AMS_TRAYS)
+        # Slots 0 and 1 are not in filament_by_id → should be -1
+        assert result[0] == -1
+        assert result[1] == -1
+        assert result[2] == 2  # the actual filament
+
+
+class TestBuildAmsMapping:
+    """Integration tests using real 3MF files."""
+
+    def test_real_3mf_single_filament(self):
+        """Test with the real example 3MF (single PETG-CF, filament id=3).
+
+        BambuConnect sends [-1, -1, 2, -1, -1] for this scenario (5 project slots,
+        only filament 3 used). See docs/cloud-print-research.md lines 1245-1263.
+        """
+        threemf = Path("examples/gib-tuners-c13-10/output/plate_sliced.gcode.3mf")
+        if not threemf.exists():
+            pytest.skip("Example 3MF not available")
+
+        result = _build_ams_mapping(threemf, ams_trays=FULL_AMS_TRAYS)
+
+        # Full 5 slots from project_settings (not capped)
+        assert len(result["amsMapping"]) == 5
+        # Matches BambuConnect's captured payload exactly
+        assert result["amsMapping"] == [-1, -1, 2, -1, -1]
+        # All arrays same length
+        assert len(result["amsDetailMapping"]) == 5
+        assert len(result["amsMapping2"]) == 5
+        # Unused slots have -1 sentinel in detail
+        assert result["amsDetailMapping"][0]["ams"] == -1
+        assert result["amsDetailMapping"][2]["ams"] == 2
+
+    def test_synthetic_single_filament_slot3(self, tmp_path):
+        """Synthetic: single filament in slot 3, 5 project slots (P1S profile)."""
+        threemf = _make_3mf(
+            tmp_path,
+            filaments_xml=(
+                '    <filament id="3" type="PETG-CF" color="#F2754E" tray_info_idx="GFG98" />'
+            ),
+            filament_colours=["#F2754E"] * 5,
+            filament_settings_ids=[
+                "Generic PLA @base",
+                "Generic PLA @base",
+                "Generic PETG-CF @base",
+                "Generic PETG-CF @base",
+                "Generic PETG-CF @base",
+            ],
+        )
+        result = _build_ams_mapping(threemf, ams_trays=FULL_AMS_TRAYS)
+
+        # Full 5 slots from project_settings (not capped)
+        assert len(result["amsMapping"]) == 5
+        # Filament 3 → phys slot 2, all others -1
+        assert result["amsMapping"] == [-1, -1, 2, -1, -1]
+
+    def test_synthetic_two_filaments(self, tmp_path):
+        """Two filaments: PLA in slot 1, PETG-CF in slot 2."""
+        threemf = _make_3mf(
+            tmp_path,
+            filaments_xml=(
+                '    <filament id="1" type="PLA" color="#FFFFFF" tray_info_idx="GFL99" />\n'
+                '    <filament id="2" type="PETG-CF" color="#F2754E" tray_info_idx="GFG98" />'
+            ),
+            filament_colours=["#FFFFFF", "#F2754E"],
+            filament_settings_ids=["Generic PLA @base", "Generic PETG-CF @base"],
+        )
+        result = _build_ams_mapping(threemf, ams_trays=FULL_AMS_TRAYS)
+
+        assert len(result["amsMapping"]) == 2
+        assert result["amsMapping"][0] == 0  # PLA white → phys 0
+        assert result["amsMapping"][1] == 2  # PETG-CF orange → phys 2
+
+    def test_no_ams_trays(self, tmp_path):
+        """Without AMS trays, falls back to sequential mapping."""
+        threemf = _make_3mf(
+            tmp_path,
+            filaments_xml='    <filament id="1" type="PLA" color="#FFFFFF" />',
+            filament_colours=["#FFFFFF"],
+            filament_settings_ids=["Generic PLA @base"],
+        )
+        result = _build_ams_mapping(threemf, ams_trays=None)
+
+        assert result["amsMapping"] == [0]
+
+    def test_bridge_gets_full_mapping_with_sentinels(self, tmp_path):
+        """Bridge now gets the full mapping including -1 sentinels.
+
+        BambuConnect sends [-1, -1, 2, -1, -1] and the library handles it.
+        No more stripping — the full array is passed through.
+        """
+        threemf = _make_3mf(
+            tmp_path,
+            filaments_xml=(
+                '    <filament id="3" type="PETG-CF" color="#F2754E" tray_info_idx="GFG98" />'
+            ),
+            filament_colours=["#F2754E"] * 5,
+            filament_settings_ids=[
+                "Generic PLA @base",
+                "Generic PLA @base",
+                "Generic PETG-CF @base",
+                "Generic PETG-CF @base",
+                "Generic PETG-CF @base",
+            ],
+        )
+        result = _build_ams_mapping(threemf, ams_trays=FULL_AMS_TRAYS)
+        raw = result["amsMapping"]
+
+        # Full mapping matches BambuConnect's format
+        assert raw == [-1, -1, 2, -1, -1]
+        # At least one valid slot
+        assert any(v >= 0 for v in raw)


### PR DESCRIPTION
## Summary
- Fixes recurring "Failed to get AMS mapping table" dialog on cloud prints
- Root cause: unused virtual slots were mapped to real physical AMS trays (e.g. `[0, 0, 2]`) instead of using `-1` sentinels like BambuConnect does (`[-1, -1, 2, -1, -1]`)
- Also fixes array truncation — now sends full-length array matching `project_settings.config` slot count
- Adds 14 unit tests for `parse_ams_trays`, `_build_ams_mapping_from_state`, and `_build_ams_mapping`

## Test plan
- [x] `uv run ruff check src tests` — passes
- [x] `uv run ruff format --check src tests` — passes
- [x] `uv run pytest` — 145/147 pass (2 Docker integration tests unrelated — image not on Hub yet)
- [x] Real 3MF test produces `[-1, -1, 2, -1, -1]` matching BambuConnect capture (docs/cloud-print-research.md:1245-1263)
- [ ] Real cloud print test — user to verify no "Failed to get AMS mapping table" dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)