### PR TITLE
Make printer optional — decouple slicing from printing

### DIFF
--- a/src/fabprint/config.py
+++ b/src/fabprint/config.py
@@ -46,7 +46,7 @@ class PrinterConfig:
     name: str  # references a printer in ~/.config/fabprint/credentials.toml
 
 
-DEFAULT_STAGES = ["load", "arrange", "plate", "slice", "print"]
+DEFAULT_STAGES = ["load", "arrange", "plate", "slice"]
 
 
 @dataclass

--- a/src/fabprint/init.py
+++ b/src/fabprint/init.py
@@ -699,25 +699,10 @@ def _prompt_overrides() -> dict[str, str]:
 
 
 def _wizard_setup_printers(configured: dict[str, dict]) -> dict[str, dict]:
-    """Step 0: Check for configured printers, optionally run setup.
+    """Check for configured printers (no prompts — printer is optional).
 
-    Returns the (possibly refreshed) configured printers dict.
+    Returns the configured printers dict (may be empty).
     """
-    from fabprint import ui
-
-    if not configured:
-        ui.warn("No printers configured yet.")
-        if _prompt_yn("Run 'fabprint setup' to add a printer first?"):
-            from fabprint.credentials import setup_printer
-
-            ui.console.print()
-            setup_printer()
-            ui.console.print()
-            # Refresh after setup
-            configured = _list_configured_printers()
-        else:
-            ui.info("Continuing without printer setup.")
-            ui.console.print()
     return configured
 
 
@@ -918,28 +903,30 @@ def _wizard_pick_slicer_version() -> str | None:
     return slicer_version
 
 
-def _wizard_pick_printer(stages: list[str]) -> str | None:
-    """Step 10: Pick printer connection.
+def _wizard_pick_printer() -> str | None:
+    """Pick printer connection (optional).
 
     Returns the printer name, or ``None`` if skipped.
     """
     from fabprint import ui
 
-    printer_name = None
-    if "print" in stages:
-        ui.heading("Printer Connection")
-        configured = _list_configured_printers()
-        if configured:
-            names = list(configured.keys())
-            chosen = _prompt_choice("Pick a printer", [*names, "Skip (configure later)"])
-            pick = names[chosen[0]] if chosen[0] < len(names) else None
-            printer_name = pick
-        elif _prompt_yn("Configure printer connection?", default=False):
-            printer_name = _prompt_str("Printer name (from 'fabprint setup')", "")
-            if not printer_name:
-                printer_name = None
+    ui.heading("Printer (optional)")
+    configured = _list_configured_printers()
+    if configured:
+        names = list(configured.keys())
+        chosen = _prompt_choice("Pick a printer", [*names, "Skip — slice only"])
+        pick = names[chosen[0]] if chosen[0] < len(names) else None
         ui.console.print()
-    return printer_name
+        return pick
+
+    if _prompt_yn("Connect a printer? (run 'fabprint setup' first)", default=False):
+        printer_name = _prompt_str("Printer name (from 'fabprint setup')", "")
+        ui.console.print()
+        return printer_name or None
+
+    ui.info("No printer — config will slice only. Add [printer] later to enable printing.")
+    ui.console.print()
+    return None
 
 
 def run_wizard(output: Path | None = None) -> str:
@@ -957,9 +944,6 @@ def run_wizard(output: Path | None = None) -> str:
 
     engine = "orca"
 
-    # --- Step 0: Check for configured printers ---
-    configured = _wizard_setup_printers(_list_configured_printers())
-
     # --- Step 1: Project name ---
     default_name = Path.cwd().name
     project_name = ui.prompt_str("Project name", default=default_name) or default_name
@@ -968,9 +952,14 @@ def run_wizard(output: Path | None = None) -> str:
     # --- Step 2: CAD files (copies, orient — filament slots assigned later) ---
     parts_config = _wizard_pick_parts()
 
-    # --- Step 3: Printer connection ---
+    # --- Step 3: Printer connection (optional) ---
+    printer_name = _wizard_pick_printer()
+    configured = _list_configured_printers() if printer_name else {}
+
+    # Build pipeline stages — include "print" only if printer selected
     stages = list(DEFAULT_STAGES)
-    printer_name = _wizard_pick_printer(stages)
+    if printer_name:
+        stages.append("print")
 
     # --- Query AMS trays in background while we continue ---
     ams_future = None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -531,12 +531,11 @@ class TestWizard:
         _mock_ui_inputs(
             monkeypatch,
             [
-                "n",  # Run setup first? -> no
                 "my-project",  # Project name
                 "1",  # Select files
                 "1",  # copies
                 "flat",  # orient
-                "n",  # Configure printer connection? -> no
+                "n",  # Connect a printer? -> no
                 "Bambu Lab P1S 0.4 nozzle",  # Printer profile name
                 "0.20mm Standard @BBL X1C",  # Process profile name
                 "256",  # plate width
@@ -574,10 +573,9 @@ class TestWizard:
         _mock_ui_inputs(
             monkeypatch,
             [
-                "n",  # Run setup first? -> no
                 "",  # Project name (use default)
                 "my-part.stl",  # Part file path
-                "n",  # Configure printer connection? -> no
+                "n",  # Connect a printer? -> no
                 "My Printer",  # Printer profile name
                 "My Process",  # Process profile name
                 "256",  # plate width


### PR DESCRIPTION
## Summary
fabprint's core value is reproducible slicing, but the init wizard previously pushed users toward configuring a printer before they could create a config. This removes that friction.

### Before
1. Wizard warns "No printers configured" and prompts to run `fabprint setup`
2. Default pipeline: `["load", "arrange", "plate", "slice", "print"]`
3. Users without a printer had to decline multiple prompts

### After
1. Wizard starts with project name — no printer prompts upfront
2. Default pipeline: `["load", "arrange", "plate", "slice"]`
3. Printer step clearly labelled "(optional)" with "Skip — slice only" option
4. "print" stage added only when user selects a printer

### What works without a printer
- `fabprint init` — creates a complete config for slicing
- `fabprint run` — loads, arranges, plates, slices
- `fabprint validate` — validates everything except printer

### Adding printing later
```bash
fabprint setup              # configure printer credentials
# Then add to fabprint.toml:
# [printer]
# name = "workshop"
# And add "print" to pipeline stages
```

## Test plan
- [x] `uv run pytest` — 506 passed
- [x] Lint, format, mypy pass
- [x] Wizard test produces config without "print" stage when no printer selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)