### PR TITLE
Include step extra in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ WORKDIR /opt/fabprint
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ ./src/
 RUN uv python install 3.12 \
-    && uv sync --frozen --no-dev --no-editable --python 3.12 \
+    && uv sync --frozen --no-dev --no-editable --python 3.12 --extra step \
     && uv cache clean
 
 ENV PATH="/opt/fabprint/.venv/bin:$PATH"


### PR DESCRIPTION
## Summary
- Add `--extra step` to `uv sync` in Dockerfile so `build123d` is installed
- Fixes `ImportError: build123d is required to load STEP files` when using the GitHub Action

## Test plan
- [ ] Merge triggers Docker rebuild (Dockerfile changed)
- [ ] Verify STEP file loading works in pegturner action run

🤖 Generated with [Claude Code](https://claude.com/claude-code)