### PR TITLE
Fix multi-select picker: Space toggles instead of searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.104 — 2026-03-19
+
+- Fix multi-select picker: Space now toggles selection instead of triggering search
+- Use `/` for search in multi-select mode, type-to-filter in single-select mode
+- Show contextual hints: "(type to filter)" vs "(/ to filter, Space to toggle)"
+
 ## 0.1.103 — 2026-03-19
 
 - Show "(type to filter)" search hint in interactive picker

--- a/src/fabprint/ui.py
+++ b/src/fabprint/ui.py
@@ -125,14 +125,19 @@ def pick(
     """
     from simple_term_menu import TerminalMenu
 
+    # For single-select: search_key=None enables type-to-filter (any key searches).
+    # For multi-select: keep search_key="/" so Space/Tab work for toggling items.
+    search_key: str | None = "/" if allow_multi else None
+    search_hint = "(/ to filter, Space to toggle)" if allow_multi else "(type to filter)"
+
     menu = TerminalMenu(
         options,
         title=f"  {prompt}",
-        search_key=None,  # type-to-filter without pressing /
+        search_key=search_key,
         multi_select=allow_multi,
         show_multi_select_hint=allow_multi,
         show_search_hint=True,
-        show_search_hint_text="(type to filter)",
+        show_search_hint_text=search_hint,
     )
     result = menu.show()
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -240,9 +240,9 @@ class TestPick:
             MockMenu.assert_called_once_with(
                 ["x", "y"],
                 title="  Select",
-                search_key=None,
+                search_key="/",
                 multi_select=True,
                 show_multi_select_hint=True,
                 show_search_hint=True,
-                show_search_hint_text="(type to filter)",
+                show_search_hint_text="(/ to filter, Space to toggle)",
             )


### PR DESCRIPTION
## Summary
- With `search_key=None`, pressing Space in multi-select mode triggered search instead of toggling item selection
- Now uses `search_key="/"` for multi-select (Space/Tab toggle items, `/` to search) and `search_key=None` for single-select (type-to-filter)
- Contextual hints: "(type to filter)" for single, "(/ to filter, Space to toggle)" for multi

## Test plan
- [ ] Run `fabprint init`, at file selection press Space to toggle files — should mark items, not search
- [ ] Verify single-select pickers still type-to-filter without pressing `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)