### PR TITLE
Drop Python upper bound, support 3.13+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to fabprint are documented here.
 - Add interactive search-and-pick for profile selection with highlighted matches
 - Add password masking for cloud login input
 - Replace manual ANSI escape codes with Rich color swatches
-- Drop Python upper bound: now supports Python 3.11+ (including 3.13)
+- Drop Python upper bound: now supports Python 3.11+ (including 3.13 and 3.14)
 
 ## 0.1.90 — 2026-03-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [


### PR DESCRIPTION
## Summary
- Remove `<3.13` constraint from `requires-python` — vtk 9.6.0 now has 3.13 and 3.14 wheels
- Add Python 3.13 to CI test matrix
- Add 3.13 trove classifier

## Test plan
- [x] All 289 tests pass on 3.12
- [x] CI will verify 3.13 on all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)