### PR TITLE
Move printer secrets to ~/.config/fabprint/credentials.toml

### DIFF
--- a/examples/gib-tuners-c13-10/fabprint.toml
+++ b/examples/gib-tuners-c13-10/fabprint.toml
@@ -3,7 +3,7 @@
 
 [printer]
 mode = "cloud-bridge"
-serial = "01P00A451601106"
+name = "workshop"  # references [printers.workshop] in ~/.config/fabprint/credentials.toml
 
 [plate]
 size = [256, 256]

--- a/src/fabprint/config.py
+++ b/src/fabprint/config.py
@@ -44,6 +44,7 @@ class PartConfig:
 @dataclass
 class PrinterConfig:
     mode: str = "bambu-lan"  # "bambu-lan", "bambu-connect", "bambu-cloud", or legacy "lan"/"cloud"
+    name: str | None = None  # references a printer in ~/.config/fabprint/credentials.toml
     ip: str | None = None
     access_code: str | None = None
     serial: str | None = None
@@ -273,6 +274,13 @@ def load_config(path: Path) -> FabprintConfig:
     printer = None
     printer_raw = raw.get("printer")
     if printer_raw:
+        # Reject secrets in project TOML — they belong in credentials.toml
+        for secret_field in ("ip", "access_code", "serial"):
+            if secret_field in printer_raw:
+                raise FabprintError(
+                    f"printer.{secret_field} should not be in project config. "
+                    f"Move it to ~/.config/fabprint/credentials.toml"
+                )
         mode = printer_raw.get("mode", "bambu-lan")
         valid_modes = (
             "bambu-lan",
@@ -287,9 +295,7 @@ def load_config(path: Path) -> FabprintConfig:
             raise FabprintError(f"printer.mode must be one of {valid_modes}, got '{mode}'")
         printer = PrinterConfig(
             mode=mode,
-            ip=printer_raw.get("ip"),
-            access_code=printer_raw.get("access_code"),
-            serial=printer_raw.get("serial"),
+            name=printer_raw.get("name"),
         )
 
     return FabprintConfig(

--- a/src/fabprint/credentials.py
+++ b/src/fabprint/credentials.py
@@ -1,0 +1,57 @@
+"""Load printer credentials from ~/.config/fabprint/credentials.toml."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+from fabprint import FabprintError
+
+
+def _credentials_path() -> Path:
+    """Return the path to the credentials file."""
+    env = os.environ.get("FABPRINT_CREDENTIALS")
+    if env:
+        return Path(env)
+    if sys.platform == "win32":
+        return Path.home() / "AppData/Roaming/fabprint/credentials.toml"
+    return Path.home() / ".config/fabprint/credentials.toml"
+
+
+def load_printer_credentials(name: str | None) -> dict[str, str | None]:
+    """Load credentials for a named printer.
+
+    Resolution order for each field:
+    1. Environment variables (BAMBU_PRINTER_IP, BAMBU_ACCESS_CODE, BAMBU_SERIAL,
+       BAMBU_EMAIL, BAMBU_PASSWORD)
+    2. Named printer entry in credentials.toml
+    3. None
+
+    If name is None and no env vars are set, returns all-None values.
+    """
+    file_creds: dict[str, str | None] = {}
+
+    if name is not None:
+        path = _credentials_path()
+        if not path.exists():
+            raise FabprintError(
+                f"Credentials file not found: {path}\n"
+                f"Create it with a [printers.{name}] section, or set env vars instead."
+            )
+        with open(path, "rb") as f:
+            raw = tomllib.load(f)
+        printers = raw.get("printers", {})
+        if name not in printers:
+            available = list(printers.keys())
+            raise FabprintError(f"Printer '{name}' not found in {path}. Available: {available}")
+        file_creds = printers[name]
+
+    return {
+        "ip": os.environ.get("BAMBU_PRINTER_IP", file_creds.get("ip")),
+        "access_code": os.environ.get("BAMBU_ACCESS_CODE", file_creds.get("access_code")),
+        "serial": os.environ.get("BAMBU_SERIAL", file_creds.get("serial")),
+        "email": os.environ.get("BAMBU_EMAIL", file_creds.get("email")),
+        "password": os.environ.get("BAMBU_PASSWORD", file_creds.get("password")),
+    }

--- a/src/fabprint/printer.py
+++ b/src/fabprint/printer.py
@@ -9,6 +9,7 @@ import zipfile
 from pathlib import Path
 
 from fabprint.config import PrinterConfig
+from fabprint.credentials import load_printer_credentials
 from fabprint.gcode import parse_gcode_metadata
 
 log = logging.getLogger(__name__)
@@ -117,18 +118,13 @@ def wrap_gcode_3mf(gcode_path: Path, output_path: Path | None = None) -> Path:
 
 
 def _resolve_credentials(config: PrinterConfig) -> dict[str, str | None]:
-    """Merge config values with env var overrides.
+    """Load credentials from credentials.toml (by printer name), with env var overrides.
 
-    Env vars take precedence over config file values.
+    Resolution: env vars > credentials.toml > None.
     """
-    return {
-        "mode": config.mode,
-        "ip": os.environ.get("BAMBU_PRINTER_IP", config.ip),
-        "access_code": os.environ.get("BAMBU_ACCESS_CODE", config.access_code),
-        "serial": os.environ.get("BAMBU_SERIAL", config.serial),
-        "email": os.environ.get("BAMBU_EMAIL"),
-        "password": os.environ.get("BAMBU_PASSWORD"),
-    }
+    creds = load_printer_credentials(config.name)
+    creds["mode"] = config.mode
+    return creds
 
 
 def _send_lan(
@@ -330,7 +326,8 @@ def _send_cloud_bridge(
         serial = os.environ.get("BAMBU_SERIAL")
     if not serial:
         raise ValueError(
-            "cloud-bridge mode requires serial. Set in [printer] config or BAMBU_SERIAL env var."
+            "cloud-bridge mode requires serial. "
+            "Set in ~/.config/fabprint/credentials.toml or BAMBU_SERIAL env var."
         )
 
     # Check printer availability before sending, and capture AMS state for mapping
@@ -434,7 +431,8 @@ def _send_cloud_http(
         serial = os.environ.get("BAMBU_SERIAL")
     if not serial:
         raise ValueError(
-            "cloud-http mode requires serial. Set in [printer] config or BAMBU_SERIAL env var."
+            "cloud-http mode requires serial. "
+            "Set in ~/.config/fabprint/credentials.toml or BAMBU_SERIAL env var."
         )
 
     sliced_3mf = gcode_path.parent / "plate_sliced.gcode.3mf"
@@ -486,7 +484,8 @@ def send_print(
             if not creds[field]:
                 env_var = f"BAMBU_{field.upper()}" if field != "ip" else "BAMBU_PRINTER_IP"
                 raise ValueError(
-                    f"LAN mode requires {field}. Set in [printer] config or {env_var} env var."
+                    f"LAN mode requires {field}. "
+                    f"Set in ~/.config/fabprint/credentials.toml or {env_var} env var."
                 )
         _send_lan(
             gcode_path,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -292,9 +292,7 @@ def test_printer_config(tmp_path):
         """
 [printer]
 mode = "lan"
-ip = "192.168.1.100"
-access_code = "12345678"
-serial = "01P00A000000"
+name = "workshop"
 
 [[parts]]
 file = "cube.stl"
@@ -304,9 +302,7 @@ file = "cube.stl"
     cfg = load_config(path)
     assert cfg.printer is not None
     assert cfg.printer.mode == "lan"
-    assert cfg.printer.ip == "192.168.1.100"
-    assert cfg.printer.access_code == "12345678"
-    assert cfg.printer.serial == "01P00A000000"
+    assert cfg.printer.name == "workshop"
 
 
 def test_printer_config_cloud(tmp_path):
@@ -324,7 +320,25 @@ file = "cube.stl"
     cfg = load_config(path)
     assert cfg.printer is not None
     assert cfg.printer.mode == "cloud"
-    assert cfg.printer.ip is None
+    assert cfg.printer.name is None
+
+
+def test_printer_rejects_secrets_in_project_toml(tmp_path):
+    for field in ("ip", "access_code", "serial"):
+        path = _write_toml(
+            tmp_path,
+            f"""
+[printer]
+mode = "lan"
+{field} = "secret_value"
+
+[[parts]]
+file = "cube.stl"
+""",
+            create_files=["cube.stl"],
+        )
+        with pytest.raises(FabprintError, match=f"printer.{field}.*credentials.toml"):
+            load_config(path)
 
 
 def test_printer_config_absent(tmp_path):

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from fabprint.config import PrinterConfig
+from fabprint.credentials import load_printer_credentials
 from fabprint.gcode import parse_gcode_metadata
 from fabprint.printer import (
     _resolve_credentials,
@@ -14,8 +15,103 @@ from fabprint.printer import (
 )
 
 
-def test_resolve_credentials_from_config():
-    config = PrinterConfig(mode="lan", ip="10.0.0.1", access_code="abc", serial="SN123")
+def _write_credentials(tmp_path, content):
+    """Write a credentials.toml and return its path."""
+    cred_path = tmp_path / "credentials.toml"
+    cred_path.write_text(content)
+    return cred_path
+
+
+def test_load_credentials_from_file(tmp_path, monkeypatch):
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.workshop]
+ip = "10.0.0.1"
+access_code = "abc"
+serial = "SN123"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    monkeypatch.delenv("BAMBU_PRINTER_IP", raising=False)
+    monkeypatch.delenv("BAMBU_ACCESS_CODE", raising=False)
+    monkeypatch.delenv("BAMBU_SERIAL", raising=False)
+    creds = load_printer_credentials("workshop")
+    assert creds["ip"] == "10.0.0.1"
+    assert creds["access_code"] == "abc"
+    assert creds["serial"] == "SN123"
+
+
+def test_load_credentials_env_overrides(tmp_path, monkeypatch):
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.workshop]
+ip = "10.0.0.1"
+access_code = "abc"
+serial = "SN123"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    monkeypatch.setenv("BAMBU_PRINTER_IP", "192.168.1.99")
+    monkeypatch.setenv("BAMBU_ACCESS_CODE", "override_code")
+    monkeypatch.setenv("BAMBU_SERIAL", "OVERRIDE_SN")
+    creds = load_printer_credentials("workshop")
+    assert creds["ip"] == "192.168.1.99"
+    assert creds["access_code"] == "override_code"
+    assert creds["serial"] == "OVERRIDE_SN"
+
+
+def test_load_credentials_no_name_env_only(monkeypatch):
+    monkeypatch.setenv("BAMBU_EMAIL", "user@test.com")
+    monkeypatch.setenv("BAMBU_PASSWORD", "secret")
+    monkeypatch.delenv("BAMBU_PRINTER_IP", raising=False)
+    monkeypatch.delenv("BAMBU_ACCESS_CODE", raising=False)
+    monkeypatch.delenv("BAMBU_SERIAL", raising=False)
+    creds = load_printer_credentials(None)
+    assert creds["email"] == "user@test.com"
+    assert creds["password"] == "secret"
+    assert creds["ip"] is None
+
+
+def test_load_credentials_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(tmp_path / "nonexistent.toml"))
+    from fabprint import FabprintError
+
+    with pytest.raises(FabprintError, match="not found"):
+        load_printer_credentials("workshop")
+
+
+def test_load_credentials_missing_printer(tmp_path, monkeypatch):
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.other]
+ip = "10.0.0.1"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    from fabprint import FabprintError
+
+    with pytest.raises(FabprintError, match="workshop.*not found"):
+        load_printer_credentials("workshop")
+
+
+def test_resolve_credentials_with_name(tmp_path, monkeypatch):
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.workshop]
+ip = "10.0.0.1"
+access_code = "abc"
+serial = "SN123"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    monkeypatch.delenv("BAMBU_PRINTER_IP", raising=False)
+    monkeypatch.delenv("BAMBU_ACCESS_CODE", raising=False)
+    monkeypatch.delenv("BAMBU_SERIAL", raising=False)
+    config = PrinterConfig(mode="lan", name="workshop")
     creds = _resolve_credentials(config)
     assert creds["mode"] == "lan"
     assert creds["ip"] == "10.0.0.1"
@@ -23,31 +119,23 @@ def test_resolve_credentials_from_config():
     assert creds["serial"] == "SN123"
 
 
-def test_resolve_credentials_env_overrides(monkeypatch):
-    config = PrinterConfig(mode="lan", ip="10.0.0.1", access_code="abc", serial="SN123")
-    monkeypatch.setenv("BAMBU_PRINTER_IP", "192.168.1.99")
-    monkeypatch.setenv("BAMBU_ACCESS_CODE", "override_code")
-    monkeypatch.setenv("BAMBU_SERIAL", "OVERRIDE_SN")
-    creds = _resolve_credentials(config)
-    assert creds["ip"] == "192.168.1.99"
-    assert creds["access_code"] == "override_code"
-    assert creds["serial"] == "OVERRIDE_SN"
-
-
-def test_resolve_credentials_cloud_env(monkeypatch):
-    config = PrinterConfig(mode="cloud")
-    monkeypatch.setenv("BAMBU_EMAIL", "user@test.com")
-    monkeypatch.setenv("BAMBU_PASSWORD", "secret")
-    creds = _resolve_credentials(config)
-    assert creds["mode"] == "cloud"
-    assert creds["email"] == "user@test.com"
-    assert creds["password"] == "secret"
-
-
-def test_send_print_lan_dry_run(tmp_path, capsys):
+def test_send_print_lan_dry_run(tmp_path, monkeypatch, capsys):
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.workshop]
+ip = "10.0.0.1"
+access_code = "abc"
+serial = "SN123"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    monkeypatch.delenv("BAMBU_PRINTER_IP", raising=False)
+    monkeypatch.delenv("BAMBU_ACCESS_CODE", raising=False)
+    monkeypatch.delenv("BAMBU_SERIAL", raising=False)
     gcode = tmp_path / "test.gcode"
     gcode.write_text("; test gcode")
-    config = PrinterConfig(mode="lan", ip="10.0.0.1", access_code="abc", serial="SN123")
+    config = PrinterConfig(mode="lan", name="workshop")
     with patch("fabprint.printer._send_lan") as mock_send:
         send_print(gcode, config, dry_run=True)
         mock_send.assert_called_once_with(
@@ -60,8 +148,11 @@ def test_send_print_lan_dry_run(tmp_path, capsys):
         )
 
 
-def test_send_print_cloud_dispatches_bambu_connect(tmp_path):
+def test_send_print_cloud_dispatches_bambu_connect(tmp_path, monkeypatch):
     """Test that cloud mode dispatches to _send_bambu_connect."""
+    monkeypatch.delenv("BAMBU_PRINTER_IP", raising=False)
+    monkeypatch.delenv("BAMBU_ACCESS_CODE", raising=False)
+    monkeypatch.delenv("BAMBU_SERIAL", raising=False)
     gcode = tmp_path / "test.gcode"
     gcode.write_text("; test gcode")
     config = PrinterConfig(mode="cloud")
@@ -71,11 +162,20 @@ def test_send_print_cloud_dispatches_bambu_connect(tmp_path):
         mock_send.assert_called_once_with(gcode, dry_run=True)
 
 
-def test_send_print_cloud_bridge_dispatches(tmp_path):
+def test_send_print_cloud_bridge_dispatches(tmp_path, monkeypatch):
     """Test that cloud-bridge mode dispatches to _send_cloud_bridge."""
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.workshop]
+serial = "SN123"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    monkeypatch.delenv("BAMBU_SERIAL", raising=False)
     gcode = tmp_path / "test.gcode"
     gcode.write_text("; test gcode")
-    config = PrinterConfig(mode="cloud-bridge", serial="SN123")
+    config = PrinterConfig(mode="cloud-bridge", name="workshop")
 
     with patch("fabprint.printer._send_cloud_bridge") as mock_send:
         send_print(gcode, config, dry_run=True)
@@ -84,29 +184,72 @@ def test_send_print_cloud_bridge_dispatches(tmp_path):
         )
 
 
-def test_send_print_lan_missing_ip():
-    config = PrinterConfig(mode="lan", ip=None, access_code="abc", serial="SN123")
+def test_send_print_lan_missing_ip(tmp_path, monkeypatch):
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.workshop]
+access_code = "abc"
+serial = "SN123"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    monkeypatch.delenv("BAMBU_PRINTER_IP", raising=False)
+    config = PrinterConfig(mode="lan", name="workshop")
     with pytest.raises(ValueError, match="ip"):
         send_print(Path("dummy.gcode"), config)
 
 
-def test_send_print_lan_missing_access_code():
-    config = PrinterConfig(mode="lan", ip="10.0.0.1", access_code=None, serial="SN123")
+def test_send_print_lan_missing_access_code(tmp_path, monkeypatch):
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.workshop]
+ip = "10.0.0.1"
+serial = "SN123"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    monkeypatch.delenv("BAMBU_ACCESS_CODE", raising=False)
+    config = PrinterConfig(mode="lan", name="workshop")
     with pytest.raises(ValueError, match="access_code"):
         send_print(Path("dummy.gcode"), config)
 
 
-def test_send_print_lan_missing_serial():
-    config = PrinterConfig(mode="lan", ip="10.0.0.1", access_code="abc", serial=None)
+def test_send_print_lan_missing_serial(tmp_path, monkeypatch):
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.workshop]
+ip = "10.0.0.1"
+access_code = "abc"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    monkeypatch.delenv("BAMBU_SERIAL", raising=False)
+    config = PrinterConfig(mode="lan", name="workshop")
     with pytest.raises(ValueError, match="serial"):
         send_print(Path("dummy.gcode"), config)
 
 
-def test_send_print_lan_dispatches(tmp_path):
+def test_send_print_lan_dispatches(tmp_path, monkeypatch):
     """Test that LAN mode dispatches to _send_lan with correct args."""
+    cred_path = _write_credentials(
+        tmp_path,
+        """
+[printers.workshop]
+ip = "10.0.0.1"
+access_code = "abc"
+serial = "SN123"
+""",
+    )
+    monkeypatch.setenv("FABPRINT_CREDENTIALS", str(cred_path))
+    monkeypatch.delenv("BAMBU_PRINTER_IP", raising=False)
+    monkeypatch.delenv("BAMBU_ACCESS_CODE", raising=False)
+    monkeypatch.delenv("BAMBU_SERIAL", raising=False)
     gcode = tmp_path / "test.gcode"
     gcode.write_text("; test gcode")
-    config = PrinterConfig(mode="lan", ip="10.0.0.1", access_code="abc", serial="SN123")
+    config = PrinterConfig(mode="lan", name="workshop")
 
     with patch("fabprint.printer._send_lan") as mock_send:
         send_print(gcode, config, dry_run=False)


### PR DESCRIPTION
## Summary
- Printer credentials (ip, access_code, serial) no longer accepted in project `fabprint.toml`
- New `~/.config/fabprint/credentials.toml` stores credentials keyed by printer name
- Project TOML `[printer]` section now takes `mode` and `name` (references credentials file)
- Env vars (`BAMBU_PRINTER_IP`, `BAMBU_ACCESS_CODE`, `BAMBU_SERIAL`) still override everything
- `FABPRINT_CREDENTIALS` env var overrides the credentials file path (used in tests)
- **Breaking change**: old `[printer]` fields rejected with helpful error message

### Credentials file format
```toml
[printers.workshop]
ip = "192.168.1.50"
access_code = "12345678"
serial = "01P00A451601106"
```

### Project TOML
```toml
[printer]
mode = "cloud-bridge"
name = "workshop"
```

## Test plan
- [x] 178 non-Docker tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)