### PR TITLE
Fix cloud token temp file for Docker Desktop on macOS

### DIFF
--- a/src/fabprint/credentials.py
+++ b/src/fabprint/credentials.py
@@ -171,7 +171,12 @@ def cloud_token_json():
         "uid": cloud.get("uid", ""),
     }
 
-    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", prefix="bambu_token_", delete=False)
+    # Use ~/.cache so Docker Desktop on macOS can mount the file (/var/folders is not shared)
+    cache_dir = Path.home() / ".cache" / "fabprint"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", prefix="bambu_token_", dir=cache_dir, delete=False
+    )
     try:
         json.dump(bridge_data, tmp)
         tmp.close()


### PR DESCRIPTION
## Summary
- `cloud_token_json()` was creating temp files in `/var/folders/` (macOS default)
- Docker Desktop can't mount paths outside `/Users/`, `/tmp/`, `/Volumes/`
- Bridge container couldn't read the token → empty output, exit code 1
- Fix: create temp files in `~/.cache/fabprint/` instead

## Test plan
- [x] `fabprint watch` works locally with cloud printer
- [x] 247 non-Docker tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)