### PR TITLE
Fix action project name clashing with printer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.77 — 2026-03-18
+
+- Fix GitHub Action: project name extraction matched `[printer] name` in addition to top-level `name`
+- Fix GitHub Action: guard metrics parsing against multi-line grep output
+
 ## 0.1.74 — 2026-03-18
 
 - Add top-level `name` field to `fabprint.toml` to prefix all output filenames

--- a/action/action.yml
+++ b/action/action.yml
@@ -94,11 +94,11 @@ runs:
 
         # Parse metrics from fabprint log output
         # Output format: "  123.4g filament, estimated 1h 7m 32s"
-        PRINT_TIME=$(grep -oE 'estimated .+' /tmp/fabprint-output.log 2>/dev/null | sed 's/estimated //' || true)
-        FILAMENT=$(grep -oE '[0-9.]+g filament' /tmp/fabprint-output.log 2>/dev/null | sed 's/g filament//' || true)
+        PRINT_TIME=$(grep -oE 'estimated .+' /tmp/fabprint-output.log 2>/dev/null | head -1 | sed 's/estimated //' || true)
+        FILAMENT=$(grep -oE '[0-9.]+g filament' /tmp/fabprint-output.log 2>/dev/null | head -1 | sed 's/g filament//' || true)
 
-        # Extract project name from config (top-level name = "...")
-        PROJECT_NAME=$(grep -E '^name\s*=' "${WORKSPACE}/${CONFIG}" 2>/dev/null | sed 's/.*=\s*"\(.*\)"/\1/' || true)
+        # Extract project name: match top-level name only (before any [section] header)
+        PROJECT_NAME=$(sed -n '/^\[/q; s/^name\s*=\s*"\(.*\)"/\1/p' "${WORKSPACE}/${CONFIG}" 2>/dev/null || true)
 
         echo "print-time=${PRINT_TIME}" >> "$GITHUB_OUTPUT"
         echo "filament-grams=${FILAMENT}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix project name extraction: `grep '^name\s*='` matched both top-level `name` and `[printer] name`, corrupting `$GITHUB_OUTPUT` with multi-line output (`Error: Invalid format 'workshop'`)
- Use `sed` that stops at the first `[section]` header to only extract the top-level name
- Add `head -1` to metrics greps to guard against multi-line output

## Test plan
- [x] All tests pass (264/264)
- [ ] Re-run action on a config with both `name = "..."` and `[printer] name = "..."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)