### PR TITLE
Fix Docker publish job ordering

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -95,8 +95,8 @@ jobs:
 
   # Rebuild the estampo Python layer on push to main or manual dispatch.
   estampo-images:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.estampo == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [detect-changes, orca-base]
+    if: always() && !failure() && (needs.detect-changes.outputs.estampo == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
## Summary
- Add `needs: [detect-changes, orca-base]` to estampo-images job
- Prevents race where estampo image build starts before orca-base is pushed
- Uses `always() && !failure()` so normal pushes (orca-base skipped) still work

## Test plan
- [ ] `workflow_dispatch` with `rebuild-base=true` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)