### PR TITLE
Fix Docker slicing timeout by removing Xvfb

### DIFF
--- a/src/fabprint/slicer.py
+++ b/src/fabprint/slicer.py
@@ -212,11 +212,8 @@ def _slice_via_docker(
         "-v",
         f"{output_dir}:/work/output",
         "--entrypoint",
-        "xvfb-run",
-        image,
-        "-a",
-        "--server-args=-screen 0 1024x768x24",
         "orca-slicer",
+        image,
     ]
 
     if settings_arg:


### PR DESCRIPTION
## Summary
- Xvfb + Mesa software GL rendering hangs during OrcaSlicer thumbnail generation, causing the 10-minute Docker slicing timeout to be hit
- Removed `xvfb-run` wrapper — OrcaSlicer now runs directly without a virtual display
- Thumbnails still work via the existing pure-Python fallback that generates placeholder PNGs for broken/missing thumbnails

## Test plan
- [ ] Run a Docker-based slice and verify it completes without timeout
- [ ] Verify output 3MF contains valid thumbnail PNGs (generated placeholders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)