### PR TITLE
Fix status --watch: skip non-JSON bridge output

### DIFF
--- a/src/fabprint/cloud/bridge.py
+++ b/src/fabprint/cloud/bridge.py
@@ -257,8 +257,13 @@ class PersistentBridge:
             self._proc = None
 
     def status(self, device_id: str = "", *, timeout: int = BRIDGE_STATUS_TIMEOUT) -> dict:
-        """Send a status query and read the JSON response."""
+        """Send a status query and read the JSON response.
+
+        The bridge may output non-JSON lines (MQTT debug messages, keepalives).
+        Read lines until we get valid JSON or timeout.
+        """
         import selectors
+        import time as _time
 
         assert self._proc is not None
         assert self._proc.stdin is not None
@@ -266,20 +271,30 @@ class PersistentBridge:
         self._proc.stdin.write("status\n")
         self._proc.stdin.flush()
 
+        deadline = _time.monotonic() + timeout
         sel = selectors.DefaultSelector()
         sel.register(self._proc.stdout, selectors.EVENT_READ)
-        ready = sel.select(timeout=timeout)
-        sel.close()
-        if not ready:
-            raise RuntimeError("Status query timed out")
-        line = self._proc.stdout.readline()
         try:
-            data = json.loads(line.strip())
-            if "error" in data:
-                raise RuntimeError(f"Bridge error: {data['error']}")
-            return data.get("print", data)
-        except json.JSONDecodeError:
-            raise RuntimeError(f"Bridge returned non-JSON: {line[:200]}")
+            while True:
+                remaining = deadline - _time.monotonic()
+                if remaining <= 0:
+                    raise RuntimeError("Status query timed out")
+                ready = sel.select(timeout=remaining)
+                if not ready:
+                    raise RuntimeError("Status query timed out")
+                line = self._proc.stdout.readline()
+                if not line:
+                    raise RuntimeError("Bridge process ended unexpectedly")
+                try:
+                    data = json.loads(line.strip())
+                    if "error" in data:
+                        raise RuntimeError(f"Bridge error: {data['error']}")
+                    return data.get("print", data)
+                except json.JSONDecodeError:
+                    log.debug("Skipping non-JSON bridge output: %s", line.strip()[:100])
+                    continue
+        finally:
+            sel.close()
 
 
 def cloud_print(

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -258,8 +258,13 @@ class TestPersistentBridge:
                 with pytest.raises(RuntimeError, match="timed out"):
                     bridge.status(timeout=5)
 
-    def test_status_non_json_raises(self, token_file):
-        mock_proc = self._make_mock_proc(status_line="not json at all\n")
+    def test_status_non_json_then_eof_raises(self, token_file):
+        """Non-JSON output followed by EOF should raise."""
+        mock_proc = self._make_mock_proc()
+        # After ready line: non-JSON, then empty (EOF)
+        mock_proc.stdout.readline = MagicMock(
+            side_effect=['{"ready":true}\n', "not json at all\n", ""]
+        )
 
         mock_sel = MagicMock()
         mock_sel.select.return_value = [True]
@@ -269,8 +274,28 @@ class TestPersistentBridge:
             patch("selectors.DefaultSelector", return_value=mock_sel),
         ):
             with PersistentBridge(token_file, "DEV123") as bridge:
-                with pytest.raises(RuntimeError, match="non-JSON"):
+                with pytest.raises(RuntimeError, match="ended unexpectedly"):
                     bridge.status()
+
+    def test_status_skips_non_json_lines(self, token_file):
+        """Non-JSON lines should be skipped, valid JSON returned."""
+        status_json = '{"print":{"gcode_state":"RUNNING"}}\n'
+        mock_proc = self._make_mock_proc()
+        # After ready line: debug line, then valid JSON
+        mock_proc.stdout.readline = MagicMock(
+            side_effect=['{"ready":true}\n', "mqtt keepalive\n", status_json]
+        )
+
+        mock_sel = MagicMock()
+        mock_sel.select.return_value = [True]
+
+        with (
+            patch("fabprint.cloud.bridge.subprocess.Popen", return_value=mock_proc),
+            patch("selectors.DefaultSelector", return_value=mock_sel),
+        ):
+            with PersistentBridge(token_file, "DEV123") as bridge:
+                result = bridge.status()
+                assert result["gcode_state"] == "RUNNING"
 
     def test_token_file_mounted_readonly(self, token_file):
         """Token file should be mounted as read-only in the container."""


### PR DESCRIPTION
## Summary
PersistentBridge.status() was failing on the second poll because the bridge outputs non-JSON lines (MQTT debug messages, keepalives) between status responses.

Fix: read lines in a loop until valid JSON is found, skipping non-JSON lines. Times out if no valid JSON arrives within the timeout period.

## Test plan
- [x] All 519 tests pass
- [x] Updated existing non-JSON test, added test for skip-then-succeed
- [ ] Test `fabprint status -w` during a live print

🤖 Generated with [Claude Code](https://claude.com/claude-code)