### PR TITLE
Remove Python 3.14 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [


### PR DESCRIPTION
cadquery-ocp (build123d dep) lacks cp314 wheels — fabprint can't install on 3.14. Remove the classifier until CI actually tests it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)