### PR TITLE
Add project metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,21 @@
 [project]
 name = "fabprint"
 version = "0.1.50"
-description = "Immutable 3D print pipeline: arrange, slice, and print"
+description = "Headless 3D print pipeline: arrange, orient, slice, and send to printer from a TOML config"
 readme = "README.md"
 requires-python = ">=3.11"
+license = {file = "LICENSE"}
+authors = [{name = "Paul Fremantle", email = "paul@fremantle.org"}]
+keywords = ["3d-printing", "bambu", "orcaslicer", "gcode", "3mf", "slicer", "pipeline"]
 classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Manufacturing",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering",
 ]
 dependencies = [
     "trimesh[easy]>=4.0.0",
@@ -18,6 +26,11 @@ dependencies = [
     "bambu-lab-cloud-api",
     "requests>=2.28",
 ]
+
+[project.urls]
+Homepage = "https://github.com/pzfreo/fabprint"
+Repository = "https://github.com/pzfreo/fabprint"
+Issues = "https://github.com/pzfreo/fabprint/issues"
 
 [project.optional-dependencies]
 step = ["build123d>=0.10.0"]


### PR DESCRIPTION
## Summary
- Add `license`, `authors`, `keywords` fields
- Add `[project.urls]` with Homepage, Repository, Issues links
- Expand classifiers: dev status (Beta), audience, license, topic
- Improve `description` to mention TOML config and headless usage

PyPI will now show license, author info, keywords, and sidebar links.

## Test plan
- [x] `uv run ruff check` passes
- [x] `uv run pytest` — 251 passed
- [x] Hatchling builds successfully with new metadata
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)