### PR TITLE
Remove dead Bambu Connect private key and signing code

### DIFF
--- a/src/fabprint/cloud/http.py
+++ b/src/fabprint/cloud/http.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any
 
-import base64
 import hashlib
 import json
 import logging
@@ -29,71 +28,6 @@ TASK_POLL_INTERVAL = 5
 # 3MF processing poll limits
 PROCESSING_POLL_MAX_ATTEMPTS = 15
 PROCESSING_POLL_INTERVAL = 2
-
-# BambuConnect X.509 certificate ID and private key for signing print tasks.
-# The server passes this signature to the printer via MQTT; without it the
-# printer rejects the command ("MQTT Command verification failed").
-# Ref: https://hackaday.com/2025/01/19/bambu-connects-authentication-x-509-certificate-and-private-key-extracted/
-BAMBU_CERT_ID = "CN=GLOF3813734089.bambulab.com:f9332ab780a6ffe6664db61be42b04ee"
-
-BAMBU_PRIVATE_KEY_PEM = """\
------BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDQNp2NfkajwcWH
-PIqosa08P1ZwETPr1veZCMqieQxWtYw97wp+JCxX4yBrBcAwid7o7PHI9KQVzPRM
-f0uXspaDUdSljrfJ/YwGEz7+GJz4+ml1UbWXBePyzXW1+N2hIGGn7BcNuA0v8rMY
-uvVgiIIQNjLErgGcCWmMHLwsMMQ7LNprUZZKsSNB4HaQDH7cQZmYBN/O45np6l+K
-VuLdzXdDpZcOM7bNO6smev822WPGDuKBo1iVfQbUe10X4dCNwkBR3QGpScVvg8gg
-tRYZDYue/qc4Xaj806RZPttknWfxdvfZgoOmAiwnyQ5K3+mzNYHgQZAOC2ydkK4J
-s+ZizK3lAgMBAAECggEAKwEcyXyrWmdLRQNcIDuSbD8ouzzSXIOp4BHQyH337nDQ
-5nnY0PTns79VksU9TMktIS7PQZJF0brjOmmQU2SvcbAVG5y+mRmlMhwHhrPOuB4A
-ahrWRrsQubV1+n/MRttJUEWS/WJmVuDp3NHAnI+VTYPkOHs4GeJXynik5PutjAr3
-tYmr3kaw0Wo/hYAXTKsI/R5aenC7jH8ZSyVcZ/j+bOSH5sT5/JY122AYmkQOFE7s
-JA0EfYJaJEwiuBWKOfRLQVEHhOFodUBZdGQcWeW3uFb88aYKN8QcKTO8/f6e4r8w
-QojgK3QMj1zmfS7xid6XCOVa17ary2hZHAEPnjcigQKBgQDQnm4TlbVTsM+CbFUS
-1rOIJRzPdnH3Y7x3IcmVKZt81eNktsdu56A4U6NEkFQqk4tVTT4TYja/hwgXmm6w
-J+w0WwZd445Bxj8PmaEr6Z/NSMYbCsi8pRelKWmlIMwD2YhtY/1xXD37zpOgN8oQ
-ryTKZR2gljbPxdfhKS7YerLp2wKBgQD/gJt3Ds69j1gMDLnnPctjmhsPRXh7PQ0e
-E9lqgFkx/vNuCuyRs6ymic2rBZmkdlpjsTJFmz1bwOzIvSRoH6kp0Mfyo6why5kr
-upDf7zz+hlvaFewme8aDeV3ex9Wvt73D66nwAy5ABOgn+66vZJeo0Iq/tnCwK3a/
-evTL9BOzPwKBgEUi7AnziEc3Bl4Lttnqa08INZcPgs9grzmv6dVUF6J0Y8qhxFAd
-1Pw1w5raVfpSMU/QrGzSFKC+iFECLgKVCHOFYwPEgQWNRKLP4BjkcMAgiP63QTU7
-ZS2oHsnJp7Ly6YKPK5Pg5O3JVSU4t+91i7TDc+EfRwTuZQ/KjSrS5u4XAoGBAP06
-v9reSDVELuWyb0Yqzrxm7k7ScbjjJ28aCTAvCTguEaKNHS7DP2jHx5mrMT35N1j7
-NHIcjFG2AnhqTf0M9CJHlQR9B4tvON5ISHJJsNAq5jpd4/G4V2XTEiBNOxKvL1tQ
-5NrGrD4zHs0R+25GarGcDwg3j7RrP4REHv9NZ4ENAoGAY7Nuz6xKu2XUwuZtJP7O
-kjsoDS7bjP95ddrtsRq5vcVjJ04avnjsr+Se9WDA//t7+eSeHjm5eXD7u0NtdqZo
-WtSm8pmWySOPXMn9QQmdzKHg1NOxer//f1KySVunX1vftTStjsZH7dRCtBEePcqg
-z5Av6MmEFDojtwTqvEZuhBM=
------END PRIVATE KEY-----"""
-
-_bambu_private_key = None
-
-
-def _get_private_key():
-    """Lazily load the BambuConnect private key (requires cryptography package)."""
-    global _bambu_private_key
-    if _bambu_private_key is None:
-        from cryptography.hazmat.primitives.serialization import load_pem_private_key
-
-        _bambu_private_key = load_pem_private_key(BAMBU_PRIVATE_KEY_PEM.encode(), password=None)
-    return _bambu_private_key
-
-
-def _sign_task_body(body_bytes: bytes) -> str:
-    """Sign the POST /my/task request body with the BambuConnect X.509 private key.
-
-    Returns a Base64-encoded RSA-SHA256 signature.
-    """
-    from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.asymmetric import padding
-
-    key = _get_private_key()
-    signature = key.sign(
-        body_bytes,
-        padding.PKCS1v15(),
-        hashes.SHA256(),
-    )
-    return base64.b64encode(signature).decode("ascii")
 
 
 def cloud_list_devices(token_file: Path) -> list[dict]:


### PR DESCRIPTION
## Summary
Remove ~65 lines of dead code from `cloud/http.py`:
- Hardcoded Bambu Connect X.509 private key (`BAMBU_PRIVATE_KEY_PEM`)
- Certificate ID (`BAMBU_CERT_ID`)
- `_get_private_key()` and `_sign_task_body()` functions
- Unused `base64` import

`_sign_task_body()` was never called — the task POST is sent unsigned because the extracted Hackaday key doesn't work with the current Bambu API (server returns 403). The code comment on line 411 confirmed this.

## Test plan
- [x] `uv run pytest` — 506 passed
- [x] Lint, format, mypy pass
- [x] Verified `_sign_task_body` had zero call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)