### PR TITLE
Add --no-ams-mapping CLI option for AMS diagnostic

### DIFF
--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -101,6 +101,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Enable experimental printer modes (e.g. cloud-http, which lacks request signing)",
     )
     print_cmd.add_argument(
+        "--no-ams-mapping",
+        action="store_true",
+        help="Skip AMS mapping and use bridge default [0,1,2,3] (diagnostic)",
+    )
+    print_cmd.add_argument(
         "--docker",
         action="store_true",
         help="Force slicing via Docker (even if local slicer is available)",
@@ -329,6 +334,7 @@ def _cmd_print(args: argparse.Namespace) -> None:
         dry_run=args.dry_run,
         upload_only=args.upload_only,
         experimental=getattr(args, "experimental", False),
+        skip_ams_mapping=getattr(args, "no_ams_mapping", False),
     )
 
 

--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -210,6 +210,7 @@ def cloud_print(
     timeout: int = 180,
     verbose: bool = False,
     ams_trays: list[dict] | None = None,
+    skip_ams_mapping: bool = False,
 ) -> dict:
     """Start a cloud print job.
 
@@ -249,14 +250,14 @@ def cloud_print(
     # "Failed to get AMS mapping table" dialog. Without this the bridge
     # defaults to [0,1,2,3] (identity) which is wrong when AMS tray order
     # differs from gcode filament order.
-    if ams_trays:
+    if ams_trays and not skip_ams_mapping:
         ams_data = _build_ams_mapping(threemf_path, ams_trays=ams_trays)
         raw = ams_data["amsMapping"]
         if raw and any(v >= 0 for v in raw):
-            # Pass full mapping including -1 sentinels for unused slots,
-            # matching BambuConnect's format: e.g. [-1, -1, 2, -1, -1]
             args.extend(["--ams-mapping", json.dumps(raw)])
             log.debug("AMS slot mapping: %s", raw)
+    elif skip_ams_mapping:
+        log.info("AMS mapping skipped (--no-ams-mapping), using bridge default [0,1,2,3]")
 
     # Auto-generate config-only 3MF if not provided.
     # The v02.05 library requires a separate config_filename (3MF without gcode).

--- a/src/fabprint/printer.py
+++ b/src/fabprint/printer.py
@@ -309,6 +309,7 @@ def _send_cloud_bridge(
     serial: str | None = None,
     dry_run: bool = False,
     verbose: bool = False,
+    skip_ams_mapping: bool = False,
 ) -> None:
     """Send gcode to printer via the bambu_cloud_bridge binary.
 
@@ -392,6 +393,7 @@ def _send_cloud_bridge(
         project_name=gcode_path.stem,
         ams_trays=ams_trays,
         verbose=verbose,
+        skip_ams_mapping=skip_ams_mapping,
     )
 
     status = result.get("result", "unknown")
@@ -483,6 +485,7 @@ def send_print(
     dry_run: bool = False,
     upload_only: bool = False,
     experimental: bool = False,
+    skip_ams_mapping: bool = False,
 ) -> None:
     """Send gcode to a Bambu Lab printer.
 
@@ -526,6 +529,7 @@ def send_print(
             serial=creds["serial"],
             dry_run=dry_run,
             verbose=log.isEnabledFor(logging.DEBUG),
+            skip_ams_mapping=skip_ams_mapping,
         )
 
     elif creds["mode"] == "cloud-http":

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -79,7 +79,9 @@ def test_send_print_cloud_bridge_dispatches(tmp_path):
 
     with patch("fabprint.printer._send_cloud_bridge") as mock_send:
         send_print(gcode, config, dry_run=True)
-        mock_send.assert_called_once_with(gcode, serial="SN123", dry_run=True, verbose=False)
+        mock_send.assert_called_once_with(
+            gcode, serial="SN123", dry_run=True, verbose=False, skip_ams_mapping=False
+        )
 
 
 def test_send_print_lan_missing_ip():


### PR DESCRIPTION
## Summary
- Adds `--no-ams-mapping` flag to `fabprint print` command
- When set, skips sending explicit AMS mapping to the bridge, falling back to the default `[0,1,2,3]`
- Threads the option through CLI → `send_print` → `_send_cloud_bridge` → `cloud_print`

## Context
The AMS mapping dialog regression coincided with rebuilding the cloud bridge Docker image using `libbambu_networking.so` v02.05 (previously v01.09). This flag isolates whether the issue is our mapping values or the library version change.

## Test plan
- [x] `uv run pytest` passes (excluding pre-existing Docker image pull failures)
- [x] `uv run ruff check src tests` passes
- [ ] Run `fabprint print --no-ams-mapping <config>` and check if AMS dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)