### PR TITLE
Make Docker the default slicer, fall back to local

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,19 +294,20 @@ docker run --rm -v "$PWD:/project" fabprint/fabprint:orca-2.3.1 plate fabprint.t
 docker run --rm fabprint/fabprint:orca-2.3.1 profiles list
 ```
 
-### Slicing via Docker from the CLI
+### Slicer selection
 
-Use `--docker` to force Docker slicing, or `--docker-version` to pick a specific OrcaSlicer version:
+By default, fabprint uses Docker if available, falling back to a local OrcaSlicer install:
 
 ```bash
-# Use default fabprint/fabprint:latest image
-fabprint slice fabprint.toml --docker
+# Default: Docker first, local fallback
+fabprint slice fabprint.toml
 
-# Use a specific OrcaSlicer version
+# Force local slicer (fail if not installed)
+fabprint slice fabprint.toml --local
+
+# Use a specific OrcaSlicer Docker image version
 fabprint slice fabprint.toml --docker-version 2.3.1
 ```
-
-If OrcaSlicer isn't installed locally, `fabprint slice` automatically falls back to Docker.
 
 ### Building your own image
 

--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -48,9 +48,9 @@ def main(argv: list[str] | None = None) -> None:
     slice_cmd.add_argument("config", type=Path, help="Path to fabprint.toml")
     slice_cmd.add_argument("-o", "--output-dir", type=Path, default=None, help="Output directory")
     slice_cmd.add_argument(
-        "--docker",
+        "--local",
         action="store_true",
-        help="Force slicing via Docker (even if local slicer is available)",
+        help="Force local slicer (fail if not installed)",
     )
     slice_cmd.add_argument(
         "--docker-version",
@@ -99,9 +99,9 @@ def main(argv: list[str] | None = None) -> None:
         help="Skip AMS mapping and use bridge default [0,1,2,3] (diagnostic)",
     )
     print_cmd.add_argument(
-        "--docker",
+        "--local",
         action="store_true",
-        help="Force slicing via Docker (even if local slicer is available)",
+        help="Force local slicer (fail if not installed)",
     )
     print_cmd.add_argument(
         "--docker-version",
@@ -514,7 +514,7 @@ def _do_slice(args: argparse.Namespace) -> Path:
         filament_ids=filament_ids,
         overrides=cfg.slicer.overrides or None,
         project_dir=cfg.base_dir,
-        docker=args.docker or args.docker_version is not None,
+        local=args.local,
         docker_version=args.docker_version,
         required_version=cfg.slicer.version,
     )

--- a/src/fabprint/slicer.py
+++ b/src/fabprint/slicer.py
@@ -595,7 +595,7 @@ def slice_plate(
     filament_ids: list[int] | None = None,
     overrides: dict[str, object] | None = None,
     project_dir: Path | None = None,
-    docker: bool = False,
+    local: bool = False,
     docker_version: str | None = None,
     required_version: str | None = None,
 ) -> Path:
@@ -604,10 +604,10 @@ def slice_plate(
     Profile names are resolved via profiles.resolve_profile_data().
     If overrides are provided, they are patched into the process profile.
 
-    Docker modes:
-      docker=True          - use Docker with default image
-      docker_version="X"   - use Docker with fabprint:orca-X image
-      neither + no local   - fallback to Docker with default image
+    Slicer selection:
+      local=True           - force local slicer, fail if not installed
+      docker_version="X"   - force Docker with fabprint:orca-X image
+      neither (default)    - try Docker first, fall back to local
 
     If required_version is set (from config), the slicer version is checked
     and must match exactly. For Docker, the image tag is used as the version.
@@ -618,27 +618,35 @@ def slice_plate(
     # use it as the docker_version for Docker-based slicing.
     if required_version and not docker_version:
         docker_version = required_version
-        docker = True
 
-    use_docker = docker or docker_version is not None
     image = _docker_image(docker_version)
 
-    if not use_docker:
-        try:
-            slicer = find_slicer(engine)
-        except FileNotFoundError:
-            if _ensure_docker_image(image):
-                log.info("Slicer not found locally, falling back to Docker (%s)", image)
-                use_docker = True
-            else:
-                raise
-
-    if use_docker and not _ensure_docker_image(image):
-        raise FileNotFoundError(
-            f"Docker image '{image}' not found locally or on Docker Hub. "
-            f"Check your Docker login or build locally with: docker build "
-            f"--build-arg ORCA_VERSION={docker_version or 'X.Y.Z'} -t {image} ."
-        )
+    if local:
+        # Force local — no Docker fallback
+        use_docker = False
+        slicer = find_slicer(engine)
+    elif docker_version is not None:
+        # Explicit Docker version requested
+        use_docker = True
+        if not _ensure_docker_image(image):
+            raise FileNotFoundError(
+                f"Docker image '{image}' not found locally or on Docker Hub. "
+                f"Check your Docker login or build locally with: docker build "
+                f"--build-arg ORCA_VERSION={docker_version or 'X.Y.Z'} -t {image} ."
+            )
+    else:
+        # Default: try Docker first, fall back to local
+        if _ensure_docker_image(image):
+            use_docker = True
+        else:
+            try:
+                slicer = find_slicer(engine)
+                use_docker = False
+            except FileNotFoundError:
+                raise FileNotFoundError(
+                    "No slicer available. Install OrcaSlicer locally or "
+                    "pull the Docker image: docker pull fabprint/fabprint:latest"
+                )
 
     # Detect and verify slicer version
     if use_docker:

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -207,6 +207,7 @@ def test_slice_plate_local_command(tmp_path):
             process="My Process",
             filaments=["PLA"],
             overrides={"wall_loops": 4},
+            local=True,
         )
 
     cmd = mock_run.call_args[0][0]
@@ -217,17 +218,18 @@ def test_slice_plate_local_command(tmp_path):
     assert str(output_dir) in cmd
 
 
-def test_slice_plate_docker_fallback(tmp_path):
-    """When local slicer not found, falls back to Docker."""
+def test_slice_plate_local_fallback(tmp_path):
+    """When Docker image not found, falls back to local slicer."""
     input_3mf = tmp_path / "plate.3mf"
     input_3mf.write_text("fake")
     output_dir = tmp_path / "output"
 
     mock_result = MagicMock(returncode=0, stdout="", stderr="")
+    slicer_path = Path("/usr/bin/orca-slicer")
 
     with (
-        patch("fabprint.slicer.find_slicer", side_effect=FileNotFoundError("not found")),
-        patch("fabprint.slicer._ensure_docker_image", return_value=True),
+        patch("fabprint.slicer._ensure_docker_image", return_value=False),
+        patch("fabprint.slicer.find_slicer", return_value=slicer_path),
         patch("fabprint.slicer.resolve_profile_data", side_effect=_mock_resolve),
         patch("fabprint.slicer.subprocess.run", return_value=mock_result) as mock_run,
     ):
@@ -239,12 +241,11 @@ def test_slice_plate_docker_fallback(tmp_path):
         )
 
     cmd = mock_run.call_args[0][0]
-    assert cmd[0] == "docker"
-    assert "fabprint/fabprint:latest" in cmd
+    assert cmd[0] == str(slicer_path)
 
 
-def test_slice_plate_docker_explicit(tmp_path):
-    """docker=True forces Docker even if local slicer exists."""
+def test_slice_plate_docker_default(tmp_path):
+    """Default behavior uses Docker when image is available."""
     input_3mf = tmp_path / "plate.3mf"
     input_3mf.write_text("fake")
     output_dir = tmp_path / "output"
@@ -261,7 +262,6 @@ def test_slice_plate_docker_explicit(tmp_path):
             engine="orca",
             output_dir=output_dir,
             printer="My Printer",
-            docker=True,
         )
 
     cmd = mock_run.call_args[0][0]


### PR DESCRIPTION
## Summary
- Default: try Docker first, fall back to local OrcaSlicer
- `--local` forces local slicer (fails if not installed)
- `--docker-version X.Y.Z` forces a specific Docker image
- Removes `--docker` flag (Docker is now the default)

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run pytest` — 181 passed (2 pre-existing Docker image failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)