### PR TITLE
Init wizard: Write / Go back / Quit instead of y/n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.106 — 2026-03-19
+
+- Init wizard preview now offers Write / Go back / Quit instead of simple y/n
+- "Go back" restarts the wizard so you can change answers
+
 ## 0.1.105 — 2026-03-19
 
 - Move slicer overrides prompt after CAD file selection in init wizard

--- a/src/fabprint/init.py
+++ b/src/fabprint/init.py
@@ -965,22 +965,29 @@ def run_wizard(output: Path | None = None) -> str:
     )
 
     # --- Preview and confirm ---
-    ui.heading("Preview")
-    ui.preview_toml(toml)
-
     dest = output or Path("fabprint.toml")
-    if dest.exists():
-        if not _prompt_yn(f"{dest} already exists. Overwrite?", default=False):
-            ui.warn("Aborted.")
+
+    while True:
+        ui.heading("Preview")
+        ui.preview_toml(toml)
+
+        answer = _prompt_str("Write / Go back / Quit? (W/g/q)", "w").strip().lower()
+
+        if answer in ("w", "write", "y", "yes", ""):
+            if dest.exists():
+                if not _prompt_yn(f"{dest} already exists. Overwrite?", default=False):
+                    continue
+            dest.write_text(toml)
+            ui.success(f"Wrote {dest}")
             return toml
 
-    if _prompt_yn(f"Write to {dest}?"):
-        dest.write_text(toml)
-        ui.success(f"Wrote {dest}")
-    else:
-        ui.info("Not written. Copy the output above to create your config.")
+        if answer in ("q", "quit"):
+            ui.info("Not written. Copy the output above to create your config.")
+            return toml
 
-    return toml
+        # Go back — re-run wizard from the top
+        ui.console.print()
+        return run_wizard(output=output)
 
 
 def _build_toml(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -546,7 +546,7 @@ class TestWizard:
                 "",  # slicer version (skip)
                 "n",  # Configure printer connection? -> no
                 "my-project",  # Project name
-                "y",  # Write to fabprint.toml?
+                "w",  # Write / Go back / Quit
             ],
         )
 
@@ -587,7 +587,7 @@ class TestWizard:
                 "",  # slicer version (skip)
                 "n",  # Configure printer connection? -> no
                 "",  # Project name (use default)
-                "n",  # Write?
+                "q",  # Write / Go back / Quit
             ],
         )
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- After previewing the generated TOML, show a numbered menu: **Write** / **Go back** / **Quit**
- "Go back" restarts the wizard so you can change any answers
- "Quit" exits without writing (same as old "n")
- If file exists, still asks overwrite confirmation before writing

## Test plan
- [ ] Run `fabprint init`, verify 3-option menu appears after preview
- [ ] Pick "Go back" — wizard restarts
- [ ] Pick "Write" — file is saved
- [ ] Pick "Quit" — exits without writing
- [ ] All 469 tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)