### PR TITLE
Reframe README around declarative, version-controlled builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ fabprint run        # arrange → slice → print, one command
 
 Everything is declared in a single TOML file — git-friendly, diffable, and committable alongside your CAD files. Lock the slicer version, pin the profiles, and the output is reproducible on any machine or in CI.
 
-### How is this different from OrcaSlicer CLI?
+### Why not just use OrcaSlicer CLI?
 
 This builds on OrcaSlicer CLI, but is designed to allow other slicers like Cura to plugin.
 


### PR DESCRIPTION
## Summary

- **Problem → Answer → Who → What → How** flow throughout the intro
- Leads with the IaC concept: *"declarative, version-controlled builds"* rather than positioning fabprint as a CLI wrapper
- Core promise stated explicitly: *"Same repo → same G-code → same print"*
- Target audience named: engineers, makers, and teams who treat their prints like software
- "like code" not "as code" — TOML is config, not code (h/t nitpick)

## Test plan

- [ ] Read the README intro — does it land the concept before the detail?
- [ ] No code changes, CI should pass trivially

🤖 Generated with [Claude Code](https://claude.com/claude-code)