### PR TITLE
Fix README prerequisites: require Docker or OrcaSlicer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ OrcaSlicer CLI slices one plate of pre-arranged models. fabprint is a pipeline a
 
 ## Quick start
 
-**Prerequisites:** Python 3.11+ is required. [Docker](https://docs.docker.com/get-docker/) is optional but recommended — it enables pinned OrcaSlicer versions for fully reproducible slicing. Without Docker, fabprint uses your locally installed OrcaSlicer.
+**Prerequisites:** Python 3.11+ and either [Docker](https://docs.docker.com/get-docker/) or a local [OrcaSlicer](https://github.com/SoftFever/OrcaSlicer) install. Docker is recommended for reproducible slicing — it lets you pin the exact OrcaSlicer version so every machine produces identical G-code.
 
 ```bash
 pip install fabprint                # STL + 3MF support, LAN + cloud printing


### PR DESCRIPTION
## Summary
- Clarify that either Docker or a local OrcaSlicer install is required (not optional)
- Recommend Docker for reproducible slicing

## Test plan
- [ ] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)