### PR TITLE
Add job summary to GitHub Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to fabprint are documented here.
 
 ## 0.1.138 — 2026-03-22
 
+- GitHub Action: add job summary with slice metrics (visible on every workflow run, not just PRs)
 - Expand GIF recording to 7 phases: setup, status, init, profiles-pin, validate, run, status-w
 - Add standalone `record_setup.py` for interactive setup recording
 - Add `profiles-pin` and `status` (quick check) as separate recorded phases

--- a/action/action.yml
+++ b/action/action.yml
@@ -113,6 +113,33 @@ runs:
         echo "gcode-path=${FULL_OUTPUT_DIR}" >> "$GITHUB_OUTPUT"
         echo "project-name=${PROJECT_NAME}" >> "$GITHUB_OUTPUT"
 
+    - name: Job summary
+      shell: bash
+      env:
+        PRINT_TIME: ${{ steps.metrics.outputs.print-time }}
+        FILAMENT: ${{ steps.metrics.outputs.filament-grams }}
+        LAYERS: ${{ steps.metrics.outputs.layer-count }}
+        FILAMENT_TYPES: ${{ steps.metrics.outputs.filament-types }}
+        FILAMENT_CHANGES: ${{ steps.metrics.outputs.filament-changes }}
+        PROJECT_NAME: ${{ steps.metrics.outputs.project-name }}
+        ORCA_VERSION: ${{ inputs.orca-version }}
+      run: |
+        TITLE="${PROJECT_NAME:+Fabprint: $PROJECT_NAME}"
+        TITLE="${TITLE:-Fabprint Slice Results}"
+        {
+          echo "### ${TITLE}"
+          echo ""
+          echo "| Metric | Value |"
+          echo "|--------|-------|"
+          [ -n "$PRINT_TIME" ] && echo "| Print time | ${PRINT_TIME} |"
+          [ -n "$FILAMENT" ] && echo "| Filament | ${FILAMENT}g |"
+          [ -n "$LAYERS" ] && echo "| Layers | ${LAYERS} |"
+          [ -n "$FILAMENT_TYPES" ] && echo "| Filament type | ${FILAMENT_TYPES} |"
+          [ -n "$FILAMENT_CHANGES" ] && [ "$FILAMENT_CHANGES" != "0" ] && echo "| Tool changes | ${FILAMENT_CHANGES} |"
+          echo ""
+          echo "Sliced with OrcaSlicer ${ORCA_VERSION}"
+        } >> "$GITHUB_STEP_SUMMARY"
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
## Summary
- Action writes slice metrics to `GITHUB_STEP_SUMMARY`
- Visible on every workflow run page (push to main, PRs, manual triggers)
- Shows same metrics as PR comment: print time, filament, layers, filament type, tool changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)