### PR TITLE
Bump version to 0.1.136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to fabprint are documented here.
 
-## 0.1.135 — 2026-03-22
+## 0.1.136 — 2026-03-22
 
 - Fix Docker image: override cadquery-ocp to 7.9+ for VTK 9.4+ compatibility, enabling STEP file loading
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabprint"
-version = "0.1.135"
+version = "0.1.136"
 description = "Reproducible 3D print builds. Define parts, slicer settings, and printer targets in code."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fabprint/__init__.py
+++ b/src/fabprint/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__version__ = "0.1.135"
+__version__ = "0.1.136"
 
 
 class FabprintError(Exception):

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ wheels = [
 
 [[package]]
 name = "fabprint"
-version = "0.1.135"
+version = "0.1.136"
 source = { editable = "." }
 dependencies = [
     { name = "bambu-lab-cloud-api" },


### PR DESCRIPTION
Version bump to enable Docker image rebuild with cadquery-ocp fix.