### PR TITLE
Add fabprint credentials command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Combined with `version = "2.3.1"` in `[slicer]` (which pins the Docker image), t
 fabprint init                        # interactive config wizard
 fabprint init --template             # dump commented TOML template
 fabprint validate                    # check config for issues
+fabprint credentials                 # set up printer credentials
 fabprint run                         # full pipeline
 fabprint run --until plate           # stop after plating
 fabprint run --only slice            # run just one stage

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,41 @@ fabprint validate                  # check ./fabprint.toml
 fabprint validate myproject.toml   # check a specific file
 ```
 
+## `fabprint credentials`
+
+Interactively create or update `~/.config/fabprint/credentials.toml`.
+
+```
+fabprint credentials
+```
+
+Prompts for:
+- **Printer name** — used to reference this printer in `fabprint.toml` (e.g. `name = "workshop"`)
+- **IP address** — for LAN mode connections
+- **Access code** — 8-digit code from the printer's screen
+- **Serial number** — from the printer label
+
+The credentials file is created with `600` permissions (owner read/write only). If the file already exists, new printers are added alongside existing ones.
+
+### Example session
+
+```
+$ fabprint credentials
+Printer name (e.g. 'workshop'): workshop
+
+Setting up printer 'workshop'
+  Leave blank to skip optional fields.
+
+  IP address (for LAN mode): 192.168.1.100
+  Access code (8 digits, from printer screen): 12345678
+  Serial number (from printer label): 01P00A451601106
+
+Wrote ~/.config/fabprint/credentials.toml (mode 600)
+Reference this printer in fabprint.toml with:
+  [printer]
+  name = "workshop"
+```
+
 ## `fabprint run`
 
 Run all or part of the pipeline.

--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -243,6 +243,13 @@ def main(argv: list[str] | None = None) -> None:
         help="Path to config file (default: ./fabprint.toml)",
     )
 
+    # --- credentials subcommand ---
+    sub.add_parser(
+        "credentials",
+        parents=[common],
+        help="Set up printer credentials (~/.config/fabprint/credentials.toml)",
+    )
+
     # --- login subcommand ---
     login_cmd = sub.add_parser(
         "login", parents=[common], help="Login to Bambu Cloud and cache token"
@@ -286,6 +293,8 @@ def main(argv: list[str] | None = None) -> None:
             _cmd_init(args)
         elif args.command == "validate":
             _cmd_validate(args)
+        elif args.command == "credentials":
+            _cmd_credentials(args)
         elif args.command == "login":
             _cmd_login(args)
         elif args.command == "status":
@@ -350,6 +359,12 @@ def _cmd_init(args: argparse.Namespace) -> None:
         print(dump_template(), end="")
     else:
         run_wizard(output=args.output)
+
+
+def _cmd_credentials(args: argparse.Namespace) -> None:
+    from fabprint.credentials import setup_credentials
+
+    setup_credentials()
 
 
 def _cmd_validate(args: argparse.Namespace) -> None:

--- a/src/fabprint/credentials.py
+++ b/src/fabprint/credentials.py
@@ -55,3 +55,65 @@ def load_printer_credentials(name: str | None) -> dict[str, str | None]:
         "email": os.environ.get("BAMBU_EMAIL", file_creds.get("email")),
         "password": os.environ.get("BAMBU_PASSWORD", file_creds.get("password")),
     }
+
+
+def setup_credentials() -> None:
+    """Interactive wizard to create or update credentials.toml."""
+    path = _credentials_path()
+
+    # Load existing file if present
+    existing: dict = {}
+    if path.exists():
+        with open(path, "rb") as f:
+            existing = tomllib.load(f)
+        printers = existing.get("printers", {})
+        if printers:
+            print(f"Existing credentials: {path}")
+            print(f"  Printers: {', '.join(printers.keys())}")
+            print()
+
+    name = input("Printer name (e.g. 'workshop'): ").strip()
+    if not name:
+        print("Aborted — printer name is required.")
+        return
+
+    print(f"\nSetting up printer '{name}'")
+    print("  Leave blank to skip optional fields.\n")
+
+    ip = input("  IP address (for LAN mode): ").strip() or None
+    access_code = input("  Access code (8 digits, from printer screen): ").strip() or None
+    serial = input("  Serial number (from printer label): ").strip() or None
+
+    entry: dict[str, str] = {}
+    if ip:
+        entry["ip"] = ip
+    if access_code:
+        entry["access_code"] = access_code
+    if serial:
+        entry["serial"] = serial
+
+    if not entry:
+        print("\nNo credentials entered. Aborted.")
+        return
+
+    # Merge into existing config
+    if "printers" not in existing:
+        existing["printers"] = {}
+    existing["printers"][name] = entry
+
+    # Write TOML manually (tomllib is read-only, no tomli_w dependency)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        for printer_name, creds in existing["printers"].items():
+            f.write(f"[printers.{printer_name}]\n")
+            for key, val in creds.items():
+                f.write(f'{key} = "{val}"\n')
+            f.write("\n")
+
+    # Set restrictive permissions (owner read/write only)
+    path.chmod(0o600)
+
+    print(f"\nWrote {path} (mode 600)")
+    print("Reference this printer in fabprint.toml with:")
+    print("  [printer]")
+    print(f'  name = "{name}"')

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,93 @@
+"""Tests for fabprint credentials setup command."""
+
+import tomllib
+
+from fabprint.credentials import setup_credentials
+
+
+class TestSetupCredentials:
+    def test_creates_new_file(self, tmp_path, monkeypatch):
+        cred_path = tmp_path / "credentials.toml"
+        monkeypatch.setattr("fabprint.credentials._credentials_path", lambda: cred_path)
+
+        inputs = iter(["workshop", "192.168.1.100", "12345678", "01P00A123"])
+        monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+
+        setup_credentials()
+
+        assert cred_path.exists()
+        assert cred_path.stat().st_mode & 0o777 == 0o600
+        with open(cred_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data["printers"]["workshop"]["ip"] == "192.168.1.100"
+        assert data["printers"]["workshop"]["access_code"] == "12345678"
+        assert data["printers"]["workshop"]["serial"] == "01P00A123"
+
+    def test_adds_to_existing(self, tmp_path, monkeypatch):
+        cred_path = tmp_path / "credentials.toml"
+        cred_path.write_text('[printers.old]\nip = "10.0.0.1"\n')
+        monkeypatch.setattr("fabprint.credentials._credentials_path", lambda: cred_path)
+
+        inputs = iter(["new-printer", "192.168.1.50", "", "ABC123"])
+        monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+
+        setup_credentials()
+
+        with open(cred_path, "rb") as f:
+            data = tomllib.load(f)
+        # Old printer preserved
+        assert data["printers"]["old"]["ip"] == "10.0.0.1"
+        # New printer added
+        assert data["printers"]["new-printer"]["serial"] == "ABC123"
+        assert "access_code" not in data["printers"]["new-printer"]
+
+    def test_aborts_on_empty_name(self, tmp_path, monkeypatch, capsys):
+        cred_path = tmp_path / "credentials.toml"
+        monkeypatch.setattr("fabprint.credentials._credentials_path", lambda: cred_path)
+
+        monkeypatch.setattr("builtins.input", lambda _="": "")
+
+        setup_credentials()
+
+        assert not cred_path.exists()
+        assert "Aborted" in capsys.readouterr().out
+
+    def test_aborts_on_no_fields(self, tmp_path, monkeypatch, capsys):
+        cred_path = tmp_path / "credentials.toml"
+        monkeypatch.setattr("fabprint.credentials._credentials_path", lambda: cred_path)
+
+        inputs = iter(["my-printer", "", "", ""])
+        monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+
+        setup_credentials()
+
+        assert not cred_path.exists()
+        assert "No credentials" in capsys.readouterr().out
+
+    def test_creates_parent_dirs(self, tmp_path, monkeypatch):
+        cred_path = tmp_path / "deep" / "nested" / "credentials.toml"
+        monkeypatch.setattr("fabprint.credentials._credentials_path", lambda: cred_path)
+
+        inputs = iter(["p1", "10.0.0.1", "", ""])
+        monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+
+        setup_credentials()
+
+        assert cred_path.exists()
+
+    def test_cli_credentials(self, tmp_path, monkeypatch):
+        """CLI wiring works."""
+        from fabprint.cli import main
+
+        cred_path = tmp_path / "credentials.toml"
+        monkeypatch.setattr("fabprint.credentials._credentials_path", lambda: cred_path)
+
+        inputs = iter(["test", "1.2.3.4", "99887766", ""])
+        monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+
+        main(["credentials"])
+
+        assert cred_path.exists()
+        with open(cred_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data["printers"]["test"]["ip"] == "1.2.3.4"


### PR DESCRIPTION
## Summary
- New `fabprint credentials` command — interactive wizard to create/update `~/.config/fabprint/credentials.toml`
- Prompts for printer name, IP address, access code, and serial number
- Creates file with `600` permissions (owner read/write only)
- Preserves existing printers when adding new ones
- Creates parent directories if needed
- Added to README CLI overview and CLI reference docs

## Test plan
- [ ] 6 new tests: create file, add to existing, abort on empty name, abort on no fields, create parent dirs, CLI wiring
- [ ] All 241 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)