### PR TITLE
Update color logo to dark teal palette

### DIFF
--- a/docs/estampo-logo-color.svg
+++ b/docs/estampo-logo-color.svg
@@ -3,44 +3,44 @@
 <title>Estampo Logo</title>
 <rect width="352" height="414" fill="white"/>
 <!-- Layer 1: dark teal (drawn first, outermost coloured layer) -->
-<rect x="61" y="38" width="6" height="156" fill="#164E63"/>
-<rect x="60" y="194" width="8" height="165" fill="#164E63"/>
-<rect x="61" y="38" width="239" height="6" fill="#164E63"/>
-<rect x="60" y="352" width="240" height="7" fill="#164E63"/>
-<rect x="60" y="359" width="228" height="1" fill="#164E63"/>
-<rect x="288" y="359" width="12" height="1" fill="#164E63"/>
+<rect x="61" y="38" width="6" height="156" fill="#063530"/>
+<rect x="60" y="194" width="8" height="165" fill="#063530"/>
+<rect x="61" y="38" width="239" height="6" fill="#063530"/>
+<rect x="60" y="352" width="240" height="7" fill="#063530"/>
+<rect x="60" y="359" width="228" height="1" fill="#063530"/>
+<rect x="288" y="359" width="12" height="1" fill="#063530"/>
 <!-- Layer 2: medium teal -->
-<rect x="74" y="52" width="6" height="148" fill="#0E7490"/>
-<rect x="73" y="200" width="8" height="147" fill="#0E7490"/>
-<rect x="74" y="52" width="226" height="5" fill="#0E7490"/>
-<rect x="73" y="339" width="227" height="8" fill="#0E7490"/>
-<rect x="74" y="193" width="199" height="1" fill="#0E7490"/>
-<rect x="73" y="194" width="200" height="6" fill="#0E7490"/>
-<!-- Layer 3: bright teal -->
-<rect x="87" y="65" width="6" height="115" fill="#0891B2"/>
-<rect x="86" y="214" width="8" height="120" fill="#0891B2"/>
-<rect x="87" y="65" width="213" height="6" fill="#0891B2"/>
-<rect x="86" y="326" width="214" height="7" fill="#0891B2"/>
-<rect x="87" y="333" width="213" height="1" fill="#0891B2"/>
-<rect x="87" y="180" width="186" height="7" fill="#0891B2"/>
-<rect x="88" y="187" width="185" height="1" fill="#0891B2"/>
-<rect x="86" y="206" width="187" height="8" fill="#0891B2"/>
-<!-- Layer 4: vivid cyan (drawn last among coloured layers, innermost) -->
-<rect x="99" y="77" width="12" height="86" fill="#06B6D4"/>
-<rect x="99" y="230" width="12" height="80" fill="#06B6D4"/>
-<rect x="99" y="78" width="201" height="10" fill="#06B6D4"/>
-<rect x="100" y="77" width="189" height="1" fill="#06B6D4"/>
-<rect x="99" y="310" width="201" height="10" fill="#06B6D4"/>
-<rect x="100" y="320" width="200" height="1" fill="#06B6D4"/>
-<rect x="261" y="163" width="12" height="67" fill="#06B6D4"/>
-<rect x="99" y="163" width="173" height="1" fill="#06B6D4"/>
-<rect x="99" y="164" width="174" height="10" fill="#06B6D4"/>
-<rect x="100" y="174" width="173" height="1" fill="#06B6D4"/>
-<rect x="99" y="219" width="174" height="11" fill="#06B6D4"/>
+<rect x="74" y="52" width="6" height="148" fill="#094A44"/>
+<rect x="73" y="200" width="8" height="147" fill="#094A44"/>
+<rect x="74" y="52" width="226" height="5" fill="#094A44"/>
+<rect x="73" y="339" width="227" height="8" fill="#094A44"/>
+<rect x="74" y="193" width="199" height="1" fill="#094A44"/>
+<rect x="73" y="194" width="200" height="6" fill="#094A44"/>
+<!-- Layer 3: teal -->
+<rect x="87" y="65" width="6" height="115" fill="#0C5F58"/>
+<rect x="86" y="214" width="8" height="120" fill="#0C5F58"/>
+<rect x="87" y="65" width="213" height="6" fill="#0C5F58"/>
+<rect x="86" y="326" width="214" height="7" fill="#0C5F58"/>
+<rect x="87" y="333" width="213" height="1" fill="#0C5F58"/>
+<rect x="87" y="180" width="186" height="7" fill="#0C5F58"/>
+<rect x="88" y="187" width="185" height="1" fill="#0C5F58"/>
+<rect x="86" y="206" width="187" height="8" fill="#0C5F58"/>
+<!-- Layer 4: lightest teal (drawn last among coloured layers, innermost) -->
+<rect x="99" y="77" width="12" height="86" fill="#0F766E"/>
+<rect x="99" y="230" width="12" height="80" fill="#0F766E"/>
+<rect x="99" y="78" width="201" height="10" fill="#0F766E"/>
+<rect x="100" y="77" width="189" height="1" fill="#0F766E"/>
+<rect x="99" y="310" width="201" height="10" fill="#0F766E"/>
+<rect x="100" y="320" width="200" height="1" fill="#0F766E"/>
+<rect x="261" y="163" width="12" height="67" fill="#0F766E"/>
+<rect x="99" y="163" width="173" height="1" fill="#0F766E"/>
+<rect x="99" y="164" width="174" height="10" fill="#0F766E"/>
+<rect x="100" y="174" width="173" height="1" fill="#0F766E"/>
+<rect x="99" y="219" width="174" height="11" fill="#0F766E"/>
 <!-- Layer 0 frame: drawn last so it sits on top -->
-<rect x="43" y="20" width="11" height="356" fill="#0F172A"/>
-<rect x="43" y="20" width="257" height="12" fill="#0F172A"/>
-<rect x="43" y="365" width="257" height="11" fill="#0F172A"/>
-<rect x="289" y="20" width="11" height="68" fill="#0F172A"/>
-<rect x="289" y="310" width="11" height="66" fill="#0F172A"/>
+<rect x="43" y="20" width="11" height="356" fill="#042F2E"/>
+<rect x="43" y="20" width="257" height="12" fill="#042F2E"/>
+<rect x="43" y="365" width="257" height="11" fill="#042F2E"/>
+<rect x="289" y="20" width="11" height="68" fill="#042F2E"/>
+<rect x="289" y="310" width="11" height="66" fill="#042F2E"/>
 </svg>


### PR DESCRIPTION
## Summary
- Remap all logo colors to a dark teal gradient (#042F2E → #0F766E)
- 5 evenly spaced shades from near-black to teal-700
- More subtle and cohesive than the previous cyan/teal mix

## Test plan
- [ ] Visual check of SVG rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)