### PR TITLE
Fix e2e slice test profile compatibility

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -183,12 +183,12 @@ jobs:
 
       - name: Verify output
         run: |
-          echo "Checking for gcode output..."
-          ls -la examples/output/*.gcode
+          echo "Checking for slice output..."
+          ls -la examples/estampo_output/
           echo "Slice test OK"
 
       - uses: actions/upload-artifact@v7
         with:
           name: slice-output
-          path: examples/output/
+          path: examples/estampo_output/
           retention-days: 5

--- a/examples/estampo.toml
+++ b/examples/estampo.toml
@@ -7,8 +7,9 @@ padding = 5.0
 
 [slicer]
 engine = "orca"
+version = "2.3.1"
 printer = "Bambu Lab P1S 0.4 nozzle"
-process = "0.20mm Standard @BBL X1C"
+process = "0.20mm Standard @BBL P1S"
 [[parts]]
 file = "../tests/fixtures/cube_10mm.stl"
 copies = 4


### PR DESCRIPTION
## Summary
- Switch example config process profile from `0.20mm Standard @BBL X1C` to `0.20mm Standard @BBL P1S` — the X1C profile has `G92 E0` in `layer_gcode` which OrcaSlicer 2.3.1 rejects with exit code 205
- Pin `version = "2.3.1"` in example slicer config for reproducibility
- Fix output directory path in release-readiness verify step (`estampo_output/` not `output/`)

## Test plan
- [ ] CI passes
- [ ] After merge, re-trigger release-readiness — all 5 jobs should pass green

🤖 Generated with [Claude Code](https://claude.com/claude-code)