### PR TITLE
Upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --extra dev
       - run: uv run ruff check src tests
@@ -25,7 +25,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
         # 3.14 excluded: cadquery-ocp (build123d dep) lacks cp314 wheels
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -35,7 +35,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
@@ -50,7 +50,7 @@ jobs:
   build-bridge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compile cloud bridge
         run: g++ -std=c++17 -o bambu_cloud_bridge scripts/bambu_cloud_bridge.cpp -ldl -lpthread
       - name: Verify binary

--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -14,7 +14,7 @@ jobs:
       packages: write  # required for GHCR push
       pull-requests: write  # required for profile update PR
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -63,7 +63,7 @@ jobs:
             || echo "changed=false" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -16,7 +16,7 @@ jobs:
   slice:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Pull or build orca-base image
         run: |
@@ -40,7 +40,7 @@ jobs:
             slice "${{ inputs.config }}" -v
 
       - name: Upload gcode
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gcode
           path: |

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -12,10 +12,10 @@ jobs:
     permissions:
       id-token: write  # required for PyPI trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to fabprint are documented here.
 ## 0.1.138 — 2026-03-22
 
 - GitHub Action: add job summary with slice metrics (visible on every workflow run, not just PRs)
+- Upgrade all GitHub Actions to Node.js 24 versions (checkout v6, setup-python v6, upload-artifact v7, github-script v8)
 - Expand GIF recording to 7 phases: setup, status, init, profiles-pin, validate, run, status-w
 - Add standalone `record_setup.py` for interactive setup recording
 - Add `profiles-pin` and `status` (quick check) as separate recorded phases

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ jobs:
   slice:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pzfreo/fabprint@main
         with:
           orca-version: "2.3.1"

--- a/action/README.md
+++ b/action/README.md
@@ -18,7 +18,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pzfreo/fabprint/action@main
         with:
           config: fabprint.toml

--- a/action/action.yml
+++ b/action/action.yml
@@ -141,7 +141,7 @@ runs:
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: fabprint-${{ steps.metrics.outputs.project-name || 'output' }}
         path: ${{ inputs.output-dir }}/
@@ -149,7 +149,7 @@ runs:
 
     - name: Post PR comment
       if: ${{ inputs.comment == 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_run') }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         PRINT_TIME: ${{ steps.metrics.outputs.print-time }}
         FILAMENT_GRAMS: ${{ steps.metrics.outputs.filament-grams }}


### PR DESCRIPTION
## Summary
Upgrade all GitHub Actions to Node.js 24 compatible versions ahead of the June 2, 2026 deadline.

| Action | Old | New |
|--------|-----|-----|
| checkout | v4 | v6 |
| setup-python | v5 | v6 |
| upload-artifact | v4 | v7 |
| github-script | v7 | v8 |

Updated in: ci.yml, test-pypi.yml, publish-cloud-bridge.yml, slice.yml, action/action.yml, action/README.md, README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)