### PR TITLE
Always export preview 3MF with bed outline

### DIFF
--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -40,11 +40,6 @@ def main(argv: list[str] | None = None) -> None:
     )
     plate_cmd.add_argument("config", type=Path, help="Path to fabprint.toml")
     plate_cmd.add_argument("-o", "--output", type=Path, default=None, help="Output 3MF path")
-    plate_cmd.add_argument(
-        "--preview",
-        action="store_true",
-        help="Also export a preview 3MF with bed outline (for visual review)",
-    )
 
     # slice subcommand
     slice_cmd = sub.add_parser(
@@ -363,6 +358,12 @@ def _generate_plate(
 
     scene = build_plate(placements, cfg.plate.size)
     export_plate(scene, output)
+
+    preview_scene = build_plate(placements, cfg.plate.size, include_bed=True)
+    preview_path = output.with_stem(output.stem + "_preview")
+    export_plate(preview_scene, preview_path)
+    print(f"Preview: {preview_path}")
+
     return cfg, filament_ids, has_paint_colors, placements
 
 
@@ -436,6 +437,12 @@ def _generate_sequential_plates(
 
         results.append((seq_num, plate_path, cfg, seq_fil_ids, has_paint_colors))
 
+    # Preview with all objects and bed outline
+    preview_scene = build_plate(placements, cfg.plate.size, include_bed=True)
+    preview_path = output_prefix.parent / f"{output_prefix.stem}_preview.3mf"
+    export_plate(preview_scene, preview_path)
+    print(f"Preview: {preview_path}")
+
     return results
 
 
@@ -464,7 +471,6 @@ def _has_sequences(cfg: FabprintConfig) -> bool:
 
 def _cmd_plate(args: argparse.Namespace) -> None:
     cfg = load_config(args.config)
-    placements = None
     if _has_sequences(cfg):
         output = args.output or Path("plate.3mf")
         results = _generate_sequential_plates(args, output)
@@ -472,19 +478,8 @@ def _cmd_plate(args: argparse.Namespace) -> None:
             print(f"Sequence {seq_num}: {plate_path}")
     else:
         output = args.output or Path("plate.3mf")
-        cfg, _, _, placements = _generate_plate(args, output)
+        _generate_plate(args, output)
         print(f"Plate exported to {output}")
-
-    if args.preview:
-        if placements is None:
-            # Sequential path: re-load to get all placements together
-            global_scale = getattr(args, "scale", None)
-            meshes, names, _, _, _, _ = _load_parts(cfg, global_scale)
-            placements = arrange(meshes, names, cfg.plate.size, cfg.plate.padding)
-        preview_scene = build_plate(placements, cfg.plate.size, include_bed=True)
-        preview_path = Path("plate_preview.3mf")
-        export_plate(preview_scene, preview_path)
-        print(f"Preview exported to {preview_path}")
 
 
 def _do_slice(args: argparse.Namespace) -> Path:


### PR DESCRIPTION
## Summary
- `plate_preview.3mf` (with bed outline) is now always exported alongside plate files
- No flag needed — open it in any 3MF viewer to see object placement on the bed
- For sequential configs, the preview shows all objects together

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run pytest` — 181 passed (2 pre-existing Docker failures)
- [ ] Manual: run `fabprint plate` / `fabprint slice` and verify `plate_preview.3mf` is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)