### PR TITLE
Add orca-base image for faster Docker rebuilds

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -41,6 +41,14 @@ jobs:
             && echo "changed=true" >> "$GITHUB_OUTPUT" \
             || echo "changed=false" >> "$GITHUB_OUTPUT"
 
+      - name: Check if orca-base Docker rebuild needed
+        id: base_changed
+        run: |
+          git diff ${{ github.sha }}^1 ${{ github.sha }} --name-only \
+            | grep -qE '^Dockerfile\.orca-base$' \
+            && echo "changed=true" >> "$GITHUB_OUTPUT" \
+            || echo "changed=false" >> "$GITHUB_OUTPUT"
+
       - name: Check if OrcaSlicer Docker rebuild needed
         id: orca_changed
         run: |
@@ -63,14 +71,14 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Log in to Docker Hub
-        if: steps.bridge_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.bridge_changed.outputs.changed == 'true' || steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GitHub Container Registry
-        if: steps.bridge_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.bridge_changed.outputs.changed == 'true' || steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -78,7 +86,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        if: steps.bridge_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.bridge_changed.outputs.changed == 'true' || steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push cloud-bridge
@@ -97,8 +105,25 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push orca-base image
+        if: steps.base_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.orca-base
+          platforms: linux/amd64
+          push: true
+          tags: |
+            fabprint/orca-base:2.3.1
+            fabprint/orca-base:latest
+            ghcr.io/${{ github.repository }}/orca-base:2.3.1
+            ghcr.io/${{ github.repository }}/orca-base:latest
+          build-args: ORCA_VERSION=2.3.1
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Build and push OrcaSlicer image
-        if: steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -115,12 +140,12 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Extract OrcaSlicer profiles from Docker image
-        if: steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           python scripts/extract_profiles.py 2.3.1 --image fabprint/fabprint:orca-2.3.1
 
       - name: Commit bundled profiles
-        if: steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           git diff --quiet src/fabprint/data/ && echo "No profile changes" && exit 0
           git add src/fabprint/data/

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -18,6 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Pull or build orca-base image
+        run: |
+          docker pull fabprint/orca-base:${{ inputs.orca_version }} 2>/dev/null \
+            || docker build --platform linux/amd64 \
+              -f Dockerfile.orca-base \
+              --build-arg ORCA_VERSION=${{ inputs.orca_version }} \
+              -t fabprint/orca-base:${{ inputs.orca_version }} .
+
       - name: Build fabprint image
         run: |
           docker build \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.114 — 2026-03-19
+
+- Split OrcaSlicer into a separate base image (`fabprint/orca-base`) for faster code-only rebuilds
+- Main `fabprint/fabprint` image now layers on top of pre-built base (~10s vs ~3-5min rebuild)
+- CI auto-publishes orca-base when `Dockerfile.orca-base` changes
+- Build script: `./scripts/build-docker.sh orca-base 2.3.1`
+
 ## 0.1.113 — 2026-03-19
 
 - Faster Docker rebuilds: split dependency and source layers in Orca Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,58 +1,17 @@
-# Multi-stage build: OrcaSlicer CLI + fabprint
+# fabprint: layers Python package on top of orca-base image
+#
+# The base image (fabprint/orca-base) contains OrcaSlicer + runtime deps and
+# changes only on OrcaSlicer version bumps. This Dockerfile just installs the
+# Python package, so code-only rebuilds are fast (~10s).
 #
 # Usage:
-#   docker build --build-arg ORCA_VERSION=2.3.1 -t fabprint/fabprint:2.3.1 .
-#   docker run --rm -v "$PWD:/project" fabprint/fabprint:2.3.1 slice fabprint.toml
-
-# ---------------------------------------------------------------------------
-# Stage 1: Extract OrcaSlicer from AppImage (x86_64 only)
-# ---------------------------------------------------------------------------
-FROM --platform=linux/amd64 ubuntu:24.04 AS orca
+#   docker build --build-arg ORCA_VERSION=2.3.1 -t fabprint/fabprint:orca-2.3.1 .
+#   docker run --rm -v "$PWD:/project" fabprint/fabprint:orca-2.3.1 slice fabprint.toml
 
 ARG ORCA_VERSION=2.3.1
+FROM fabprint/orca-base:${ORCA_VERSION}
 
-WORKDIR /tmp
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
-    apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
-RUN curl -fSL -o orca.AppImage \
-        "https://github.com/SoftFever/OrcaSlicer/releases/download/v${ORCA_VERSION}/OrcaSlicer_Linux_AppImage_Ubuntu2404_V${ORCA_VERSION}.AppImage" \
-    && chmod +x orca.AppImage \
-    && ./orca.AppImage --appimage-extract \
-    && mv squashfs-root /opt/orca-slicer \
-    && rm orca.AppImage
-
-# ---------------------------------------------------------------------------
-# Stage 2: Runtime image
-# ---------------------------------------------------------------------------
-FROM --platform=linux/amd64 ubuntu:24.04
-
-ARG ORCA_VERSION=2.3.1
 LABEL org.opencontainers.image.description="fabprint with OrcaSlicer ${ORCA_VERSION}"
-LABEL fabprint.orca-version="${ORCA_VERSION}"
-
-# OrcaSlicer runtime deps (needed even for CLI — links GTK/GL at startup)
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
-    apt-get update && apt-get install -y --no-install-recommends \
-        libgl1 libgl1-mesa-dri libegl1 \
-        libgtk-3-0 \
-        libwebkit2gtk-4.1-0 \
-        libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 \
-        xvfb \
-        ca-certificates
-
-# Copy extracted OrcaSlicer
-COPY --from=orca /opt/orca-slicer /opt/orca-slicer
-RUN ln -s /opt/orca-slicer/bin/orca-slicer /usr/bin/orca-slicer
-
-# Wire up system profiles so fabprint can discover them
-# fabprint looks at ~/.config/OrcaSlicer/system/BBL on Linux
-ENV HOME=/home/fabprint
-RUN useradd -m -d /home/fabprint fabprint \
-    && mkdir -p /home/fabprint/.config/OrcaSlicer/system \
-    && ln -s /opt/orca-slicer/resources/profiles/BBL \
-             /home/fabprint/.config/OrcaSlicer/system/BBL
 
 # Install uv (fast Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/Dockerfile.orca-base
+++ b/Dockerfile.orca-base
@@ -1,0 +1,58 @@
+# Base image: OrcaSlicer + runtime deps
+#
+# Rebuild only when OrcaSlicer version changes. The main Dockerfile
+# (fabprint/fabprint) layers on top of this for fast code-only rebuilds.
+#
+# Usage:
+#   docker build -f Dockerfile.orca-base --build-arg ORCA_VERSION=2.3.1 \
+#     -t fabprint/orca-base:2.3.1 .
+
+# ---------------------------------------------------------------------------
+# Stage 1: Extract OrcaSlicer from AppImage (x86_64 only)
+# ---------------------------------------------------------------------------
+FROM --platform=linux/amd64 ubuntu:24.04 AS orca
+
+ARG ORCA_VERSION=2.3.1
+
+WORKDIR /tmp
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+RUN curl -fSL -o orca.AppImage \
+        "https://github.com/SoftFever/OrcaSlicer/releases/download/v${ORCA_VERSION}/OrcaSlicer_Linux_AppImage_Ubuntu2404_V${ORCA_VERSION}.AppImage" \
+    && chmod +x orca.AppImage \
+    && ./orca.AppImage --appimage-extract \
+    && mv squashfs-root /opt/orca-slicer \
+    && rm orca.AppImage
+
+# ---------------------------------------------------------------------------
+# Stage 2: Runtime image with OrcaSlicer + system deps
+# ---------------------------------------------------------------------------
+FROM --platform=linux/amd64 ubuntu:24.04
+
+ARG ORCA_VERSION=2.3.1
+LABEL org.opencontainers.image.description="OrcaSlicer ${ORCA_VERSION} base image for fabprint"
+LABEL fabprint.orca-version="${ORCA_VERSION}"
+
+# OrcaSlicer runtime deps (needed even for CLI — links GTK/GL at startup)
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends \
+        libgl1 libgl1-mesa-dri libegl1 \
+        libgtk-3-0 \
+        libwebkit2gtk-4.1-0 \
+        libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 \
+        xvfb \
+        ca-certificates
+
+# Copy extracted OrcaSlicer
+COPY --from=orca /opt/orca-slicer /opt/orca-slicer
+RUN ln -s /opt/orca-slicer/bin/orca-slicer /usr/bin/orca-slicer
+
+# Wire up system profiles so fabprint can discover them
+# fabprint looks at ~/.config/OrcaSlicer/system/BBL on Linux
+ENV HOME=/home/fabprint
+RUN useradd -m -d /home/fabprint fabprint \
+    && mkdir -p /home/fabprint/.config/OrcaSlicer/system \
+    && ln -s /opt/orca-slicer/resources/profiles/BBL \
+             /home/fabprint/.config/OrcaSlicer/system/BBL

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -2,9 +2,11 @@
 # Build and optionally push fabprint Docker images.
 #
 # Usage:
-#   ./scripts/build-docker.sh slicer 2.3.1       # build slicer image
+#   ./scripts/build-docker.sh orca-base 2.3.1       # build orca-base image
+#   ./scripts/build-docker.sh orca-base 2.3.1 --push
+#   ./scripts/build-docker.sh slicer 2.3.1           # build slicer image
 #   ./scripts/build-docker.sh slicer 2.3.1 --push
-#   ./scripts/build-docker.sh cloud-bridge        # build cloud bridge image
+#   ./scripts/build-docker.sh cloud-bridge           # build cloud bridge image
 #   ./scripts/build-docker.sh cloud-bridge --push
 #
 # Legacy (slicer only):
@@ -13,9 +15,33 @@
 
 set -euo pipefail
 
-TARGET="${1:?Usage: $0 <slicer|cloud-bridge|orca-version> [version] [--push]}"
+TARGET="${1:?Usage: $0 <orca-base|slicer|cloud-bridge|orca-version> [version] [--push]}"
 
 case "$TARGET" in
+    orca-base)
+        VERSION="${2:?Usage: $0 orca-base <orca-version> [--push]}"
+        PUSH="${3:-}"
+        IMAGE="fabprint/orca-base:${VERSION}"
+
+        echo "Building ${IMAGE} ..."
+        docker build \
+            --platform linux/amd64 \
+            -f Dockerfile.orca-base \
+            --build-arg "ORCA_VERSION=${VERSION}" \
+            -t "${IMAGE}" \
+            .
+
+        echo "Tagging as fabprint/orca-base:latest ..."
+        docker tag "${IMAGE}" fabprint/orca-base:latest
+        echo "Build complete: ${IMAGE}"
+
+        if [ "${PUSH}" = "--push" ]; then
+            docker push "${IMAGE}"
+            docker push fabprint/orca-base:latest
+            echo "Pushed."
+        fi
+        ;;
+
     slicer)
         VERSION="${2:?Usage: $0 slicer <orca-version> [--push]}"
         PUSH="${3:-}"


### PR DESCRIPTION
## Summary
Phase 4 of the [Docker optimization plan](docs/docker-optimization-plan.md).

- New `Dockerfile.orca-base`: contains OrcaSlicer extraction + GTK/GL runtime deps + profile symlinks. Only rebuilds when OrcaSlicer version changes.
- `Dockerfile` simplified to `FROM fabprint/orca-base:${ORCA_VERSION}` + uv install. Code-only rebuilds now ~10s instead of 3-5 minutes.
- CI publishes `fabprint/orca-base:2.3.1` to Docker Hub + GHCR when `Dockerfile.orca-base` changes. Also rebuilds main image when base changes.
- Build script gains `orca-base` target: `./scripts/build-docker.sh orca-base 2.3.1`
- Slice workflow pulls pre-built orca-base before building, falls back to building from scratch

**Note:** The first CI run after merge needs `workflow_dispatch` to publish the initial orca-base image, since the base doesn't exist on Docker Hub yet. Subsequent runs will use the cached base.

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — all formatted
- [x] `uv run mypy src/fabprint` — zero errors
- [x] `uv run pytest` — 496 passed, 9 skipped
- [ ] Manual `workflow_dispatch` after merge to publish initial orca-base image

🤖 Generated with [Claude Code](https://claude.com/claude-code)