### PR TITLE
Auto-publish Docker and TestPyPI on push to main

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -1,12 +1,11 @@
-name: Publish packages and Docker images
+name: Release
 
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch:
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -21,15 +20,10 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          else
-            VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          fi
+          VERSION="${GITHUB_REF_NAME#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Verify tag matches pyproject.toml version
-        if: github.ref_type == 'tag'
         run: |
           TOML_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           TAG_VERSION="${GITHUB_REF_NAME#v}"
@@ -37,30 +31,6 @@ jobs:
             echo "::error::Tag $TAG_VERSION does not match pyproject.toml version $TOML_VERSION"
             exit 1
           fi
-
-      - name: Check if cloud-bridge Docker rebuild needed
-        id: bridge_changed
-        run: |
-          git diff ${{ github.sha }}^1 ${{ github.sha }} --name-only \
-            | grep -qE 'Dockerfile\.cloud-bridge|scripts/bambu_cloud_bridge\.cpp' \
-            && echo "changed=true" >> "$GITHUB_OUTPUT" \
-            || echo "changed=false" >> "$GITHUB_OUTPUT"
-
-      - name: Check if orca-base Docker rebuild needed
-        id: base_changed
-        run: |
-          git diff ${{ github.sha }}^1 ${{ github.sha }} --name-only \
-            | grep -qE '^Dockerfile\.orca-base$' \
-            && echo "changed=true" >> "$GITHUB_OUTPUT" \
-            || echo "changed=false" >> "$GITHUB_OUTPUT"
-
-      - name: Check if OrcaSlicer Docker rebuild needed
-        id: orca_changed
-        run: |
-          git diff ${{ github.sha }}^1 ${{ github.sha }} --name-only \
-            | grep -qE '^Dockerfile$|^src/fabprint/|^pyproject\.toml$' \
-            && echo "changed=true" >> "$GITHUB_OUTPUT" \
-            || echo "changed=false" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -76,14 +46,12 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Log in to Docker Hub
-        if: steps.bridge_changed.outputs.changed == 'true' || steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GitHub Container Registry
-        if: steps.bridge_changed.outputs.changed == 'true' || steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -91,11 +59,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        if: steps.bridge_changed.outputs.changed == 'true' || steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push cloud-bridge
-        if: steps.bridge_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -109,7 +75,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push orca-base image
-        if: steps.base_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -123,8 +88,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and push OrcaSlicer image
-        if: steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+      - name: Build and push fabprint image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -141,12 +105,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Extract OrcaSlicer profiles from Docker image
-        if: steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           python scripts/extract_profiles.py 2.3.1 --image fabprint/fabprint:orca-2.3.1
 
       - name: Open PR for bundled profile updates
-        if: steps.base_changed.outputs.changed == 'true' || steps.orca_changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           git diff --quiet src/fabprint/data/ && echo "No profile changes" && exit 0
           BRANCH="update-orca-profiles-${{ steps.version.outputs.version }}"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,112 @@
+name: Publish Docker images
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Check if cloud-bridge rebuild needed
+        id: bridge_changed
+        run: |
+          git diff HEAD~1 HEAD --name-only \
+            | grep -qE 'Dockerfile\.cloud-bridge|scripts/bambu_cloud_bridge\.cpp' \
+            && echo "changed=true" >> "$GITHUB_OUTPUT" \
+            || echo "changed=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check if orca-base rebuild needed
+        id: base_changed
+        run: |
+          git diff HEAD~1 HEAD --name-only \
+            | grep -qE '^Dockerfile\.orca-base$' \
+            && echo "changed=true" >> "$GITHUB_OUTPUT" \
+            || echo "changed=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check if fabprint image rebuild needed
+        id: fabprint_changed
+        run: |
+          git diff HEAD~1 HEAD --name-only \
+            | grep -qE '^Dockerfile$|^src/fabprint/|^pyproject\.toml$|^uv\.lock$' \
+            && echo "changed=true" >> "$GITHUB_OUTPUT" \
+            || echo "changed=false" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if no Docker-relevant changes
+        id: should_build
+        run: |
+          if [[ "${{ steps.bridge_changed.outputs.changed }}" == "true" || \
+                "${{ steps.base_changed.outputs.changed }}" == "true" || \
+                "${{ steps.fabprint_changed.outputs.changed }}" == "true" ]]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "No Docker-relevant changes — skipping rebuild"
+          fi
+
+      - name: Log in to Docker Hub
+        if: steps.should_build.outputs.build == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        if: steps.should_build.outputs.build == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.should_build.outputs.build == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push cloud-bridge
+        if: steps.bridge_changed.outputs.changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.cloud-bridge
+          platforms: linux/amd64
+          push: true
+          tags: fabprint/cloud-bridge:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push orca-base
+        if: steps.base_changed.outputs.changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.orca-base
+          platforms: linux/amd64
+          push: true
+          tags: |
+            fabprint/orca-base:2.3.1
+            ghcr.io/${{ github.repository }}/orca-base:2.3.1
+          build-args: ORCA_VERSION=2.3.1
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push fabprint image
+        if: steps.fabprint_changed.outputs.changed == 'true' || steps.base_changed.outputs.changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            fabprint/fabprint:orca-2.3.1
+            ghcr.io/${{ github.repository }}:orca-2.3.1
+          build-args: ORCA_VERSION=2.3.1
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -1,6 +1,8 @@
 name: Publish to TestPyPI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to fabprint are documented here.
 - Add `fabprint status --clear` to clear FAILED state (sends resume command)
 - Add `fabprint status --cancel` to cancel the current print job
 - Supports bambu-cloud (via MQTT) and moonraker printers
+- Auto-publish: push to main rebuilds Docker images and publishes to TestPyPI
+- Split release workflow: tags publish to real PyPI with immutable Docker tags
 
 ## 0.1.139 — 2026-03-22
 


### PR DESCRIPTION
## Summary

Two publishing processes:

### Push to main (automatic)
- **TestPyPI**: publishes `.dev` package for testing
- **Docker**: rebuilds images with mutable tags (`orca-2.3.1`) when relevant files change
- No version bump needed

### Release (tag `v*`)
- **PyPI**: publishes release version
- **Docker**: tags images immutably with version number (e.g. `0.1.140`)
- **Profiles**: extracts and PRs profile updates
- Requires version bump in `pyproject.toml` matching the tag

## Changes
- New `publish-docker.yml` for push-to-main Docker rebuilds
- `publish-cloud-bridge.yml` simplified to release-only (tags)
- `test-pypi.yml` now also triggers on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)