### PR TITLE
Move slicer overrides after CAD file selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.105 — 2026-03-19
+
+- Move slicer overrides prompt after CAD file selection in init wizard
+
 ## 0.1.104 — 2026-03-19
 
 - Fix multi-select picker: Space now toggles selection instead of triggering search

--- a/src/fabprint/init.py
+++ b/src/fabprint/init.py
@@ -685,10 +685,10 @@ def _wizard_setup_printers(configured: dict[str, dict]) -> dict[str, dict]:
 def _wizard_pick_profiles(
     engine: str,
     profiles: dict[str, list[str]],
-) -> tuple[str | None, str | None, dict[str, str], _MachineInfo]:
-    """Steps 1/3/4/4b: Pick printer profile, process profile, and overrides.
+) -> tuple[str | None, str | None, _MachineInfo]:
+    """Steps 3/4: Pick printer profile and process profile.
 
-    Returns ``(printer_profile, process_profile, overrides, machine_info)``.
+    Returns ``(printer_profile, process_profile, machine_info)``.
     """
     from fabprint import ui
 
@@ -718,12 +718,7 @@ def _wizard_pick_profiles(
         process_profile = _prompt_str("Process profile name (e.g. '0.20mm Standard @BBL X1C')")
         ui.console.print()
 
-    # --- Step 4b: Slicer overrides ---
-    ui.heading("Slicer Overrides")
-    overrides = _prompt_overrides()
-    ui.console.print()
-
-    return printer_profile, process_profile, overrides, machine_info
+    return printer_profile, process_profile, machine_info
 
 
 def _wizard_pick_filaments(
@@ -917,10 +912,8 @@ def run_wizard(output: Path | None = None) -> str:
         ui.warn("No profiles found — profile names will need to be entered manually")
         ui.console.print()
 
-    # --- Steps 3, 4, 4b: Pick profiles and overrides ---
-    printer_profile, process_profile, overrides, machine_info = _wizard_pick_profiles(
-        engine, profiles
-    )
+    # --- Steps 3, 4: Pick profiles ---
+    printer_profile, process_profile, machine_info = _wizard_pick_profiles(engine, profiles)
 
     # --- Collect AMS results (should be done by now) ---
     ams_trays: list[dict] = []
@@ -937,6 +930,11 @@ def run_wizard(output: Path | None = None) -> str:
 
     # --- Step 6: Discover CAD files ---
     parts_config = _wizard_pick_parts(filament_names)
+
+    # --- Slicer overrides (after parts so context is clear) ---
+    ui.heading("Slicer Overrides")
+    overrides = _prompt_overrides()
+    ui.console.print()
 
     # --- Steps 7-8: Plate size and slicer version ---
     plate_x, plate_y, slicer_version = _wizard_pick_plate_and_version(machine_info)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -536,11 +536,11 @@ class TestWizard:
                 "n",  # Run setup first? -> no
                 "Bambu Lab P1S 0.4 nozzle",  # Printer profile name
                 "0.20mm Standard @BBL X1C",  # Process profile name
-                "n",  # Add slicer overrides? -> no
                 "Generic PLA @base",  # Filament name
                 "1",  # Select files
                 "1",  # copies
                 "flat",  # orient
+                "n",  # Add slicer overrides? -> no
                 "256",  # plate width
                 "256",  # plate depth
                 "",  # slicer version (skip)
@@ -579,9 +579,9 @@ class TestWizard:
                 "n",  # Run setup first? -> no
                 "My Printer",  # Printer profile name
                 "My Process",  # Process profile name
-                "n",  # Add slicer overrides? -> no
                 "My PLA",  # Filament name
                 "my-part.stl",  # Part file path
+                "n",  # Add slicer overrides? -> no
                 "256",  # plate width
                 "256",  # plate depth
                 "",  # slicer version (skip)


### PR DESCRIPTION
## Summary
- Reorder init wizard: profiles → filaments → **parts** → **overrides** → plate/version
- Previously overrides were asked before files and filaments, which felt premature
- User now has full context of what they're printing when choosing infill, supports, etc.

## Test plan
- [ ] Run `fabprint init` — verify files are selected before overrides are prompted
- [ ] All 469 tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)