### PR TITLE
Fix Dockerfile hatchling discovery failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.116 — 2026-03-19
+
+- Fix Dockerfile: add stub `src/fabprint/__init__.py` before dep install so hatchling can discover the package
+
 ## 0.1.114 — 2026-03-19
 
 - Split OrcaSlicer into a separate base image (`fabprint/orca-base`) for faster code-only rebuilds

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # Install dependencies first (cached unless lockfile changes)
 WORKDIR /opt/fabprint
 COPY pyproject.toml uv.lock README.md LICENSE ./
+# Stub so hatchling can discover the package during dep install
+RUN mkdir -p src/fabprint && touch src/fabprint/__init__.py
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv python install 3.12 \
     && uv sync --frozen --no-dev --no-editable --python 3.12


### PR DESCRIPTION
## Summary
- The fabprint Docker image build was failing because `uv sync` runs before `COPY src/` (to cache deps), but hatchling needs `src/fabprint/` to exist for package discovery
- Fix: create a stub `src/fabprint/__init__.py` before the first `uv sync`; the real source overwrites it in the next layer

## Test plan
- [ ] CI publish workflow builds fabprint image successfully
- [ ] `docker build -t fabprint/fabprint:test .` works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)