### PR TITLE
Pin VTK 9.3.x for STEP file support in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to fabprint are documented here.
 
+## 0.1.135 — 2026-03-22
+
+- Fix Docker image: pin VTK to 9.3.x for cadquery-ocp compatibility, enabling STEP file loading
+
 ## 0.1.134 — 2026-03-22
 
 - GitHub Action: support PR comments when triggered via `workflow_run` (looks up PR from commit SHA)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "requests>=2.28",
     "typer>=0.15.0",
     "build123d>=0.10.0",
+    "vtk>=9.3,<9.4",  # cadquery-ocp is compiled against VTK 9.3
     "watchfiles>=1.0.0",
     "questionary>=2.1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "fabprint"
-version = "0.1.121"
+version = "0.1.131"
 source = { editable = "." }
 dependencies = [
     { name = "bambu-lab-cloud-api" },
@@ -603,6 +603,7 @@ dependencies = [
     { name = "sf-hamilton" },
     { name = "trimesh", extra = ["easy"] },
     { name = "typer" },
+    { name = "vtk" },
     { name = "watchfiles" },
 ]
 
@@ -632,6 +633,7 @@ requires-dist = [
     { name = "sf-hamilton", specifier = ">=1.82.0" },
     { name = "trimesh", extras = ["easy"], specifier = ">=4.0.0" },
     { name = "typer", specifier = ">=0.15.0" },
+    { name = "vtk", specifier = ">=9.3,<9.4" },
     { name = "watchfiles", specifier = ">=1.0.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary
- Pin `vtk>=9.3,<9.4` in pyproject.toml
- cadquery-ocp is compiled against VTK 9.3 but uv resolves VTK 9.6, which ships incompatible shared library names
- Without this pin, `import build123d` fails in the Docker image with `ImportError: libvtkWrappingPythonCore3.12-9.3.so: cannot open shared object file`

## Test plan
- [x] Verified VTK 9.3.1 fixes the import in the Docker image
- [x] All local tests pass
- [ ] Rebuild Docker image after merge and test decoy-case slice workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)