### PR TITLE
Switch CHANGELOG to Unreleased pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here.
 
-## 0.2.0 — 2026-03-29
+## Unreleased
 
 **Project renamed from `fabprint` to `estampo`.**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,15 @@ Do NOT push a PR until all four checks pass locally.
 
 ## Changelog (MANDATORY)
 Every PR must include a CHANGELOG.md update:
-1. Check the latest published version: `curl -s https://pypi.org/pypi/estampo/json | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])"`
-2. Add an entry at the top of CHANGELOG.md under a new version heading
-3. Use the format: `## <next-version> — YYYY-MM-DD`
-4. Bump the patch version from the latest on PyPI (e.g. 0.1.73 → 0.1.74)
-5. Use today's date
-6. List changes as bullet points — concise, user-facing descriptions
+1. Add bullet points under the `## Unreleased` section at the top of CHANGELOG.md
+2. If `## Unreleased` doesn't exist, create it above the latest version heading
+3. List changes as bullet points — concise, user-facing descriptions
+4. Do NOT assign a version number — that happens at release time
+
+At release time (not during normal PRs):
+1. Rename `## Unreleased` to `## <version> — YYYY-MM-DD`
+2. Bump `version` in `pyproject.toml` to match
+3. Tag with `v<version>` to trigger the Release workflow (publishes to PyPI)
 
 ## Post-PR Checklist (MANDATORY)
 After pushing a PR or merging to main:


### PR DESCRIPTION
## Summary
- CHANGELOG now uses `## Unreleased` at the top instead of pre-assigning version numbers
- CLAUDE.md updated: PRs add bullets under Unreleased, version numbers assigned at release time
- Aligns with the two publishing flows: TestPyPI (auto `.dev` on push to main) and PyPI (on `v*` tags)

## Test plan
- [ ] Verify CLAUDE.md instructions are clear
- [ ] Future PRs use `## Unreleased` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)