### PR TITLE
Fix: make orca-base immutable on push to main

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       bridge: ${{ steps.check.outputs.bridge }}
-      base: ${{ steps.check.outputs.base }}
       fabprint: ${{ steps.check.outputs.fabprint }}
     steps:
       - uses: actions/checkout@v6
@@ -22,8 +21,6 @@ jobs:
           CHANGED=$(git diff HEAD~1 HEAD --name-only)
           echo "$CHANGED" | grep -qE 'Dockerfile\.cloud-bridge|scripts/bambu_cloud_bridge\.cpp' \
             && echo "bridge=true" >> "$GITHUB_OUTPUT" || echo "bridge=false" >> "$GITHUB_OUTPUT"
-          echo "$CHANGED" | grep -qE '^Dockerfile\.orca-base$' \
-            && echo "base=true" >> "$GITHUB_OUTPUT" || echo "base=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -qE '^Dockerfile$|^src/fabprint/|^pyproject\.toml$|^uv\.lock$' \
             && echo "fabprint=true" >> "$GITHUB_OUTPUT" || echo "fabprint=false" >> "$GITHUB_OUTPUT"
 
@@ -55,9 +52,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  orca-images:
+  # Only rebuild the fabprint Python layer on push to main.
+  # The orca-base image is immutable per OrcaSlicer version and only
+  # rebuilt on release tags (publish-cloud-bridge.yml) to ensure
+  # reproducible slicer behavior.
+  fabprint-images:
     needs: detect-changes
-    if: needs.detect-changes.outputs.base == 'true' || needs.detect-changes.outputs.fabprint == 'true'
+    if: needs.detect-changes.outputs.fabprint == 'true'
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -76,21 +77,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v3
-
-      - name: Build and push orca-base
-        if: needs.detect-changes.outputs.base == 'true'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.orca-base
-          platforms: linux/amd64
-          push: true
-          tags: |
-            fabprint/orca-base:${{ matrix.orca-version }}
-            ghcr.io/${{ github.repository }}/orca-base:${{ matrix.orca-version }}
-          build-args: ORCA_VERSION=${{ matrix.orca-version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Build and push fabprint image
         uses: docker/build-push-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 All notable changes to fabprint are documented here.
 
-## 0.1.141 — 2026-03-23
+## 0.1.141 — 2026-03-24
 
 - Add OrcaSlicer 2.3.2 support (new default); 2.3.1 remains available
 - Docker publish workflows use matrix strategy to build both versions in parallel
 - Release workflow split into separate jobs for PyPI, Docker images, and profile extraction
+- Fix: orca-base images are now immutable — only rebuilt on release tags, not push to main
+  (prevents accidental slicer behavior changes from system package updates)
 
 ## 0.1.140 — 2026-03-22
 


### PR DESCRIPTION
## Problem
The orca-2.3.2 PR changed `Dockerfile.orca-base` (ARG default), which triggered a full orca-base rebuild for both versions. The rebuilt orca-base:2.3.1 image has different system packages, causing OrcaSlicer to reject profiles that previously worked ("Relative extruder addressing requires G92 E0").

This breaks reproducible builds — the core promise of fabprint.

## Fix
Remove orca-base from the push-to-main workflow entirely. Push-to-main now only rebuilds the fabprint Python layer on top of the existing (immutable) orca-base images.

orca-base is only rebuilt on release tags via `publish-cloud-bridge.yml`.

## Still needed
The current orca-base:2.3.1 image on Docker Hub/GHCR is the broken one. We need to either:
1. Restore it from a previous digest, or
2. Rebuild it in a controlled way and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)