### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here.
 
-## Unreleased
+## 0.2.1 — 2026-03-29
 
 - Fix profiles extraction: use correct Docker image tag format (`orca-<version>`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estampo"
-version = "0.2.0"
+version = "0.2.1"
 description = "Reproducible 3D print builds. Define parts, slicer settings, and printer targets in code."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Patch release to trigger the profiles extraction pipeline with the corrected Docker image tag format from #221
- v0.2.0 shipped without bundled profiles because the profiles job failed due to the wrong tag — this broke interactive profile selection in `estampo init` for Docker-based users

## Test plan
- [ ] CI passes
- [ ] After merge and tag, verify the profiles job succeeds and opens a PR with bundled profile data

🤖 Generated with [Claude Code](https://claude.com/claude-code)