### PR TITLE
Add private cache fallback for libbambu_networking.so

### DIFF
--- a/Dockerfile.cloud-bridge
+++ b/Dockerfile.cloud-bridge
@@ -23,19 +23,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Fetch libbambu_networking.so from Bambu's official API at build time.
+# Fetch libbambu_networking.so — try Bambu's API first, fall back to private cache.
 # The API returns a signed CDN URL for the current Linux plugin zip.
-# No redistribution of Bambu's proprietary binary — fetched from their servers.
+# If Bambu's API/CDN is unavailable, fetch from a private GitHub release.
 ARG BAMBU_SLICER_VERSION=02.05.00.00
+ARG BNL_TOKEN=""
 RUN mkdir -p /tmp/bambu_plugin \
-    && PLUGIN_URL=$(curl -fsSL \
+    && (PLUGIN_URL=$(curl -fsSL \
         -H "User-Agent: BambuStudio/${BAMBU_SLICER_VERSION}" \
         -H "X-BBL-OS-Type: linux" \
         "https://api.bambulab.com/v1/iot-service/api/slicer/resource?slicer/plugins/cloud=${BAMBU_SLICER_VERSION}" \
         | python3 -c "import sys,json; r=json.load(sys.stdin)['resources']; print([x for x in r if 'plugins' in x['type']][0]['url'])") \
     && curl -fsSL -o /tmp/plugins.zip "$PLUGIN_URL" \
     && unzip -j /tmp/plugins.zip libbambu_networking.so -d /tmp/bambu_plugin/ \
-    && rm /tmp/plugins.zip
+    && rm /tmp/plugins.zip \
+    && echo "Fetched libbambu_networking.so from Bambu API") \
+    || (echo "Bambu API failed, falling back to private cache..." \
+    && curl -fsSL \
+        -H "Authorization: token ${BNL_TOKEN}" \
+        -H "Accept: application/octet-stream" \
+        -o /tmp/bambu_plugin/libbambu_networking.so \
+        "https://api.github.com/repos/pzfreo/bnl/releases/assets/$(curl -fsSL \
+            -H "Authorization: token ${BNL_TOKEN}" \
+            "https://api.github.com/repos/pzfreo/bnl/releases/tags/v${BAMBU_SLICER_VERSION}" \
+            | python3 -c "import sys,json; print([a for a in json.load(sys.stdin)['assets'] if a['name']=='libbambu_networking.so'][0]['id'])")" \
+    && echo "Fetched libbambu_networking.so from private cache")
 
 # Download slicer TLS certificate (for MQTT to *.bambulab.com)
 RUN mkdir -p /tmp/bambu_agent/cert /tmp/bambu_agent/log /tmp/bambu_agent/config \

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -42,11 +42,13 @@ case "$TARGET" in
     cloud-bridge)
         PUSH="${2:-}"
         IMAGE="fabprint/cloud-bridge:latest"
+        BNL_TOKEN="${BNL_TOKEN:-$(gh auth token 2>/dev/null || true)}"
 
         echo "Building ${IMAGE} ..."
         docker build \
             --platform linux/amd64 \
             -f Dockerfile.cloud-bridge \
+            --build-arg "BNL_TOKEN=${BNL_TOKEN}" \
             -t "${IMAGE}" \
             .
 

--- a/scripts/cache-bnl.sh
+++ b/scripts/cache-bnl.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Cache libbambu_networking.so from a running cloud-bridge image to the
+# private pzfreo/bnl GitHub repo as a release asset.
+#
+# Usage:
+#   ./scripts/cache-bnl.sh                     # uses default version 02.05.00.00
+#   ./scripts/cache-bnl.sh 02.06.00.00         # specify version
+
+set -euo pipefail
+
+VERSION="${1:-02.05.00.00}"
+IMAGE="fabprint/cloud-bridge:latest"
+TMPFILE=$(mktemp)
+
+echo "Extracting libbambu_networking.so from ${IMAGE} ..."
+docker run --rm --entrypoint cat "${IMAGE}" /tmp/bambu_plugin/libbambu_networking.so > "${TMPFILE}"
+
+SHA256=$(shasum -a 256 "${TMPFILE}" | awk '{print $1}')
+echo "SHA256: ${SHA256}"
+
+echo "Creating release v${VERSION} on pzfreo/bnl ..."
+gh release create "v${VERSION}" \
+    --repo pzfreo/bnl \
+    --title "v${VERSION}" \
+    --notes "libbambu_networking.so v${VERSION}
+SHA256: ${SHA256}
+Arch: x86_64 Linux" \
+    "${TMPFILE}#libbambu_networking.so" \
+    2>/dev/null \
+|| (echo "Release exists, uploading asset..." \
+    && gh release upload "v${VERSION}" \
+        --repo pzfreo/bnl \
+        --clobber \
+        "${TMPFILE}#libbambu_networking.so")
+
+rm "${TMPFILE}"
+echo "Done. Cached v${VERSION} to pzfreo/bnl"


### PR DESCRIPTION
## Summary
- Dockerfile.cloud-bridge now tries Bambu's API first, falls back to `pzfreo/bnl` private GitHub release
- Build script passes `BNL_TOKEN` (from env or `gh auth token`) to Docker build
- New `scripts/cache-bnl.sh` to store .so versions after successful builds

## Context
Bambu has changed their CDN before, breaking Docker builds. This adds a private fallback so we can always rebuild even if their API goes down.

## Test plan
- [x] Verified v02.05.00.00 cached at `pzfreo/bnl` releases
- [ ] Test build with Bambu API available (primary path)
- [ ] Test build with Bambu API blocked (fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)