### PR TITLE
Fix release-readiness downstream jobs skipped on workflow_dispatch

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -94,6 +94,7 @@ jobs:
 
   smoke-test:
     needs: build-estampo-image
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v7
@@ -115,6 +116,7 @@ jobs:
 
   profile-extraction:
     needs: build-estampo-image
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -159,6 +161,7 @@ jobs:
 
   slice-test:
     needs: build-estampo-image
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add `if: always() && !failure() && !cancelled()` to smoke-test, profile-extraction, and slice-test jobs
- Without this, the `detect-changes` job being skipped on `workflow_dispatch` caused all downstream jobs to skip via the `needs` chain

## Test plan
- [ ] Merge and re-trigger `release-readiness` via workflow_dispatch — all 5 jobs should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)