### PR TITLE
Add readme field to pyproject.toml for PyPI page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "fabprint"
 version = "0.1.35"
 description = "Immutable 3D print pipeline: arrange, slice, and print"
+readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "trimesh[easy]>=4.0.0",


### PR DESCRIPTION
## Summary
- PyPI project page was empty because `pyproject.toml` was missing the `readme` field
- Adds `readme = "README.md"` so PyPI renders the README as the project description

## Test plan
- [ ] Verify next PyPI publish shows README content on https://pypi.org/project/fabprint/

🤖 Generated with [Claude Code](https://claude.com/claude-code)