### PR TITLE
Improve picker hints and validate slicer overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.103 — 2026-03-19
+
+- Show "(type to filter)" search hint in interactive picker
+- Validate slicer overrides: auto-append `%` for density, enforce integer/float types
+- Fix multi-select file picker prompt (removed stale "comma-separated" hint)
+
 ## 0.1.102 — 2026-03-19
 
 - Replace broken Rich Live picker with `simple-term-menu` for reliable interactive selection

--- a/src/fabprint/init.py
+++ b/src/fabprint/init.py
@@ -490,10 +490,16 @@ def _prompt_yn(prompt: str, default: bool = True) -> bool:
 
 # Each entry: (display_name, slicer_key, value_spec)
 # value_spec is either ("text", "hint string") or ("choice", [...options])
+# value_spec types:
+#   ("choice", [...options])  — user picks from a list
+#   ("percent", "hint")      — numeric, auto-appends % if missing
+#   ("int", "hint")          — positive integer
+#   ("float", "hint")        — positive float
+#   ("text", "hint")         — free-form text (no validation)
 OverrideSpec = tuple[str, str, tuple[str, str] | tuple[str, list[str]]]
 
 COMMON_OVERRIDES: list[OverrideSpec] = [
-    ("Infill density", "sparse_infill_density", ("text", "e.g. 15%, 25%, 50%")),
+    ("Infill density", "sparse_infill_density", ("percent", "e.g. 15, 25, 50")),
     (
         "Infill pattern",
         "sparse_infill_pattern",
@@ -511,8 +517,8 @@ COMMON_OVERRIDES: list[OverrideSpec] = [
             ],
         ),
     ),
-    ("Wall loops", "wall_loops", ("text", "e.g. 2, 3, 4")),
-    ("Layer height", "layer_height", ("text", "e.g. 0.12, 0.16, 0.20, 0.28")),
+    ("Wall loops", "wall_loops", ("int", "e.g. 2, 3, 4")),
+    ("Layer height", "layer_height", ("float", "e.g. 0.12, 0.16, 0.20, 0.28")),
     (
         "Enable support",
         "enable_support",
@@ -523,8 +529,8 @@ COMMON_OVERRIDES: list[OverrideSpec] = [
         "support_type",
         ("choice", ["normal", "tree", "hybrid"]),
     ),
-    ("Top shell layers", "top_shell_layers", ("text", "e.g. 3, 5")),
-    ("Bottom shell layers", "bottom_shell_layers", ("text", "e.g. 3, 5")),
+    ("Top shell layers", "top_shell_layers", ("int", "e.g. 3, 5")),
+    ("Bottom shell layers", "bottom_shell_layers", ("int", "e.g. 3, 5")),
     (
         "Brim type",
         "brim_type",
@@ -536,6 +542,56 @@ COMMON_OVERRIDES: list[OverrideSpec] = [
         ("choice", ["nearest", "aligned", "back", "random"]),
     ),
 ]
+
+
+def _validate_override(value: str, spec_type: str) -> str | None:
+    """Validate and normalise an override value.
+
+    Returns the normalised value, or ``None`` if invalid.
+    """
+    from fabprint import ui
+
+    value = value.strip()
+    if not value:
+        return None
+
+    if spec_type == "percent":
+        raw = value.rstrip("%").strip()
+        try:
+            num = float(raw)
+        except ValueError:
+            ui.warn(f"Expected a number, got '{value}'")
+            return None
+        if num < 0 or num > 100:
+            ui.warn("Percentage must be between 0 and 100")
+            return None
+        # Auto-append %
+        return f"{raw}%"
+
+    if spec_type == "int":
+        try:
+            num = int(value)
+        except ValueError:
+            ui.warn(f"Expected an integer, got '{value}'")
+            return None
+        if num < 0:
+            ui.warn("Value must be a positive integer")
+            return None
+        return str(num)
+
+    if spec_type == "float":
+        try:
+            num = float(value)
+        except ValueError:
+            ui.warn(f"Expected a number, got '{value}'")
+            return None
+        if num <= 0:
+            ui.warn("Value must be a positive number")
+            return None
+        return value
+
+    # "text" or unknown — accept as-is
+    return value
 
 
 def _prompt_overrides() -> dict[str, str]:
@@ -587,10 +643,14 @@ def _prompt_overrides() -> dict[str, str]:
                     continue
             else:
                 hint = spec[1]
-                value = _prompt_str(f"Value for {key} ({hint})")
-                if value:
-                    overrides[key] = value
-                    ui.success(f'{key} = "{value}"')
+                spec_type = spec[0]
+                raw = _prompt_str(f"Value for {key} ({hint})")
+                validated = _validate_override(raw, spec_type) if raw else None
+                if validated:
+                    overrides[key] = validated
+                    ui.success(f'{key} = "{validated}"')
+                elif raw:
+                    continue  # validation failed, loop back
 
         ui.console.print()
         if not _prompt_yn("Add another override?", default=False):
@@ -741,7 +801,7 @@ def _wizard_pick_parts(filament_names: list[str]) -> list[dict]:
         ui.info(f"Found {len(candidates)} CAD file(s) in current directory")
         names = [p.name for p in candidates]
         chosen = _prompt_choice(
-            "Select files (comma-separated or 'all')",
+            "Select files",
             names,
             allow_multi=True,
         )

--- a/src/fabprint/ui.py
+++ b/src/fabprint/ui.py
@@ -131,6 +131,8 @@ def pick(
         search_key=None,  # type-to-filter without pressing /
         multi_select=allow_multi,
         show_multi_select_hint=allow_multi,
+        show_search_hint=True,
+        show_search_hint_text="(type to filter)",
     )
     result = menu.show()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,7 @@ from fabprint.init import (
     ValidationResult,
     _build_toml,
     _closest_match,
+    _validate_override,
     dump_template,
     validate_config,
 )
@@ -295,6 +296,62 @@ class TestClosestMatch:
     def test_no_match(self):
         result = _closest_match("xyz_nothing", ["abc", "def"])
         assert result is None or isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Override validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOverride:
+    def test_percent_bare_number(self):
+        assert _validate_override("25", "percent") == "25%"
+
+    def test_percent_with_sign(self):
+        assert _validate_override("25%", "percent") == "25%"
+
+    def test_percent_with_spaces(self):
+        assert _validate_override(" 30 ", "percent") == "30%"
+
+    def test_percent_rejects_text(self):
+        assert _validate_override("abc", "percent") is None
+
+    def test_percent_rejects_negative(self):
+        assert _validate_override("-5", "percent") is None
+
+    def test_percent_rejects_over_100(self):
+        assert _validate_override("150", "percent") is None
+
+    def test_percent_zero(self):
+        assert _validate_override("0", "percent") == "0%"
+
+    def test_int_valid(self):
+        assert _validate_override("3", "int") == "3"
+
+    def test_int_rejects_float(self):
+        assert _validate_override("3.5", "int") is None
+
+    def test_int_rejects_text(self):
+        assert _validate_override("abc", "int") is None
+
+    def test_int_rejects_negative(self):
+        assert _validate_override("-1", "int") is None
+
+    def test_float_valid(self):
+        assert _validate_override("0.20", "float") == "0.20"
+
+    def test_float_rejects_zero(self):
+        assert _validate_override("0", "float") is None
+
+    def test_float_rejects_text(self):
+        assert _validate_override("abc", "float") is None
+
+    def test_text_passthrough(self):
+        assert _validate_override("anything", "text") == "anything"
+
+    def test_empty_returns_none(self):
+        assert _validate_override("", "percent") is None
+        assert _validate_override("  ", "int") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -243,4 +243,6 @@ class TestPick:
                 search_key=None,
                 multi_select=True,
                 show_multi_select_hint=True,
+                show_search_hint=True,
+                show_search_hint_text="(type to filter)",
             )


### PR DESCRIPTION
## Summary
- Show "(type to filter)" search hint in the interactive picker so users know they can search
- Remove stale "comma-separated or 'all'" from file multi-select prompt (simple-term-menu uses Space/Tab instead)
- Validate slicer override inputs:
  - **Infill density**: auto-appends `%` if missing (entering `25` → `25%`), rejects non-numeric and out-of-range
  - **Wall loops, shell layers**: enforces positive integer
  - **Layer height**: enforces positive float
- 16 new tests for `_validate_override`

## Test plan
- [ ] Run `fabprint init`, verify "(type to filter)" appears in picker
- [ ] Test multi-select file picker uses Space/Tab to toggle
- [ ] Enter `25` for infill density, verify it becomes `25%` in TOML
- [ ] Enter `abc` for wall loops, verify warning and re-prompt
- [ ] All 469 tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)