### PR TITLE
Support PR comments when action is triggered via workflow_run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.134 — 2026-03-22
+
+- GitHub Action: support PR comments when triggered via `workflow_run` (looks up PR from commit SHA)
+
 ## 0.1.133 — 2026-03-22
 
 - Add `upside-down` orientation keyword: flips part 180° around X axis

--- a/action/README.md
+++ b/action/README.md
@@ -55,6 +55,7 @@ jobs:
 - STL/3MF/STEP model files referenced in your config
 - The GHCR package must be public, or you must authenticate with `docker login ghcr.io` before this action runs
 - If using the `comment` feature, your job needs `permissions: pull-requests: write`
+- PR comments work with both `pull_request` and `workflow_run` triggers (the action looks up the PR from the commit SHA)
 
 ## Supported OrcaSlicer versions
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -105,7 +105,7 @@ runs:
         if-no-files-found: warn
 
     - name: Post PR comment
-      if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ inputs.comment == 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_run') }}
       uses: actions/github-script@v7
       env:
         PRINT_TIME: ${{ steps.metrics.outputs.print-time }}
@@ -113,8 +113,29 @@ runs:
         ORCA_VERSION: ${{ inputs.orca-version }}
         PROJECT_NAME: ${{ steps.metrics.outputs.project-name }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        EVENT_NAME: ${{ github.event_name }}
+        WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
       with:
         script: |
+          // Resolve PR number — direct for pull_request, lookup for workflow_run
+          let prNumber;
+          if (process.env.EVENT_NAME === 'pull_request') {
+            prNumber = context.issue.number;
+          } else if (process.env.EVENT_NAME === 'workflow_run') {
+            const sha = process.env.WORKFLOW_RUN_SHA;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+            });
+            const openPr = prs.find(pr => pr.state === 'open');
+            if (!openPr) {
+              core.info(`No open PR found for SHA ${sha} — skipping comment`);
+              return;
+            }
+            prNumber = openPr.number;
+          }
+
           const printTime = process.env.PRINT_TIME || 'unknown';
           const filament = process.env.FILAMENT_GRAMS || 'unknown';
           const orcaVersion = process.env.ORCA_VERSION || 'unknown';
@@ -142,7 +163,7 @@ runs:
           const { data: comments } = await github.rest.issues.listComments({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            issue_number: context.issue.number,
+            issue_number: prNumber,
           });
           const existing = comments.find(c => c.body.includes(marker));
 
@@ -157,7 +178,7 @@ runs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: prNumber,
               body,
             });
           }


### PR DESCRIPTION
## Summary
- Action's PR comment feature now works with `workflow_run` triggers (not just `pull_request`)
- Looks up the PR from the commit SHA via `listPullRequestsAssociatedWithCommit`
- Silently skips if no open PR is found (e.g. push to main)
- Existing `pull_request` behavior unchanged

## Test plan
- [ ] CI passes
- [ ] Will be tested end-to-end via decoy-case repo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)