### PR TITLE
Harden release pipeline: tag-based publishing + TestPyPI

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -2,36 +2,41 @@ name: Publish packages and Docker images
 
 on:
   push:
-    branches: [main]
+    tags: ["v*"]
   workflow_dispatch:
 
 jobs:
-  push:
+  publish:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write  # required for PyPI trusted publishing
       packages: write  # required for GHCR push
+      pull-requests: write  # required for profile update PR
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          token: ${{ secrets.GH_PAT }}
 
-      - name: Bump patch version
+      - name: Extract version from tag
         id: version
         run: |
-          OLD=$(python3 -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['version'])")
-          IFS='.' read -r maj min patch <<< "$OLD"
-          NEW="$maj.$min.$((patch + 1))"
-          sed -i "s/version = \"$OLD\"/version = \"$NEW\"/" pyproject.toml
-          sed -i "s/__version__ = \"$OLD\"/__version__ = \"$NEW\"/" src/fabprint/__init__.py
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml src/fabprint/__init__.py
-          git commit -m "Bump version to $NEW [skip ci]"
-          git push
-          echo "version=$NEW" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches pyproject.toml version
+        if: github.ref_type == 'tag'
+        run: |
+          TOML_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$TOML_VERSION" != "$TAG_VERSION" ]]; then
+            echo "::error::Tag $TAG_VERSION does not match pyproject.toml version $TOML_VERSION"
+            exit 1
+          fi
 
       - name: Check if cloud-bridge Docker rebuild needed
         id: bridge_changed
@@ -98,9 +103,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            fabprint/cloud-bridge:latest
             fabprint/cloud-bridge:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository }}/cloud-bridge:latest
             ghcr.io/${{ github.repository }}/cloud-bridge:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -115,9 +118,7 @@ jobs:
           push: true
           tags: |
             fabprint/orca-base:2.3.1
-            fabprint/orca-base:latest
             ghcr.io/${{ github.repository }}/orca-base:2.3.1
-            ghcr.io/${{ github.repository }}/orca-base:latest
           build-args: ORCA_VERSION=2.3.1
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -131,9 +132,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            fabprint/fabprint:latest
+            fabprint/fabprint:${{ steps.version.outputs.version }}
             fabprint/fabprint:orca-2.3.1
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}:orca-2.3.1
           build-args: ORCA_VERSION=2.3.1
           cache-from: type=gha
@@ -144,10 +145,21 @@ jobs:
         run: |
           python scripts/extract_profiles.py 2.3.1 --image fabprint/fabprint:orca-2.3.1
 
-      - name: Commit bundled profiles
+      - name: Open PR for bundled profile updates
         if: steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           git diff --quiet src/fabprint/data/ && echo "No profile changes" && exit 0
+          BRANCH="update-orca-profiles-${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add src/fabprint/data/
-          git commit -m "Update bundled OrcaSlicer 2.3.1 profiles [skip ci]"
-          git push
+          git commit -m "Update bundled OrcaSlicer 2.3.1 profiles"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "Update bundled OrcaSlicer 2.3.1 profiles" \
+            --body "Auto-generated profile update from release ${{ steps.version.outputs.version }}." \
+            --base main \
+            --head "$BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -1,0 +1,38 @@
+name: Publish to TestPyPI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build Python package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Append dev suffix to avoid version conflicts
+        run: |
+          pip install pkginfo
+          # Rebuild with a unique dev version so TestPyPI accepts it
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          DEV_VERSION="${VERSION}.dev${GITHUB_RUN_NUMBER}"
+          sed -i "s/version = \"$VERSION\"/version = \"$DEV_VERSION\"/" pyproject.toml
+          python -m build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.131 — 2026-03-21
+
+- Harden release pipeline: publish only on git tags (`v*`), not on every push to main
+- Remove self-mutating version bump — version is set in `pyproject.toml` before tagging
+- Drop `GH_PAT` usage; checkout now uses default `GITHUB_TOKEN`
+- Profile updates now open a PR instead of pushing directly to main
+- Remove mutable `:latest` Docker tags; all images tagged with version only
+- Add TestPyPI workflow: publishes `.dev` packages on every PR for pre-release testing
+- New release process: bump version in `pyproject.toml`, tag with `git tag v<version>`, push tag
+
 ## 0.1.128 — 2026-03-20
 
 - Refresh README: adopt tighter structure from proposed rewrite while keeping OrcaSlicer CLI comparison, rich TOML examples, visuals, and env var docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabprint"
-version = "0.1.130"
+version = "0.1.131"
 description = "Headless 3D print pipeline: arrange, orient, slice, and send to printer from a TOML config"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fabprint/__init__.py
+++ b/src/fabprint/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__version__ = "0.1.130"
+__version__ = "0.1.131"
 
 
 class FabprintError(Exception):


### PR DESCRIPTION
## Summary
- **Publish on tags only**: Workflow now triggers on `v*` tags instead of every push to main. No more accidental releases from README typo fixes.
- **No more auto-bump**: Removed the self-mutating version bump step. Set version in `pyproject.toml` before tagging.
- **Tag validation**: CI verifies the git tag matches `pyproject.toml` version before publishing.
- **Drop `GH_PAT`**: Checkout uses default `GITHUB_TOKEN` — no more elevated permissions.
- **Profile updates via PR**: OrcaSlicer profile updates now open a PR instead of pushing directly to main.
- **Immutable Docker tags**: Removed mutable `:latest` tags; all images tagged with version only.
- **TestPyPI on PRs**: New workflow publishes `.dev` packages to TestPyPI on every PR, so you can `pip install -i https://test.pypi.org/simple/ fabprint` to test before merging.

## New release process
```bash
# 1. Bump version in pyproject.toml and src/fabprint/__init__.py
# 2. Update CHANGELOG.md
# 3. Commit, merge PR
# 4. Tag and push:
git tag v0.1.131
git push origin v0.1.131
```

## Setup required
- Configure [TestPyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) for the `test-pypi.yml` workflow
- The `GH_PAT` secret can be removed from repo settings after merging

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm TestPyPI workflow runs and publishes a `.dev` package
- [ ] After merge, test a release by tagging `v0.1.131` and pushing
- [ ] Verify `GH_PAT` is no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)