### PR TITLE
Fix watch command hanging on bridge status query

### DIFF
--- a/src/fabprint/cloud.py
+++ b/src/fabprint/cloud.py
@@ -267,7 +267,13 @@ class PersistentBridge:
             self._container_id = None
 
     def status(self, device_id: str, *, timeout: int = BRIDGE_STATUS_TIMEOUT) -> dict:
-        """Query printer status via the running container."""
+        """Query printer status via the running container.
+
+        The bridge binary outputs JSON but may not exit afterwards, so we
+        read the first line of stdout and kill the process.
+        """
+        import selectors
+
         assert self._container_id is not None
         cmd = [
             "docker",
@@ -278,16 +284,24 @@ class PersistentBridge:
             device_id,
             "/input/token.json",
         ]
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        assert proc.stdout is not None
         try:
-            data = json.loads(result.stdout.strip())
+            sel = selectors.DefaultSelector()
+            sel.register(proc.stdout, selectors.EVENT_READ)
+            ready = sel.select(timeout=timeout)
+            sel.close()
+            if not ready:
+                raise RuntimeError(f"Status query timed out for printer {device_id}")
+            line = proc.stdout.readline()
+        finally:
+            proc.kill()
+            proc.wait()
+        try:
+            data = json.loads(line.strip())
             return data.get("print", data)
         except json.JSONDecodeError:
-            if result.returncode == 2:
-                raise RuntimeError(f"No status received from printer {device_id}")
-            raise RuntimeError(
-                f"Bridge returned non-JSON (exit {result.returncode}): {result.stdout[:200]}"
-            )
+            raise RuntimeError(f"Bridge returned non-JSON (exit {proc.returncode}): {line[:200]}")
 
 
 def cloud_print(


### PR DESCRIPTION
## Summary
- `fabprint watch` was hanging indefinitely because the bridge binary outputs JSON but doesn't exit
- `PersistentBridge.status()` used `subprocess.run()` which waits for process termination
- Fix: use `Popen` with `selectors` to read the first line of stdout, then kill the process

## Test plan
- [x] `fabprint watch` works locally — discovers printer, shows dashboard
- [x] 247 non-Docker tests pass
- [x] mypy passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)