### PR TITLE
Bump version to 0.1.135

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabprint"
-version = "0.1.131"
+version = "0.1.135"
 description = "Reproducible 3D print builds. Define parts, slicer settings, and printer targets in code."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fabprint/__init__.py
+++ b/src/fabprint/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__version__ = "0.1.131"
+__version__ = "0.1.135"
 
 
 class FabprintError(Exception):

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "fabprint"
-version = "0.1.131"
+version = "0.1.135"
 source = { editable = "." }
 dependencies = [
     { name = "bambu-lab-cloud-api" },


### PR DESCRIPTION
## Summary
Bump version to 0.1.135 to enable Docker image rebuild (PyPI rejects duplicate versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)