### PR TITLE
Add unit tests for profile management features

### DIFF
--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,12 +1,18 @@
 """Tests for profile discovery, resolution, and pinning."""
 
 import json
+from unittest.mock import patch
 
 import pytest
 
 from fabprint.profiles import (
     SYSTEM_DIRS,
+    _resolve_profile_data_from_dir,
+    add_profile,
+    detect_category,
+    discover_profile_names,
     discover_profiles,
+    load_bundled_profiles,
     pin_profiles,
     resolve_profile,
     resolve_profile_data,
@@ -119,3 +125,299 @@ def test_resolve_profile_data_real_process():
     assert "inherits" not in data
     # Should have many keys from the full chain
     assert len(data) > 50
+
+
+# ---------------------------------------------------------------------------
+# Bundled profiles
+# ---------------------------------------------------------------------------
+
+
+def test_load_bundled_profiles_exact_version(tmp_path):
+    """Load bundled profiles when exact version file exists."""
+    data = {"machine": ["PrinterA"], "process": ["Fast"], "filament": ["PLA"]}
+    bundled = tmp_path / "profiles.orca.2.3.1.json"
+    bundled.write_text(json.dumps(data))
+
+    with patch("fabprint.profiles._BUNDLED_DIR", tmp_path):
+        result = load_bundled_profiles("orca", "2.3.1")
+    assert result["machine"] == ["PrinterA"]
+    assert result["process"] == ["Fast"]
+    assert result["filament"] == ["PLA"]
+
+
+def test_load_bundled_profiles_fallback_to_highest(tmp_path):
+    """When version doesn't match, fall back to highest available."""
+    old = {"machine": ["Old"]}
+    new = {"machine": ["New"], "process": ["P"]}
+    (tmp_path / "profiles.orca.2.2.0.json").write_text(json.dumps(old))
+    (tmp_path / "profiles.orca.2.3.1.json").write_text(json.dumps(new))
+
+    with patch("fabprint.profiles._BUNDLED_DIR", tmp_path):
+        result = load_bundled_profiles("orca", "9.9.9")
+    assert result["machine"] == ["New"]
+
+
+def test_load_bundled_profiles_no_version(tmp_path):
+    """When no version given, fall back to highest available."""
+    data = {"machine": ["M1"]}
+    (tmp_path / "profiles.orca.1.0.0.json").write_text(json.dumps(data))
+
+    with patch("fabprint.profiles._BUNDLED_DIR", tmp_path):
+        result = load_bundled_profiles("orca")
+    assert result["machine"] == ["M1"]
+
+
+def test_load_bundled_profiles_missing(tmp_path):
+    """Return empty dict when no bundled profiles exist."""
+    with patch("fabprint.profiles._BUNDLED_DIR", tmp_path):
+        result = load_bundled_profiles("orca", "2.3.1")
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# discover_profile_names
+# ---------------------------------------------------------------------------
+
+
+def test_discover_profile_names_system_first():
+    """System profiles take priority when available."""
+    fake_system = {"machine": {"Printer": {}}, "process": {}, "filament": {}}
+    with patch("fabprint.profiles.discover_profiles", return_value=fake_system):
+        names, source = discover_profile_names("orca")
+    assert source == "system"
+    assert "Printer" in names["machine"]
+
+
+def test_discover_profile_names_pinned_fallback(tmp_path):
+    """Falls back to pinned profiles when system is empty."""
+    pinned_dir = tmp_path / "profiles" / "machine"
+    pinned_dir.mkdir(parents=True)
+    (pinned_dir / "MyPrinter.json").write_text("{}")
+
+    with patch("fabprint.profiles.discover_profiles", return_value={}):
+        names, source = discover_profile_names("orca", project_dir=tmp_path)
+    assert source == "pinned"
+    assert "MyPrinter" in names["machine"]
+
+
+def test_discover_profile_names_bundled_fallback(tmp_path):
+    """Falls back to bundled profiles when no system or pinned."""
+    bundled = {"machine": ["Bundled"], "process": [], "filament": []}
+    with (
+        patch("fabprint.profiles.discover_profiles", return_value={}),
+        patch("fabprint.profiles.load_bundled_profiles", return_value=bundled),
+    ):
+        names, source = discover_profile_names("orca", version="2.3.1")
+    assert source == "bundled"
+    assert names["machine"] == ["Bundled"]
+
+
+def test_discover_profile_names_none(tmp_path):
+    """Returns 'none' when no profiles found anywhere."""
+    with (
+        patch("fabprint.profiles.discover_profiles", return_value={}),
+        patch("fabprint.profiles.load_bundled_profiles", return_value={}),
+    ):
+        names, source = discover_profile_names("orca", version="2.3.1")
+    assert source == "none"
+    assert all(v == [] for v in names.values())
+
+
+# ---------------------------------------------------------------------------
+# _resolve_profile_data_from_dir
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_profile_data_from_dir_simple(tmp_path):
+    """Resolve a single profile with no inheritance."""
+    cat_dir = tmp_path / "process"
+    cat_dir.mkdir()
+    (cat_dir / "Fast.json").write_text(json.dumps({"layer_height": 0.3}))
+
+    data = _resolve_profile_data_from_dir("Fast", "process", tmp_path)
+    assert data["layer_height"] == 0.3
+
+
+def test_resolve_profile_data_from_dir_inheritance(tmp_path):
+    """Resolve a profile chain: child inherits from parent."""
+    cat_dir = tmp_path / "process"
+    cat_dir.mkdir()
+    (cat_dir / "Base.json").write_text(json.dumps({"layer_height": 0.2, "wall_loops": 2}))
+    (cat_dir / "Child.json").write_text(json.dumps({"inherits": "Base", "wall_loops": 4}))
+
+    data = _resolve_profile_data_from_dir("Child", "process", tmp_path)
+    assert data["layer_height"] == 0.2  # inherited
+    assert data["wall_loops"] == 4  # overridden
+    assert "inherits" not in data
+
+
+def test_resolve_profile_data_from_dir_cycle(tmp_path):
+    """Circular inheritance doesn't loop forever."""
+    cat_dir = tmp_path / "process"
+    cat_dir.mkdir()
+    (cat_dir / "A.json").write_text(json.dumps({"inherits": "B", "a": 1}))
+    (cat_dir / "B.json").write_text(json.dumps({"inherits": "A", "b": 2}))
+
+    data = _resolve_profile_data_from_dir("A", "process", tmp_path)
+    assert data["a"] == 1
+    assert data["b"] == 2
+
+
+def test_resolve_profile_data_from_dir_not_found(tmp_path):
+    """Missing profile raises FileNotFoundError."""
+    (tmp_path / "process").mkdir()
+    with pytest.raises(FileNotFoundError, match="not found"):
+        _resolve_profile_data_from_dir("Nope", "process", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# detect_category
+# ---------------------------------------------------------------------------
+
+
+def test_detect_category_machine():
+    data = {"printer_model": "P1S", "machine_start_gcode": "G28"}
+    assert detect_category(data) == "machine"
+
+
+def test_detect_category_process():
+    data = {"layer_height": 0.2, "wall_loops": 3, "sparse_infill_density": "15%"}
+    assert detect_category(data) == "process"
+
+
+def test_detect_category_filament():
+    data = {"filament_type": "PLA", "filament_density": 1.24}
+    assert detect_category(data) == "filament"
+
+
+def test_detect_category_unknown():
+    data = {"random_key": 42}
+    assert detect_category(data) is None
+
+
+# ---------------------------------------------------------------------------
+# add_profile
+# ---------------------------------------------------------------------------
+
+
+def test_add_profile_from_file(tmp_path):
+    """Import a local JSON file into profiles/."""
+    src = tmp_path / "my_process.json"
+    src.write_text(json.dumps({"layer_height": 0.15, "wall_loops": 3}))
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    dest = add_profile(str(src), project, category="process")
+    assert dest.exists()
+    assert dest.parent.name == "process"
+    assert json.loads(dest.read_text())["layer_height"] == 0.15
+
+
+def test_add_profile_auto_detect_category(tmp_path):
+    """Category is auto-detected from JSON keys."""
+    src = tmp_path / "pla.json"
+    src.write_text(json.dumps({"filament_type": "PLA", "filament_density": 1.24}))
+
+    dest = add_profile(str(src), tmp_path)
+    assert dest.parent.name == "filament"
+
+
+def test_add_profile_custom_name(tmp_path):
+    """Custom name overrides filename."""
+    src = tmp_path / "generic.json"
+    src.write_text(json.dumps({"filament_type": "PETG"}))
+
+    dest = add_profile(str(src), tmp_path, category="filament", name="MyPETG")
+    assert dest.name == "MyPETG.json"
+
+
+def test_add_profile_invalid_json(tmp_path):
+    """Invalid JSON raises FabprintError."""
+    src = tmp_path / "bad.json"
+    src.write_text("not json")
+
+    from fabprint import FabprintError
+
+    with pytest.raises(FabprintError, match="Invalid JSON"):
+        add_profile(str(src), tmp_path, category="process")
+
+
+def test_add_profile_not_found(tmp_path):
+    from fabprint import FabprintError
+
+    with pytest.raises(FabprintError, match="not found"):
+        add_profile("/nonexistent/file.json", tmp_path, category="process")
+
+
+def test_add_profile_invalid_category(tmp_path):
+    src = tmp_path / "p.json"
+    src.write_text(json.dumps({"x": 1}))
+
+    from fabprint import FabprintError
+
+    with pytest.raises(FabprintError, match="Invalid category"):
+        add_profile(str(src), tmp_path, category="bogus")
+
+
+def test_add_profile_warns_on_unresolved_inherits(tmp_path, caplog):
+    """Warns when imported profile inherits from a missing parent."""
+    src = tmp_path / "child.json"
+    src.write_text(json.dumps({"inherits": "MissingParent", "layer_height": 0.2}))
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        add_profile(str(src), tmp_path, category="process")
+    assert "MissingParent" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# pin_profiles Docker fallback (mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_pin_profiles_docker_fallback(tmp_path):
+    """Docker fallback is invoked when local resolution fails."""
+    # Set up a fake Docker-extracted directory
+    docker_dir = tmp_path / "docker_profiles"
+    machine_dir = docker_dir / "machine"
+    machine_dir.mkdir(parents=True)
+    (machine_dir / "DockerPrinter.json").write_text(
+        json.dumps({"printer_model": "test", "nozzle_diameter": [0.4]})
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with patch("fabprint.profiles.extract_docker_profiles", return_value=docker_dir):
+        pinned = pin_profiles(
+            engine="orca",
+            printer="DockerPrinter",
+            process=None,
+            filaments=[],
+            project_dir=project,
+            docker_version="2.3.1",
+        )
+
+    assert len(pinned) == 1
+    assert pinned[0].name == "DockerPrinter.json"
+    data = json.loads(pinned[0].read_text())
+    assert data["printer_model"] == "test"
+
+
+def test_pin_profiles_no_docker_version_raises(tmp_path):
+    """Without docker_version, missing profiles raise FabprintError."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    from fabprint import FabprintError
+
+    with pytest.raises(FabprintError, match="not found locally"):
+        pin_profiles(
+            engine="orca",
+            printer="NonexistentPrinter",
+            process=None,
+            filaments=[],
+            project_dir=project,
+        )


### PR DESCRIPTION
## Summary
- 25 new tests covering all new profile management code paths from PR #134
- Tests use mocks/tmp_path so they run everywhere (no Docker or OrcaSlicer needed)
- Covers: bundled profile loading, discover_profile_names fallback chain, profile inheritance resolution, category auto-detection, `profiles add` import, and Docker fallback for `profiles pin`

## Test plan
- [x] All 281 tests pass locally (25 new, 0 failures)
- [x] Ruff lint + format clean
- [x] mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)