### PR TITLE
Fix release-readiness e2e failures

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Test estampo CLI
         run: |
           docker run --rm estampo/estampo:orca-${{ env.ORCA_VERSION }}-test --help
-          docker run --rm estampo/estampo:orca-${{ env.ORCA_VERSION }}-test slice --help
+          docker run --rm estampo/estampo:orca-${{ env.ORCA_VERSION }}-test run --help
 
       - name: Test OrcaSlicer accessible
         run: |
@@ -179,7 +179,7 @@ jobs:
             -v "${{ github.workspace }}:/project" \
             -w /project/examples \
             estampo/estampo:orca-${{ env.ORCA_VERSION }}-test \
-            slice estampo.toml -v
+            run estampo.toml -v
 
       - name: Verify output
         run: |

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -37,7 +37,7 @@ jobs:
           docker run --rm \
             -v "${{ github.workspace }}:/project" \
             estampo:orca-${{ inputs.orca_version }} \
-            slice "${{ inputs.config }}" -v
+            run "${{ inputs.config }}" -v
 
       - name: Upload gcode
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project are documented here.
 - Consolidate Docker image tag construction into single `docker_image()` function in `slicer.py`
 - Add consistency test to catch Docker image tag drift across the codebase
 - Add release-readiness workflow: e2e Docker build, smoke test, profile extraction, and real slice test
+- Fix Docker CLI command: `slice` -> `run` in workflows, Dockerfile comment
+- Fix profile extraction: use direct path instead of symlink in Docker container
 
 ## 0.2.1 — 2026-03-29
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   docker build --build-arg ORCA_VERSION=2.3.1 -t estampo/estampo:orca-2.3.1 .
-#   docker run --rm -v "$PWD:/project" estampo/estampo:orca-2.3.1 slice estampo.toml
+#   docker run --rm -v "$PWD:/project" estampo/estampo:orca-2.3.1 run estampo.toml
 
 ARG ORCA_VERSION=2.3.1
 FROM estampo/orca-base:${ORCA_VERSION}

--- a/scripts/extract_profiles.py
+++ b/scripts/extract_profiles.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from estampo.slicer import docker_image
 
-PROFILE_ROOT = "/home/estampo/.config/OrcaSlicer/system/BBL"
+PROFILE_ROOT = "/opt/orca-slicer/resources/profiles/BBL"
 CATEGORIES = ("machine", "process", "filament")
 OUT_DIR = Path(__file__).parent.parent / "src" / "estampo" / "data"
 


### PR DESCRIPTION
## Summary
Three fixes uncovered by the first release-readiness e2e run:

1. **CLI command is `run`, not `slice`** — fixed in `release-readiness.yml`, `slice.yml`, and `Dockerfile` usage comment. The `slice.yml` workflow was also broken by this.
2. **Profile extraction returned empty lists** — `extract_profiles.py` used the symlink path `/home/estampo/.config/OrcaSlicer/system/BBL` which `find(1)` doesn't traverse by default. Switched to the direct path `/opt/orca-slicer/resources/profiles/BBL`.

## Test plan
- [ ] CI passes
- [ ] After merge, re-trigger release-readiness workflow — all 5 jobs should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)