### PR TITLE
Add CHANGELOG, CONTRIBUTING, and mypy to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - run: uv sync --extra dev
       - run: uv run ruff check src tests
       - run: uv run ruff format --check src tests
+      - run: uv run mypy src/fabprint
 
   test:
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to fabprint are documented here.
+
+## 0.1.53 — 2026-03-17
+
+- Fix LICENSE copyright placeholder
+- Add `py.typed` marker for PEP 561 type checking
+- Add `__all__` to `__init__.py`
+- Add `SECURITY.md`
+
+## 0.1.51 — 2026-03-17
+
+- Add project metadata to `pyproject.toml` (license, authors, keywords, URLs, classifiers)
+- Fix Dockerfile missing LICENSE for hatchling build
+
+## 0.1.50 — 2026-03-17
+
+- Fix per-object filament resolution bug (`config.py:262`) — only the last part's
+  `[parts.filaments]` overrides were applied in multi-part configs
+- Replace `ValueError` with `FabprintError` for consistent user-facing errors
+- Narrow bare `except Exception` to specific types in cloud.py
+- Extract magic numbers into named constants (cloud.py, gcode.py)
+
+## 0.1.49 — 2026-03-16
+
+- Add "How is this different from OrcaSlicer CLI?" section to README
+- Add asciinema recordings for `init` and `run` commands
+
+## 0.1.48 — 2026-03-15
+
+- Flag Moonraker support as experimental (untested against real hardware)
+
+## 0.1.47 — 2026-03-15
+
+- Add multi-printer-type `status`/`watch` commands
+- Refactor printer system: unified `fabprint setup`, multi-printer-type support
+  (bambu-lan, bambu-cloud, moonraker)
+- Move printer secrets from project TOML to `~/.config/fabprint/credentials.toml`
+- Skip file permission assertion on Windows
+
+## 0.1.45 — 2026-03-14
+
+- Improve `init` wizard UX: search filter for long profile lists
+- Fix README images and links for PyPI rendering
+
+## 0.1.43 — 2026-03-13
+
+- Add `fabprint init`, `validate`, and interactive wizard commands
+- Remove BambuStudio slicer engine support (OrcaSlicer only)
+
+## 0.1.41 — 2026-03-12
+
+- Keep build123d as optional extra (vtk lacks Python 3.13 wheels)
+- Add developer docs and simplify README
+
+## 0.1.40 — 2026-03-11
+
+- Replace `plate`/`slice`/`print` commands with Hamilton-driven `run` pipeline
+- Make config arg optional — auto-discover `./fabprint.toml`
+- Split CLI and config reference into separate docs
+- Add slicer.overrides support for per-project process tweaks
+
+## 0.1.37 — 2026-03-09
+
+- Add `fabprint login`, `status`, and `watch` subcommands
+- Support multi-object 3MF files with per-object filament assignment
+- Add sequential printing support
+- Add `gcode-info` subcommand for extruder usage analysis
+
+## 0.1.33 — 2026-03-06
+
+- Add cloud printing via C++ bridge (bambu_cloud_bridge)
+- Add X.509 RSA-SHA256 command signing for cloud MQTT
+- Add pure Python HTTP cloud print mode (partial — signing limitation)
+
+## 0.1.25 — 2026-02-28
+
+- Add Bambu Connect-compatible `.gcode.3mf` export
+- Render isometric plate thumbnails with shading
+- Docker as default slicer with local fallback
+
+## 0.1.15 — 2026-02-20
+
+- Add `print` subcommand with LAN and cloud printer support
+- Add slicer version pinning and Docker integration
+- Preserve paint_color from pre-painted 3MF inputs
+
+## 0.1.5 — 2026-02-10
+
+- Add profile discovery, resolution, and pinning
+- Add per-part AMS filament assignment
+- Add uniform scale factor for parts
+
+## 0.1.0 — 2026-02-05
+
+- Initial release: core plate generation pipeline
+- Load STL/3MF, orient, arrange via bin-packing, export plate 3MF
+- OrcaSlicer CLI integration (local + Docker)
+- Cross-platform support (macOS, Linux, Windows)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,10 @@
 Before pushing any PR branch, always run locally:
 1. `uv run ruff check src tests` — lint must pass with zero errors
 2. `uv run ruff format --check src tests` — formatting must pass (run `uv run ruff format src tests` to auto-fix)
-3. `uv run pytest` — all tests must pass
+3. `uv run mypy src/fabprint` — type check must pass with zero errors
+4. `uv run pytest` — all tests must pass
 
-Do NOT push a PR until all three checks pass locally.
+Do NOT push a PR until all four checks pass locally.
 
 ## Post-PR Checklist (MANDATORY)
 After pushing a PR or merging to main:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to fabprint
+
+Thanks for your interest in contributing! Here's how to get started.
+
+## Development setup
+
+See [docs/developing.md](docs/developing.md) for full setup instructions. Quick start:
+
+```bash
+git clone https://github.com/pzfreo/fabprint.git
+cd fabprint
+uv sync --extra dev
+```
+
+## Before submitting a PR
+
+1. **Lint**: `uv run ruff check src tests`
+2. **Format**: `uv run ruff format src tests`
+3. **Test**: `uv run pytest`
+4. **Type check**: `uv run mypy src/fabprint`
+
+All four must pass — CI enforces them.
+
+## Code style
+
+- Python 3.11+ with `from __future__ import annotations`
+- Type hints on all public functions
+- Use `FabprintError` for user-facing errors (not `ValueError`)
+- Keep functions focused — prefer small functions over long ones
+- No unnecessary comments or docstrings on obvious code
+
+## Issues
+
+- Bug reports: include Python version, OS, and the full error message
+- Feature requests: describe the use case, not just the solution
+- Security issues: see [SECURITY.md](SECURITY.md) — do not open a public issue
+
+## Pull requests
+
+- One logical change per PR
+- Write a clear title and description
+- Add tests for new functionality
+- Update CHANGELOG.md for user-visible changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Issues = "https://github.com/pzfreo/fabprint/issues"
 
 [project.optional-dependencies]
 step = ["build123d>=0.10.0"]
-dev = ["pytest>=8.0.0", "ruff>=0.4.0", "packaging>=23.0"]
+dev = ["pytest>=8.0.0", "ruff>=0.4.0", "packaging>=23.0", "mypy>=1.10.0"]
 
 [project.scripts]
 fabprint = "fabprint.cli:main"
@@ -49,6 +49,13 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+warn_unused_configs = true
+check_untyped_defs = true
+disable_error_code = ["import-untyped"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -447,9 +447,9 @@ def _query_printer_status(name: str, creds: dict) -> dict:
     elif ptype == "bambu-lan":
         from fabprint.printer import get_lan_status
 
-        ip = creds.get("ip")
-        access_code = creds.get("access_code")
-        serial = creds.get("serial")
+        ip = creds.get("ip") or ""
+        access_code = creds.get("access_code") or ""
+        serial = creds.get("serial") or ""
         if not all([ip, access_code, serial]):
             raise ValueError(f"bambu-lan printer '{name}' requires ip, access_code, serial")
         return get_lan_status(ip, access_code, serial)

--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -16,6 +16,11 @@ Two approaches:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
 import base64
 import hashlib
 import io
@@ -202,6 +207,7 @@ def _run_bridge(
         )
         return result
     else:
+        assert bridge is not None  # guaranteed by use_docker check above
         cmd = [bridge] + args
 
     if verbose:
@@ -262,6 +268,7 @@ class PersistentBridge:
 
     def status(self, device_id: str, *, timeout: int = BRIDGE_STATUS_TIMEOUT) -> dict:
         """Query printer status via the running container."""
+        assert self._container_id is not None
         cmd = [
             "docker",
             "exec",
@@ -631,7 +638,7 @@ def _build_ams_mapping(
     Returns a dict with all AMS-related task body fields, matching BambuConnect's format.
     Uses the total filament slot count from project_settings.config (not just plate filaments).
     """
-    result = {
+    result: dict[str, list] = {
         "amsDetailMapping": [],
         "amsMapping": [],
         "amsMapping2": [],
@@ -653,7 +660,7 @@ def _build_ams_mapping(
             filament_by_id = {}
             if "Metadata/slice_info.config" in z.namelist():
                 root = ET.fromstring(z.read("Metadata/slice_info.config"))
-                plate_el = None
+                plate_el: ET.Element | None = None
                 for plate in root.findall("plate"):
                     idx_meta = plate.find("metadata[@key='index']")
                     if idx_meta is not None and idx_meta.get("value") == str(plate_index):
@@ -695,11 +702,11 @@ def _build_ams_mapping(
     setting_ids = []
     for slot_idx in range(total_slots):
         filament_id = slot_idx + 1
-        f = filament_by_id.get(filament_id)
-        if f is not None:
-            source_color = f.get("color", "#000000").lstrip("#").upper() + "FF"
-            fil_type = f.get("type", "")
-            tray_idx = f.get("tray_info_idx", "")
+        fil_el = filament_by_id.get(filament_id)
+        if fil_el is not None:
+            source_color = fil_el.get("color", "#000000").lstrip("#").upper() + "FF"
+            fil_type = fil_el.get("type", "")
+            tray_idx = fil_el.get("tray_info_idx", "")
             phys_slot = phys_by_id[slot_idx]  # 0-based physical slot
             # targetColor = actual AMS color; falls back to sourceColor if unknown
             actual_tray = tray_by_phys.get(phys_slot)
@@ -821,7 +828,7 @@ def _build_ams_mapping_from_state(
 
 
 def _poll_task_status(
-    session: requests.Session,  # noqa: F821
+    session: Any,  # requests.Session — imported inside cloud_print_http()
     task_id: int,
     device_id: str = "",
     *,

--- a/src/fabprint/config.py
+++ b/src/fabprint/config.py
@@ -205,8 +205,10 @@ def load_config(path: Path) -> FabprintConfig:
     if has_int_filaments and not has_string_filaments and not slicer.slots:
         # All integers, no slots map — backward compatible, no resolution needed
         for i, raw_fil in enumerate(raw_filaments):
+            assert isinstance(raw_fil, int)
             parts[i].filament = raw_fil
             for obj_name, obj_fil in raw_obj_filaments[i].items():
+                assert isinstance(obj_fil, int)
                 parts[i].object_filaments[obj_name] = obj_fil
     else:
         if not slicer.filaments:

--- a/src/fabprint/plate.py
+++ b/src/fabprint/plate.py
@@ -169,7 +169,7 @@ def _inject_paint_data(output: Path, scene: trimesh.Scene) -> None:
     # prefixes (avoids ns0: renames). Note: ET.tostring still drops
     # unused namespace declarations from the root element.
     for _event, (prefix, uri) in ET.iterparse(io.BytesIO(model_xml), events=["start-ns"]):
-        ET.register_namespace(prefix, uri)
+        ET.register_namespace(prefix, uri)  # type: ignore[arg-type]
 
     root = SafeET.fromstring(model_xml)
 

--- a/src/fabprint/printer.py
+++ b/src/fabprint/printer.py
@@ -191,7 +191,7 @@ def get_lan_status(ip: str, access_code: str, serial: str) -> dict:
         printer.connect()
         # Give MQTT a moment to receive the first status push
         time.sleep(3)
-        status = printer.get_device_status() or {}
+        status = printer.get_device_status() or {}  # type: ignore[attr-defined]
         return status
     finally:
         printer.disconnect()
@@ -396,17 +396,20 @@ def send_print(
         )
 
     if ptype == "bambu-lan":
-        for field in ("ip", "access_code", "serial"):
-            if not creds[field]:
+        ip = creds.get("ip") or ""
+        access_code = creds.get("access_code") or ""
+        serial = creds.get("serial") or ""
+        for field_name, field_val in [("ip", ip), ("access_code", access_code), ("serial", serial)]:
+            if not field_val:
                 raise FabprintError(
-                    f"bambu-lan printer '{config.name}' requires {field}. "
+                    f"bambu-lan printer '{config.name}' requires {field_name}. "
                     "Run 'fabprint setup' to configure it."
                 )
         _send_lan(
             gcode_path,
-            ip=creds["ip"],
-            access_code=creds["access_code"],
-            serial=creds["serial"],
+            ip=ip,
+            access_code=access_code,
+            serial=serial,
             dry_run=dry_run,
             upload_only=upload_only,
         )

--- a/src/fabprint/profiles.py
+++ b/src/fabprint/profiles.py
@@ -184,8 +184,8 @@ def pin_profiles(
 
         # Always re-flatten to pick up any slicer updates
         data = resolve_profile_data(name, engine, category)
-        with open(dest, "w") as f:
-            json.dump(data, f, indent=4)
+        with open(dest, "w") as fh:
+            json.dump(data, fh, indent=4)
         log.info("Pinned %s → %s (flattened)", name, dest)
         pinned.append(dest)
 

--- a/src/fabprint/slicer.py
+++ b/src/fabprint/slicer.py
@@ -325,7 +325,7 @@ def _render_plate_thumbnail(width: int, height: int, plate_3mf: Path) -> bytes:
     from PIL import Image, ImageDraw
 
     scene = trimesh.load(str(plate_3mf), force="scene")
-    meshes = list(scene.geometry.values())
+    meshes = list(scene.geometry.values())  # type: ignore[attr-defined]
     if not meshes:
         raise ValueError("No geometry in plate 3MF")
 

--- a/src/fabprint/viewer.py
+++ b/src/fabprint/viewer.py
@@ -74,7 +74,7 @@ def _try_trimesh(
 
     # Add ghost plate
     plate = _make_plate_outline(plate_size)
-    plate.visual.face_colors = [200, 200, 200, 80]
+    plate.visual.face_colors = [200, 200, 200, 80]  # type: ignore[union-attr]
     scene.add_geometry(plate, node_name="build_plate")
 
     for i, mesh in enumerate(meshes):


### PR DESCRIPTION
## Summary
- Add **CHANGELOG.md** with version history from 0.1.0 to 0.1.53
- Add **CONTRIBUTING.md** linking to docs/developing.md with PR conventions
- Add **mypy** type checking to CI lint job and fix all 36 type errors across the codebase
- Update pyproject.toml with mypy config and dev dependency
- Update CLAUDE.md pre-PR checklist to include mypy

## Test plan
- [ ] CI lint job passes (includes new `uv run mypy src/fabprint` step)
- [ ] All existing tests pass on all OS/Python matrix combinations
- [ ] Cloud bridge build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)