### PR TITLE
Optimize Docker builds: layer splitting, cache mounts, multi-stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.113 — 2026-03-19
+
+- Faster Docker rebuilds: split dependency and source layers in Orca Dockerfile
+- Add BuildKit cache mounts for apt and uv in both Dockerfiles
+- Multi-stage cloud-bridge build drops g++ from final image (~100MB smaller)
+
 ## 0.1.112 — 2026-03-19
 
 - Skip redundant `docker pull` for cloud-bridge image (pull once per 24h instead of every invocation)

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ FROM --platform=linux/amd64 ubuntu:24.04 AS orca
 ARG ORCA_VERSION=2.3.1
 
 WORKDIR /tmp
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
 RUN curl -fSL -o orca.AppImage \
         "https://github.com/SoftFever/OrcaSlicer/releases/download/v${ORCA_VERSION}/OrcaSlicer_Linux_AppImage_Ubuntu2404_V${ORCA_VERSION}.AppImage" \
     && chmod +x orca.AppImage \
@@ -31,14 +32,15 @@ LABEL org.opencontainers.image.description="fabprint with OrcaSlicer ${ORCA_VERS
 LABEL fabprint.orca-version="${ORCA_VERSION}"
 
 # OrcaSlicer runtime deps (needed even for CLI — links GTK/GL at startup)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends \
         libgl1 libgl1-mesa-dri libegl1 \
         libgtk-3-0 \
         libwebkit2gtk-4.1-0 \
         libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 \
         xvfb \
-        ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+        ca-certificates
 
 # Copy extracted OrcaSlicer
 COPY --from=orca /opt/orca-slicer /opt/orca-slicer
@@ -55,13 +57,17 @@ RUN useradd -m -d /home/fabprint fabprint \
 # Install uv (fast Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# Install fabprint
+# Install dependencies first (cached unless lockfile changes)
 WORKDIR /opt/fabprint
 COPY pyproject.toml uv.lock README.md LICENSE ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv python install 3.12 \
+    && uv sync --frozen --no-dev --no-editable --python 3.12
+
+# Copy source and re-link (fast — deps already installed)
 COPY src/ ./src/
-RUN uv python install 3.12 \
-    && uv sync --frozen --no-dev --no-editable --python 3.12 \
-    && uv cache clean
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable --python 3.12
 
 ENV PATH="/opt/fabprint/.venv/bin:$PATH"
 

--- a/Dockerfile.cloud-bridge
+++ b/Dockerfile.cloud-bridge
@@ -12,19 +12,37 @@
 # Note: x86_64/amd64 only (libbambu_networking.so is x86_64 binary).
 # On Apple Silicon Macs, Docker runs this via Rosetta emulation.
 
+# ---------------------------------------------------------------------------
+# Stage 1: Compile the bridge binary
+# ---------------------------------------------------------------------------
+FROM --platform=linux/amd64 ubuntu:24.04 AS builder
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends g++
+
+COPY scripts/bambu_cloud_bridge.cpp /opt/bridge/bambu_cloud_bridge.cpp
+RUN g++ -std=c++17 -O2 \
+        -o /usr/local/bin/bambu_cloud_bridge \
+        /opt/bridge/bambu_cloud_bridge.cpp \
+        -ldl -lpthread
+
+# ---------------------------------------------------------------------------
+# Stage 2: Runtime image (no compiler)
+# ---------------------------------------------------------------------------
 FROM --platform=linux/amd64 ubuntu:24.04
 
 LABEL org.opencontainers.image.description="Bambu Lab cloud print bridge (headless)"
 
-# Build tools + runtime deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        g++ \
+# Runtime deps only — no g++
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         libcurl4 \
         python3 \
-        unzip \
-    && rm -rf /var/lib/apt/lists/*
+        unzip
 
 # Fetch libbambu_networking.so — try Bambu's API first, fall back to private cache.
 # The API returns a signed CDN URL for the current Linux plugin zip.
@@ -57,13 +75,8 @@ RUN mkdir -p /tmp/bambu_agent/cert /tmp/bambu_agent/log /tmp/bambu_agent/config 
     && curl -fSL -o /tmp/bambu_agent/cert/slicer_base64.cer \
        "https://raw.githubusercontent.com/bambulab/BambuStudio/master/resources/cert/slicer_base64.cer"
 
-# Compile the bridge
-COPY scripts/bambu_cloud_bridge.cpp /opt/bridge/bambu_cloud_bridge.cpp
-RUN g++ -std=c++17 -O2 \
-        -o /usr/local/bin/bambu_cloud_bridge \
-        /opt/bridge/bambu_cloud_bridge.cpp \
-        -ldl -lpthread \
-    && rm -rf /opt/bridge
+# Copy compiled bridge from builder stage
+COPY --from=builder /usr/local/bin/bambu_cloud_bridge /usr/local/bin/bambu_cloud_bridge
 
 # Set library path for the bridge
 ENV BAMBU_LIB_PATH=/tmp/bambu_plugin/libbambu_networking.so


### PR DESCRIPTION
## Summary
Phases 2+3 of the [Docker optimization plan](docs/docker-optimization-plan.md). Dockerfile-only changes — no Python code modified.

**Orca Dockerfile:**
- Split dependency install from source copy — deps cached unless `uv.lock` changes (saves 30-60s on code-only rebuilds)
- BuildKit cache mounts for apt and uv — no re-downloading packages on rebuild
- Removed `uv cache clean` (external cache mount handles this)

**Cloud-bridge Dockerfile:**
- Multi-stage build: g++ in builder stage only, binary copied to runtime image
- Final image ~100MB smaller (no compiler toolchain)
- BuildKit cache mounts for apt

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — all formatted
- [x] `uv run mypy src/fabprint` — zero errors
- [x] `uv run pytest` — 496 passed, 9 skipped
- [ ] CI Docker build (triggered by Dockerfile change detection in publish workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)