### PR TITLE
Fix profiles extraction Docker image tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased
+
+- Fix profiles extraction: use correct Docker image tag format (`orca-<version>`)
+
 ## 0.2.0 — 2026-03-29
 
 **Project renamed from `fabprint` to `estampo`.**

--- a/scripts/extract_profiles.py
+++ b/scripts/extract_profiles.py
@@ -72,7 +72,7 @@ def main() -> None:
     parser.add_argument("versions", nargs="+", help="OrcaSlicer version(s) to extract")
     parser.add_argument(
         "--image",
-        help="Docker image to use (default: estampo/estampo:<version>). "
+        help="Docker image to use (default: estampo/estampo:orca-<version>). "
         "Only valid when a single version is given.",
     )
     args = parser.parse_args()
@@ -83,7 +83,7 @@ def main() -> None:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
     for version in args.versions:
-        image = args.image or f"estampo/estampo:{version}"
+        image = args.image or f"estampo/estampo:orca-{version}"
         data = extract(version, image)
         out = OUT_DIR / f"profiles.orca.{version}.json"
         out.write_text(json.dumps(data, indent=2) + "\n")


### PR DESCRIPTION
## Summary
- Fix `scripts/extract_profiles.py` default image tag from `estampo/estampo:<version>` to `estampo/estampo:orca-<version>`, matching the actual Docker tag format
- This caused the profiles job to fail during the v0.2.0 release

## Test plan
- [ ] Verify next release's profiles job pulls the correct image

🤖 Generated with [Claude Code](https://claude.com/claude-code)