### PR TITLE
Add LICENSE to Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Install fabprint
 WORKDIR /opt/fabprint
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ ./src/
 RUN uv python install 3.12 \
     && uv sync --frozen --no-dev --no-editable --python 3.12 \


### PR DESCRIPTION
## Summary
- Add `LICENSE` file to the Dockerfile `COPY` line so hatchling can resolve `license = {file = "LICENSE"}` during Docker builds
- Fixes the OrcaSlicer Docker image build failure from #96

## Test plan
- [ ] Verify CI passes
- [ ] Docker build succeeds with LICENSE present

🤖 Generated with [Claude Code](https://claude.com/claude-code)