### PR TITLE
Warn on unpinned slicer version, fix gap slot resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.81 — 2026-03-18
+
+- Avoid resolving the same filament profile multiple times for gap slots
+- Warn when `slicer.version` is not set in config (builds may not be reproducible)
+- Fix GitHub Action: use `--local` to avoid Docker-in-Docker failure when slicing
+
 ## 0.1.80 — 2026-03-18
 
 - Fix GitHub Action: use `--local` to avoid Docker-in-Docker failure when slicing

--- a/src/fabprint/config.py
+++ b/src/fabprint/config.py
@@ -234,10 +234,9 @@ def load_config(path: Path) -> FabprintConfig:
                     used_slots.add(next_slot)
                     next_slot += 1
 
-            # Build the filaments list, filling gaps with the first profile
+            # Build the filaments list — use empty string for unused gap slots
             max_slot = max(slot_to_name.keys())
-            first_name = slot_to_name[min(slot_to_name.keys())]
-            slicer.filaments = [slot_to_name.get(s, first_name) for s in range(1, max_slot + 1)]
+            slicer.filaments = [slot_to_name.get(s, "") for s in range(1, max_slot + 1)]
 
         # Build name → index lookup (first occurrence for name-based refs)
         fil_index: dict[str, int] = {}

--- a/src/fabprint/slicer.py
+++ b/src/fabprint/slicer.py
@@ -18,7 +18,6 @@ from fabprint.profiles import resolve_profile_data
 log = logging.getLogger(__name__)
 
 DOCKERHUB_REPO = "fabprint/fabprint"
-DEFAULT_DOCKER_IMAGE = f"{DOCKERHUB_REPO}:latest"
 
 
 def _slicer_paths() -> dict[str, Path]:
@@ -45,7 +44,7 @@ def _docker_image(version: str | None = None) -> str:
     """Return the Docker image name for a given OrcaSlicer version."""
     if version:
         return f"{DOCKERHUB_REPO}:orca-{version}"
-    return DEFAULT_DOCKER_IMAGE
+    return f"{DOCKERHUB_REPO}:latest"
 
 
 def find_slicer(engine: str) -> Path:
@@ -271,10 +270,20 @@ def _resolve_profiles(
     filament_arg = None
     if filaments:
         resolved = []
+        # Resolve real profiles; reuse the first for gap (empty) slots
+        first_path: str | None = None
         for i, f in enumerate(filaments):
-            data = resolve_profile_data(f, engine, "filament", project_dir)
-            path = _write_tmp_profile(data, tmp_dir, f"filament_{i}")
-            resolved.append(str(path))
+            if f:
+                data = resolve_profile_data(f, engine, "filament", project_dir)
+                path = _write_tmp_profile(data, tmp_dir, f"filament_{i}")
+                resolved.append(str(path))
+                if first_path is None:
+                    first_path = str(path)
+            else:
+                resolved.append("")
+        # Fill gap slots with the first resolved profile (same file, no re-resolve)
+        if first_path:
+            resolved = [p if p else first_path for p in resolved]
         filament_arg = ";".join(resolved)
 
     settings_arg = ";".join(settings) if settings else None
@@ -665,6 +674,12 @@ def slice_plate(
     if required_version and not docker_version:
         docker_version = required_version
 
+    if not docker_version and not local:
+        print(
+            "  \033[33mWarning: No slicer.version set in config. "
+            'Pin a version (e.g. version = "2.3.1") for reproducible builds.\033[0m'
+        )
+
     image = _docker_image(docker_version)
 
     if local:
@@ -695,7 +710,7 @@ def slice_plate(
             except FileNotFoundError:
                 raise FileNotFoundError(
                     "No slicer available. Install OrcaSlicer locally or "
-                    "pull the Docker image: docker pull fabprint/fabprint:latest"
+                    "pull a Docker image: docker pull fabprint/fabprint:orca-2.3.1"
                 )
 
     # Detect and verify slicer version


### PR DESCRIPTION
## Summary
- Warn when `slicer.version` is not set — unpinned versions use `:latest` which drifts between machines
- Avoid resolving the same filament profile multiple times for unused gap slots in `[slicer.slots]` — reuse the first resolved profile path
- Root cause of action segfault identified: `orca-2.3.1` image (Feb 22) differs from `:latest` (Mar 16) — different OrcaSlicer builds. Fix: always pin `slicer.version` in config

## Test plan
- [x] 264 tests pass
- [x] Lint, format, type checks pass
- [ ] Verify warning appears when `slicer.version` is absent
- [ ] Verify pegturner inserts config works with version pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)