### PR TITLE
Fix Docker BuildKit cache lock conflicts

### DIFF
--- a/Dockerfile.cloud-bridge
+++ b/Dockerfile.cloud-bridge
@@ -17,8 +17,8 @@
 # ---------------------------------------------------------------------------
 FROM --platform=linux/amd64 ubuntu:24.04 AS builder
 
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=apt-bridge-builder,target=/var/cache/apt \
+    --mount=type=cache,id=apt-bridge-builder,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends g++
 
 COPY scripts/bambu_cloud_bridge.cpp /opt/bridge/bambu_cloud_bridge.cpp
@@ -35,8 +35,8 @@ FROM --platform=linux/amd64 ubuntu:24.04
 LABEL org.opencontainers.image.description="Bambu Lab cloud print bridge (headless)"
 
 # Runtime deps only — no g++
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=apt-bridge-runtime,target=/var/cache/apt \
+    --mount=type=cache,id=apt-bridge-runtime,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \

--- a/Dockerfile.orca-base
+++ b/Dockerfile.orca-base
@@ -15,8 +15,8 @@ FROM --platform=linux/amd64 ubuntu:24.04 AS orca
 ARG ORCA_VERSION=2.3.1
 
 WORKDIR /tmp
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=apt-orca,target=/var/cache/apt \
+    --mount=type=cache,id=apt-orca,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
 RUN curl -fSL -o orca.AppImage \
         "https://github.com/SoftFever/OrcaSlicer/releases/download/v${ORCA_VERSION}/OrcaSlicer_Linux_AppImage_Ubuntu2404_V${ORCA_VERSION}.AppImage" \
@@ -35,8 +35,8 @@ LABEL org.opencontainers.image.description="OrcaSlicer ${ORCA_VERSION} base imag
 LABEL fabprint.orca-version="${ORCA_VERSION}"
 
 # OrcaSlicer runtime deps (needed even for CLI — links GTK/GL at startup)
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=apt-runtime,target=/var/cache/apt \
+    --mount=type=cache,id=apt-runtime,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends \
         libgl1 libgl1-mesa-dri libegl1 \
         libgtk-3-0 \


### PR DESCRIPTION
## Summary
Fix CI Docker build failure caused by parallel stages sharing the same apt cache mount, resulting in `/var/lib/apt/lists/lock` contention (exit code 100).

Each stage now uses a unique cache `id` (e.g. `apt-orca`, `apt-runtime`, `apt-bridge-builder`, `apt-bridge-runtime`) to prevent lock conflicts.

## Test plan
- [x] `uv run pytest` — 496 passed, 9 skipped
- [ ] CI Docker build succeeds (this was the failing step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)