### PR TITLE
Add Python version classifiers for PyPI badge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,11 @@ version = "0.1.41"
 description = "Immutable 3D print pipeline: arrange, slice, and print"
 readme = "README.md"
 requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 dependencies = [
     "trimesh[easy]>=4.0.0",
     "rectpack>=0.2.0",


### PR DESCRIPTION
## Summary
- Added `Programming Language :: Python :: 3.11/3.12/3.13` classifiers to `pyproject.toml`
- The `pyversions` shields.io badge reads from PyPI classifiers, not `requires-python` — this is why the badge was showing as empty

## Test plan
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)