### PR TITLE
Query AMS in background during init; Docker required for cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ OrcaSlicer CLI slices one plate of pre-arranged models. fabprint is a pipeline a
 
 ## Quick start
 
-**Prerequisites:** Python 3.11+ and either [Docker](https://docs.docker.com/get-docker/) or a local [OrcaSlicer](https://github.com/SoftFever/OrcaSlicer) install. Docker is recommended for reproducible slicing — it lets you pin the exact OrcaSlicer version so every machine produces identical G-code.
+**Prerequisites:** Python 3.11+ and either [Docker](https://docs.docker.com/get-docker/) or a local [OrcaSlicer](https://github.com/SoftFever/OrcaSlicer) install. Docker is required for Bambu Cloud printing and recommended for reproducible slicing — it lets you pin the exact OrcaSlicer version so every machine produces identical G-code.
 
 ```bash
 pip install fabprint                # STL + 3MF support, LAN + cloud printing

--- a/src/fabprint/init.py
+++ b/src/fabprint/init.py
@@ -412,21 +412,13 @@ def run_wizard(output: Path | None = None) -> str:
         else:
             print("  Continuing without printer setup.\n")
 
-    # --- Query AMS trays from configured printer ---
-    ams_trays: list[dict] = []
+    # --- Query AMS trays in background while we ask other questions ---
+    ams_future = None
     if configured:
-        print("Checking printer AMS status...")
-        ams_trays = _query_ams_trays(configured)
-        if ams_trays:
-            print(f"  Found {len(ams_trays)} loaded AMS slot(s):")
-            for t in ams_trays:
-                c = t["color"]
-                r, g, b = int(c[0:2], 16), int(c[2:4], 16), int(c[4:6], 16)
-                swatch = f"\033[48;2;{r};{g};{b}m  \033[0m"
-                print(f"    Slot {t['phys_slot'] + 1}: {t['type']}  {swatch}")
-        else:
-            print("  Could not read AMS trays (printer may be offline).")
-        print()
+        from concurrent.futures import ThreadPoolExecutor
+
+        _ams_pool = ThreadPoolExecutor(max_workers=1)
+        ams_future = _ams_pool.submit(_query_ams_trays, configured)
 
     # --- Step 1: Discover profiles ---
     try:
@@ -459,6 +451,22 @@ def run_wizard(output: Path | None = None) -> str:
     else:
         process_profile = _prompt_str("Process profile name (e.g. '0.20mm Standard @BBL X1C')")
         print()
+
+    # --- Collect AMS results (should be done by now) ---
+    ams_trays: list[dict] = []
+    if ams_future is not None:
+        try:
+            ams_trays = ams_future.result(timeout=10)
+        except Exception:
+            pass
+        if ams_trays:
+            print(f"AMS loaded ({len(ams_trays)} slot(s)):")
+            for t in ams_trays:
+                c = t["color"]
+                r, g, b = int(c[0:2], 16), int(c[2:4], 16), int(c[4:6], 16)
+                swatch = f"\033[48;2;{r};{g};{b}m  \033[0m"
+                print(f"  Slot {t['phys_slot'] + 1}: {t['type']}  {swatch}")
+            print()
 
     # --- Step 5: Pick filament(s) ---
     filament_names: list[str] = []


### PR DESCRIPTION
## Summary
- AMS tray query now runs in a background thread while the user answers printer/process profile questions. Results are collected just before the filament step, so the network call doesn't block the wizard.
- Updated README prerequisites to note Docker is required for Bambu Cloud printing, not just recommended for reproducible slicing.

## Test plan
- [ ] Run `fabprint init` with a cloud printer configured — AMS results should appear before filament selection without a visible wait
- [ ] Run without a printer — no background query, no errors
- [ ] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)