### PR TITLE
Add default printer name and project name to init wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.97 — 2026-03-19
+
+- Default printer name "workshop" in `fabprint setup` (press Enter to accept)
+- Init wizard prompts for project name, defaulting to current directory name
+- Generated `fabprint.toml` now includes top-level `name` field
+
 ## 0.1.96 — 2026-03-19
 
 - Standardize type annotations: `Optional[X]` → `X | None` across cli.py and pipeline.py

--- a/src/fabprint/credentials.py
+++ b/src/fabprint/credentials.py
@@ -228,7 +228,7 @@ def setup_printer() -> None:
         ui.choice_table(items, ["Name", "Type"])
         ui.console.print()
 
-    name = ui.prompt_str("Printer name (e.g. 'workshop')")
+    name = ui.prompt_str("Printer name", default="workshop")
     if not name:
         ui.warn("Aborted — printer name is required.")
         return

--- a/src/fabprint/init.py
+++ b/src/fabprint/init.py
@@ -887,8 +887,13 @@ def run_wizard(output: Path | None = None) -> str:
     # --- Step 10: Printer connection ---
     printer_name = _wizard_pick_printer(stages)
 
+    # --- Project name ---
+    default_name = Path.cwd().name
+    project_name = ui.prompt_str("Project name", default=default_name) or default_name
+
     # --- Build TOML ---
     toml = _build_toml(
+        project_name=project_name,
         engine=engine,
         printer_profile=printer_profile,
         process_profile=process_profile,
@@ -922,6 +927,7 @@ def run_wizard(output: Path | None = None) -> str:
 
 def _build_toml(
     *,
+    project_name: str | None = None,
     engine: str,
     printer_profile: str | None,
     process_profile: str | None,
@@ -935,6 +941,11 @@ def _build_toml(
 ) -> str:
     """Build a TOML string from wizard answers."""
     lines: list[str] = []
+
+    # Project name
+    if project_name:
+        lines.append(f'name = "{project_name}"')
+        lines.append("")
 
     # Pipeline
     stage_list = ", ".join(f'"{s}"' for s in stages)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -124,15 +124,18 @@ class TestSetupPrinter:
         assert data["printers"]["new-printer"]["type"] == "bambu-lan"
         assert data["printers"]["new-printer"]["serial"] == "ABC123"
 
-    def test_aborts_on_empty_name(self, tmp_path, monkeypatch):
+    def test_default_name_used_on_empty_input(self, tmp_path, monkeypatch):
         cred_path = tmp_path / "credentials.toml"
         monkeypatch.setattr("fabprint.credentials._credentials_path", lambda: cred_path)
 
-        _mock_ui_inputs(monkeypatch, [""])
+        # Empty name input → default "workshop" is used
+        _mock_ui_inputs(monkeypatch, ["", "1", "10.0.0.1", "12345678", "SN001"])
 
         setup_printer()
 
-        assert not cred_path.exists()
+        with open(cred_path, "rb") as f:
+            data = tomllib.load(f)
+        assert "workshop" in data["printers"]
 
     def test_creates_parent_dirs(self, tmp_path, monkeypatch):
         cred_path = tmp_path / "deep" / "nested" / "credentials.toml"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -543,6 +543,7 @@ class TestWizard:
                 "256",  # plate depth
                 "",  # slicer version (skip)
                 "n",  # Configure printer connection? -> no
+                "my-project",  # Project name
                 "y",  # Write to fabprint.toml?
             ],
         )
@@ -561,6 +562,7 @@ class TestWizard:
         result = run_wizard()
         assert "[slicer]" in result
         assert "test-part.stl" in result
+        assert 'name = "my-project"' in result
         assert (tmp_path / "fabprint.toml").exists()
 
     def test_wizard_no_write(self, tmp_path, monkeypatch):
@@ -582,6 +584,7 @@ class TestWizard:
                 "256",  # plate depth
                 "",  # slicer version (skip)
                 "n",  # Configure printer connection? -> no
+                "",  # Project name (use default)
                 "n",  # Write?
             ],
         )


### PR DESCRIPTION
## Summary
- `fabprint setup`: default printer name "workshop" — just press Enter to accept
- `fabprint init`: prompts for project name, defaults to current directory name
- Generated `fabprint.toml` now includes top-level `name = "..."` field

## Test plan
- [x] All 478 tests pass
- [x] Updated wizard tests to include project name prompt
- [x] Updated credentials test for default printer name behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)