### PR TITLE
Fix Docker thumbnail rendering with xvfb-run

### DIFF
--- a/src/fabprint/slicer.py
+++ b/src/fabprint/slicer.py
@@ -212,8 +212,9 @@ def _slice_via_docker(
         "-v",
         f"{output_dir}:/work/output",
         "--entrypoint",
-        "orca-slicer",
+        "xvfb-run",
         image,
+        "orca-slicer",
     ]
 
     if settings_arg:


### PR DESCRIPTION
## Summary
- Wrap OrcaSlicer with `xvfb-run` in Docker to provide a virtual display
- Fixes "Wayland: Failed to connect to display" error that prevented thumbnail generation
- Docker image already has xvfb installed, it just wasn't being used

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run pytest` — 181 passed
- [ ] Manual: `fabprint slice config.toml --docker` and verify thumbnails in .gcode.3mf

🤖 Generated with [Claude Code](https://claude.com/claude-code)