### PR TITLE
Clean up Docker tag scheme

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -70,6 +70,7 @@ jobs:
           push: true
           tags: |
             fabprint/cloud-bridge:${{ steps.version.outputs.version }}
+            fabprint/cloud-bridge:latest
             ghcr.io/${{ github.repository }}/cloud-bridge:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -96,9 +97,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            fabprint/fabprint:${{ steps.version.outputs.version }}
+            fabprint/fabprint:orca-2.3.1-${{ steps.version.outputs.version }}
             fabprint/fabprint:orca-2.3.1
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}:orca-2.3.1-${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}:orca-2.3.1
           build-args: ORCA_VERSION=2.3.1
           cache-from: type=gha


### PR DESCRIPTION
## Summary

| Image | Push to main | Release (tag v*) |
|-------|-------------|------------------|
| fabprint | `:orca-2.3.1` (mutable) | `:orca-2.3.1-0.1.140` (immutable) + `:orca-2.3.1` |
| cloud-bridge | `:latest` (mutable) | `:0.1.140` (immutable) + `:latest` |

No `:latest` for the fabprint image — slicer version always explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)