### PR TITLE
Pass ams_mapping2 to bridge for v02.05 library compatibility

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -256,6 +256,10 @@ def cloud_print(
         if raw and any(v >= 0 for v in raw):
             args.extend(["--ams-mapping", json.dumps(raw)])
             log.debug("AMS slot mapping: %s", raw)
+        raw2 = ams_data["amsMapping2"]
+        if raw2:
+            args.extend(["--ams-mapping2", json.dumps(raw2)])
+            log.debug("AMS slot mapping2: %s", raw2)
     elif skip_ams_mapping:
         log.info("AMS mapping skipped (--no-ams-mapping), using bridge default [0,1,2,3]")
 
@@ -608,7 +612,7 @@ def _build_ams_mapping(
                 }
             )
             mapping.append(phys_slot)
-            mapping2.append({"amsId": phys_slot // 4, "slotId": phys_slot % 4})
+            mapping2.append({"ams_id": phys_slot // 4, "slot_id": phys_slot % 4})
             setting_ids.append(tray_idx)
         else:
             # Unused slot — use -1 sentinel matching BambuConnect's format.
@@ -623,7 +627,7 @@ def _build_ams_mapping(
                 }
             )
             mapping.append(-1)
-            mapping2.append({"amsId": 255, "slotId": 255})
+            mapping2.append({"ams_id": 255, "slot_id": 255})
             setting_ids.append("")
 
     result["amsDetailMapping"] = detail


### PR DESCRIPTION
## Summary
- Pass `--ams-mapping2` (v1 format) to the bridge alongside legacy `--ams-mapping`
- Fix key names from camelCase (`amsId`/`slotId`) to snake_case (`ams_id`/`slot_id`) to match OrcaSlicer's format

## Context
Testing with `--no-ams-mapping` (PR #58) confirmed the error persists even with the default `[0,1,2,3]` mapping, ruling out our mapping values as the cause. The v02.05 `libbambu_networking.so` likely requires `ams_mapping2` — the v1 format that OrcaSlicer sends with `{"ams_id": N, "slot_id": N}` entries. We were computing this but never passing it to the bridge.

Error code: `[0700-8012 132911]`

## Test plan
- [x] `uv run pytest tests/test_cloud.py -v` passes
- [x] `uv run ruff check src tests` passes
- [ ] Run a cloud print and check if AMS dialog is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)