### PR TITLE
Update docs: status flags, profiles_dir, release process

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -179,10 +179,10 @@ You cannot combine `--until` and `--only`.
 
 ## `fabprint status`
 
-Query printer status.
+Query printer status, clear errors, or cancel jobs.
 
 ```
-fabprint status [--printer NAME] [--watch] [--interval SECONDS]
+fabprint status [--printer NAME] [--watch] [--interval SECONDS] [--clear] [--cancel]
 ```
 
 | Option              | Description                                      |
@@ -190,8 +190,19 @@ fabprint status [--printer NAME] [--watch] [--interval SECONDS]
 | `--printer NAME`    | Query a specific printer (default: all)          |
 | `-w, --watch`       | Live dashboard mode with auto-refresh            |
 | `--interval SECONDS`| Refresh interval in watch mode (default: 10)     |
+| `--clear`           | Clear FAILED state (sends resume, returns to IDLE) |
+| `--cancel`          | Cancel the current print job                     |
 
 Without `--printer`, shows all configured printers. Add `-w` for a live dashboard.
+
+### Examples
+
+```bash
+fabprint status                             # show all printers
+fabprint status --printer workshop -w       # live dashboard for one printer
+fabprint status --printer workshop --cancel # stop current print
+fabprint status --printer workshop --clear  # clear FAILED → IDLE
+```
 
 ## `fabprint watch`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -136,13 +136,14 @@ Build plate dimensions for bin-packing.
 
 Slicer engine and profile selection.
 
-| Key         | Type       | Default  | Description                                                |
-|-------------|------------|----------|------------------------------------------------------------|
-| `engine`    | `string`   | `"orca"` | Slicer engine (`"orca"`)                                   |
-| `version`   | `string`   | —        | Required OrcaSlicer version (e.g. `"2.3.1"`)               |
-| `printer`   | `string`   | —        | Printer profile name                                       |
-| `process`   | `string`   | —        | Process profile name                                       |
-| `filaments` | `[string]` | —        | Filament profiles (auto-derived from parts if omitted)     |
+| Key            | Type       | Default      | Description                                                |
+|----------------|------------|--------------|-------------------------------------------------------------|
+| `engine`       | `string`   | `"orca"`     | Slicer engine (`"orca"`)                                   |
+| `version`      | `string`   | —            | Required OrcaSlicer version (e.g. `"2.3.1"`)               |
+| `printer`      | `string`   | —            | Printer profile name                                       |
+| `process`      | `string`   | —            | Process profile name                                       |
+| `filaments`    | `[string]` | —            | Filament profiles (auto-derived from parts if omitted)     |
+| `profiles_dir` | `string`   | `"profiles"` | Directory for pinned profiles (relative to config file)    |
 
 ### `[slicer.slots]`
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -27,6 +27,35 @@ Before pushing a PR branch:
 2. `uv run ruff format --check src tests` — formatting must pass
 3. `uv run pytest` — all tests must pass
 
+## Publishing
+
+Two automated pipelines handle publishing:
+
+### Push to main (automatic)
+
+Every merge to main triggers:
+- **TestPyPI** — publishes a `.dev` package (e.g. `0.1.140.dev42`)
+- **Docker** — rebuilds images with mutable tags (`orca-2.3.1`) when relevant files change
+
+No version bump needed for day-to-day work.
+
+### Release (tag)
+
+To publish a release:
+
+```bash
+# 1. Bump version in pyproject.toml and src/fabprint/__init__.py
+# 2. Update CHANGELOG.md
+# 3. Commit, tag, and push
+git tag v0.1.141
+git push origin v0.1.141
+```
+
+This triggers:
+- **PyPI** — publishes the release version
+- **Docker** — tags images immutably (e.g. `fabprint/fabprint:0.1.141`)
+- **Profiles** — extracts slicer profiles and opens a PR if changed
+
 ## Docker images
 
 Pre-built OrcaSlicer images are on [Docker Hub](https://hub.docker.com/r/fabprint/fabprint). To build your own:


### PR DESCRIPTION
## Summary
- **cli.md**: document `--clear` and `--cancel` flags with examples
- **config.md**: add `profiles_dir` to `[slicer]` reference table
- **developing.md**: document push-to-main auto-publish and tag-based release workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)