### PR TITLE
Fix action: use --local to avoid Docker-in-Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.80 — 2026-03-18
+
+- Fix GitHub Action: use `--local` to avoid Docker-in-Docker failure when slicing
+
 ## 0.1.79 — 2026-03-18
 
 - Include `gcode_stats` in `slice` stage so metrics are always available after slicing

--- a/action/action.yml
+++ b/action/action.yml
@@ -66,6 +66,7 @@ runs:
           run "${CONFIG}" \
           --until "${UNTIL}" \
           --output-dir "/project/${OUTPUT_DIR}" \
+          --local \
           -v \
           2>&1 | tee /tmp/fabprint-output.log
 


### PR DESCRIPTION
## Summary
- Add `--local` flag to the `fabprint run` command in the action
- The action already runs inside the fabprint Docker image (which has OrcaSlicer installed), so trying to launch a second Docker container for slicing is unnecessary and fails without a Docker socket
- Eliminates the misleading "Docker not available, using local slicer" warning

## Test plan
- [ ] Action runs without "Pulling Docker image" or Docker fallback warning
- [ ] Slicing completes using the local OrcaSlicer in the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)