### PR TITLE
Fix picker display: pad to constant height for Rich Live

### DIFF
--- a/src/fabprint/ui.py
+++ b/src/fabprint/ui.py
@@ -136,8 +136,10 @@ def _build_picker_display(
 ) -> Text:
     """Build the Rich renderable for the live picker.
 
-    Returns a single Text object so Rich Live can accurately calculate
-    the number of lines to overwrite on each refresh.
+    Always produces exactly ``_MAX_VISIBLE + 2`` lines so that Rich Live's
+    cursor-up count is constant across refreshes.  Variable height causes
+    Rich to miscalculate how many lines to overwrite, resulting in duplicate
+    or side-by-side rendering.
     """
     lines: list[str] = []
 
@@ -147,13 +149,20 @@ def _build_picker_display(
         label = _highlight_match(name, query) if query else escape(name)
         lines.append(f"  [dim]{i:>4}[/dim]  {label}")
 
+    # Pad to fixed height so Rich Live cursor math is always correct
+    while len(lines) < _MAX_VISIBLE:
+        lines.append("")
+
+    # Status line (always exactly 1 line)
     if len(filtered) > _MAX_VISIBLE:
         remaining = len(filtered) - _MAX_VISIBLE
         lines.append(f"  [dim]... and {remaining} more (keep typing to narrow)[/dim]")
     elif not filtered:
         lines.append("  [dim]No matches — keep typing or backspace[/dim]")
+    else:
+        lines.append("")
 
-    # Status / input line
+    # Prompt line (always exactly 1 line)
     multi_hint = " [dim](comma-sep, 'all')[/dim]" if allow_multi else ""
     lines.append(f"  [bold]{prompt}>[/bold] {escape(query)}[blink]▌[/blink]{multi_hint}")
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -299,6 +299,23 @@ class TestBuildPickerDisplay:
         out = buf.getvalue()
         assert "Alpha" in out  # match is still visible
 
+    def test_constant_height(self):
+        """Output must always have the same number of lines regardless of item count."""
+        from fabprint.ui import _MAX_VISIBLE
+
+        expected = _MAX_VISIBLE + 2  # items + status + prompt
+
+        few = _build_picker_display(["A", "B"], "", "Pick", False, 2)
+        many = _build_picker_display([f"item{i}" for i in range(30)], "", "Pick", False, 30)
+        none = _build_picker_display([], "xyz", "Pick", False, 5)
+
+        for renderable in (few, many, none):
+            buf = StringIO()
+            c = Console(file=buf, highlight=False, width=120)
+            c.print(renderable, end="")
+            line_count = buf.getvalue().count("\n") + 1
+            assert line_count == expected, f"Expected {expected} lines, got {line_count}"
+
 
 # ---------------------------------------------------------------------------
 # _try_select


### PR DESCRIPTION
## Summary
Root cause found: Rich Live uses cursor-up ANSI sequences to overwrite previous output. When the renderable's height changes between refreshes (e.g. filtering shrinks the list), Rich miscalculates how many lines to overwrite, causing duplicate/overlapping lines.

Fix: always output exactly `_MAX_VISIBLE + 2` lines (15 item slots + 1 status + 1 prompt), padding short results with blank lines. This keeps the cursor-up count constant.

This is a known Rich issue ([#1144](https://github.com/Textualize/rich/issues/1144), [#1762](https://github.com/Textualize/rich/issues/1762), [#3796](https://github.com/Textualize/rich/issues/3796)). The standard workaround is fixed-height renderables.

## Test plan
- [x] All 479 tests pass (new `test_constant_height` added)
- [x] Constant height verified for: few items, many items, zero matches
- [ ] Visual verification on terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)