### PR TITLE
Silence Hamilton telemetry, warnings, and tracebacks

### DIFF
--- a/src/fabprint/cli.py
+++ b/src/fabprint/cli.py
@@ -20,6 +20,14 @@ log = logging.getLogger(__name__)
 
 def _build_driver(verbose: bool = False):
     """Build a Hamilton driver wired to the fabprint pipeline."""
+    import os
+
+    # Disable Hamilton telemetry before first import
+    os.environ["HAMILTON_TELEMETRY_ENABLED"] = "false"
+
+    # Silence all Hamilton loggers (pandera warnings, tracebacks, extension messages)
+    logging.getLogger("hamilton").setLevel(logging.WARNING)
+
     from hamilton import driver
 
     from fabprint import adapters, pipeline


### PR DESCRIPTION
## Summary
- Disable Hamilton's anonymous telemetry collection via `HAMILTON_TELEMETRY_ENABLED=false`
- Suppress all Hamilton internal log messages (pandera import notice, extension loading, error traceback box) by setting the `hamilton` logger to WARNING level
- Pipeline errors now show only the clean `error: ...` message, no more multi-line traceback boxes

## Test plan
- [ ] Run `fabprint run` with parts that exceed plate size — should show `error: Only 5/6 parts fit...` with no traceback
- [ ] Run `fabprint run` normally — no pandera/telemetry/Hamilton INFO messages
- [ ] Run with `-v` — fabprint's own timing adapter still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)