### PR TITLE
Always send verification code during cloud login

### DIFF
--- a/docs/recordings/demo.tape
+++ b/docs/recordings/demo.tape
@@ -8,6 +8,10 @@
 #
 # Everything is scripted EXCEPT password and verification code entry.
 # Adjust profile search terms below if your printer isn't a P1S.
+#
+# The interactive picker uses simple-term-menu:
+#   Single-select: type to filter, Enter to select highlighted item
+#   Multi-select:  / to search, Space to toggle, Enter to confirm
 
 Output docs/recordings/demo.gif
 
@@ -125,50 +129,28 @@ Enter
 Wait+Screen /fabprint init/
 Sleep 500ms
 
-# --- Printer Profile (live search picker) ---
+# --- Printer Profile (simple-term-menu, single-select) ---
 # Printer already configured, skips to profile picker
 Wait+Screen /Printer Profile/
 Sleep 500ms
 
-# Search for P1S 0.4 nozzle — unique match, Enter auto-selects
+# Type to filter, Enter selects highlighted match
 Type@100ms "P1S 0.4"
-Sleep 1s
+Sleep 500ms
 Enter
 Sleep 1s
 
-# --- Process Profile (live search picker) ---
+# --- Process Profile (simple-term-menu, single-select) ---
 Wait+Screen /Process Profile/
 Sleep 500ms
 
-# Search for process profile — unique match, Enter auto-selects
+# Type to filter, Enter selects highlighted match
 Type@100ms "0.20mm Standard "
 Sleep 200ms
-Type@100ms "@BBL X1C"
-Sleep 1s
+Type "@BBL X1C"
+Sleep 500ms
 Enter
 Sleep 1s
-
-# --- Slicer Overrides ---
-Wait+Screen /Slicer Overrides/
-Sleep 300ms
-
-# Yes, add overrides
-Type "y"
-Enter
-
-# Pick infill density (option 1)
-Wait+Screen /Pick override/
-Type "1"
-Enter
-
-# Enter infill value
-Wait+Screen /Value for/
-Type "15%"
-Enter
-
-# Don't add another override
-Wait+Screen /Add another override/
-Enter
 
 # --- Filament (AMS connected — accept matched suggestions) ---
 Wait+Screen /Filament Profiles/
@@ -178,14 +160,17 @@ Sleep 1s
 Wait+Screen /Use these filaments/
 Enter
 
-# --- CAD Files ---
+# --- CAD Files (simple-term-menu, multi-select) ---
 Wait+Screen /CAD Files/
 Sleep 500ms
 
-# Select all files (should find decoy_base.step + decoy_shell.step)
-Type@100ms "all"
-Sleep 300ms
+# Multi-select: Space toggles items, Enter confirms
+# Toggle first item, move down, toggle second, confirm
+Space
+Down
+Space
 Enter
+Sleep 500ms
 
 # First file — copies (accept default 1)
 Wait+Screen /copies/
@@ -213,6 +198,28 @@ Wait+Screen /filament slot/
 Type "3"
 Enter
 
+# --- Slicer Overrides (now after CAD files) ---
+Wait+Screen /Slicer Overrides/
+Sleep 300ms
+
+# Yes, add overrides
+Type "y"
+Enter
+
+# Pick infill density (option 1)
+Wait+Screen /Pick override/
+Type "1"
+Enter
+
+# Enter infill value (percent type — "15" auto-becomes "15%")
+Wait+Screen /Value for/
+Type "15"
+Enter
+
+# Don't add another override
+Wait+Screen /Add another override/
+Enter
+
 # --- Build Plate ---
 Wait+Screen /Build Plate/
 Sleep 300ms
@@ -234,14 +241,13 @@ Wait+Screen /Pick version|version to pin/
 Type "1"
 Enter
 
-# --- Printer Connection (live picker) ---
+# --- Printer Connection (simple-term-menu, single-select) ---
 Wait+Screen /Printer Connection/
 Sleep 500ms
 
-# Select "workshop" (first option)
-Type "1"
-Sleep 300ms
+# Select "workshop" (first option) — Enter picks highlighted
 Enter
+Sleep 500ms
 
 # --- Project Name ---
 Wait+Screen /Project name/
@@ -251,9 +257,10 @@ Sleep 300ms
 Enter
 
 # --- Preview and write ---
-Wait+Screen /Write to/
+Wait+Screen /Write.*Go back.*Quit/
 
-Type "y"
+# "w" to write
+Type "w"
 Enter
 
 Wait+Screen /Wrote fabprint.toml/

--- a/src/fabprint/auth.py
+++ b/src/fabprint/auth.py
@@ -55,10 +55,12 @@ def _login(email: str, password: str) -> tuple[str, str]:
     login_type = data.get("loginType", "")
 
     # Step 2: Handle verification code flow
-    # Note: Bambu API auto-sends a code when loginType == "verifyCode",
-    # so we do NOT call _request_verification_code() here (that would send a second code).
+    # Always request a code — the API sometimes auto-sends one when
+    # loginType == "verifyCode", but not always (IP-based trust).
+    # Calling explicitly ensures the user always receives a code,
+    # though they may occasionally get two emails.
     if not token and login_type == "verifyCode":
-        ui.success(f"Verification code sent to {email}")
+        _request_verification_code(email)
         code = ui.prompt_password("Enter verification code")
         resp = requests.post(
             f"{API_BASE}/v1/user-service/user/login",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -135,26 +135,29 @@ class TestLoginVerificationCodeFlow:
         _silence_ui(monkeypatch)
         monkeypatch.setattr("fabprint.ui.prompt_password", lambda prompt: "123456")
 
-        # First call returns verifyCode (API auto-sends code), second returns token
+        # First call returns verifyCode, second sends code email, third logs in with code
         first_resp = _mock_response(200, json_data={"loginType": "verifyCode"})
-        second_resp = _mock_response(
+        code_send_resp = _mock_response(200)
+        third_resp = _mock_response(
             200,
             json_data={"accessToken": "code_tok", "refreshToken": "code_ref"},
         )
 
         with patch("fabprint.auth.requests.post") as mock_post:
-            mock_post.side_effect = [first_resp, second_resp]
+            mock_post.side_effect = [first_resp, code_send_resp, third_resp]
             token, refresh = _login("user@example.com", "pw")
 
         assert token == "code_tok"
         assert refresh == "code_ref"
 
-        # Two POST calls: password login (triggers code), code login
-        assert mock_post.call_count == 2
-        # Second call sends the code
-        second_call_json = mock_post.call_args_list[1][1]["json"]
-        assert second_call_json["code"] == "123456"
-        assert second_call_json["account"] == "user@example.com"
+        # Three POST calls: password login, send-code, code login
+        assert mock_post.call_count == 3
+        # Second call is the verification code email
+        assert "sendemail/code" in mock_post.call_args_list[1][0][0]
+        # Third call sends the code
+        third_call_json = mock_post.call_args_list[2][1]["json"]
+        assert third_call_json["code"] == "123456"
+        assert third_call_json["account"] == "user@example.com"
 
     def test_verify_code_flow_no_token_raises(self, monkeypatch):
         """Verification code flow returns but still no token."""
@@ -162,10 +165,11 @@ class TestLoginVerificationCodeFlow:
         monkeypatch.setattr("fabprint.ui.prompt_password", lambda prompt: "000000")
 
         first_resp = _mock_response(200, json_data={"loginType": "verifyCode"})
-        second_resp = _mock_response(200, json_data={"message": "bad code"})
+        code_send_resp = _mock_response(200)
+        third_resp = _mock_response(200, json_data={"message": "bad code"})
 
         with patch("fabprint.auth.requests.post") as mock_post:
-            mock_post.side_effect = [first_resp, second_resp]
+            mock_post.side_effect = [first_resp, code_send_resp, third_resp]
             with pytest.raises(FabprintError, match="Login failed"):
                 _login("user@example.com", "pw")
 


### PR DESCRIPTION
## Summary
- Always call `_request_verification_code()` explicitly during cloud login, regardless of whether the API auto-sends one
- The Bambu API inconsistently auto-sends codes based on IP trust — this ensures the user always receives at least one code
- May occasionally result in two emails when the API also auto-sends
- Update auth tests for the 3-step flow (password login → send code → code login)
- Update demo tape for current init wizard flow (simple-term-menu, overrides after CAD files, Write/Go back/Quit)

## Test plan
- [x] `uv run pytest` — 477 passed
- [x] Lint, format, mypy all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)