### PR TITLE
Document release-readiness workflow and slicer architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,37 @@ After pushing a PR or merging to main:
 1. Check GitHub Actions CI status with `gh run list --limit 3`
 2. If any run fails, inspect with `gh run view <id> --log-failed`
 3. Fix failures before moving on to other work
+
+## Architecture: Slicer Execution
+
+The user installs estampo via pip/pipx on their local machine. When slicing:
+1. The Python CLI calls `docker run --entrypoint orca-slicer estampo/estampo:orca-<version> ...`
+2. Docker runs OrcaSlicer inside the container; volumes mount input/output
+3. If Docker is unavailable, falls back to a locally installed OrcaSlicer with a warning
+
+In the GitHub Action context, estampo runs *inside* the Docker container. Docker-in-Docker is not available, so it automatically falls back to the local OrcaSlicer binary baked into the image.
+
+**Key rule**: Never force slicer settings (like `use_relative_e_distances`) — let the OrcaSlicer profile chain decide. Forcing values can conflict with machine profiles.
+
+## Docker Image Tags
+
+All Docker image tags use the format `estampo/estampo:orca-<version>`. The `docker_image()` function in `slicer.py` is the single source of truth — always import it rather than constructing the tag string manually.
+
+## Release Process
+
+1. Run `release-readiness` workflow manually before tagging — it builds Docker images, runs smoke tests, extracts profiles, and does a real slice end-to-end
+2. Update `CHANGELOG.md` — rename `## Unreleased` to `## <version> — YYYY-MM-DD`
+3. Bump `version` in `pyproject.toml`
+4. Commit, tag `v<version>`, push tag
+5. The release workflow publishes to PyPI, builds Docker images, and opens a PR for bundled profiles
+
+## CI Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `ci.yml` | PR / push to main | Lint, test (3 OS × 3 Python), coverage |
+| `test-pypi.yml` | PR / push to main | Publish dev package to TestPyPI |
+| `publish-docker.yml` | Push to main | Build Docker images when relevant files change |
+| `publish-cloud-bridge.yml` | Tag push (`v*`) | Full release: PyPI, Docker images, profile extraction |
+| `release-readiness.yml` | Manual / push to main | Pre-release e2e: Docker build, smoke test, profiles, real slice |
+| `slice.yml` | Manual | Run a slice with custom config |

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -36,6 +36,7 @@ Two automated pipelines handle publishing:
 Every merge to main triggers:
 - **TestPyPI** — publishes a `.dev` package (e.g. `0.1.140.dev42`)
 - **Docker** — rebuilds images with mutable tags (`orca-2.3.1`) when relevant files change
+- **Release readiness** — builds Docker images, runs smoke tests, profile extraction, and a real slice (only when relevant files change)
 
 No version bump needed for day-to-day work.
 
@@ -44,17 +45,34 @@ No version bump needed for day-to-day work.
 To publish a release:
 
 ```bash
-# 1. Bump version in pyproject.toml and src/estampo/__init__.py
-# 2. Update CHANGELOG.md
-# 3. Commit, tag, and push
-git tag v0.1.141
-git push origin v0.1.141
+# 1. Run release-readiness check first
+gh workflow run release-readiness.yml -f orca_version=2.3.1
+# 2. Wait for all 5 jobs to pass
+# 3. Bump version in pyproject.toml
+# 4. Rename "## Unreleased" to "## <version> — YYYY-MM-DD" in CHANGELOG.md
+# 5. Commit, tag, and push
+git tag v0.2.1
+git push origin v0.2.1
 ```
 
 This triggers:
 - **PyPI** — publishes the release version
-- **Docker** — tags images immutably (e.g. `estampo/estampo:0.1.141`)
-- **Profiles** — extracts slicer profiles and opens a PR if changed
+- **Docker** — tags images immutably (e.g. `estampo/estampo:orca-2.3.1-v0.2.1`)
+- **Profiles** — extracts slicer profiles from the Docker image and opens a PR with bundled profile data
+
+### Release readiness
+
+The `release-readiness.yml` workflow exercises the full release pipeline without publishing:
+
+| Job | What it tests |
+|-----|---------------|
+| `build-estampo-image` | Docker image builds successfully |
+| `build-cloud-bridge` | Cloud bridge image builds and binary works |
+| `smoke-test` | `estampo --help` and `estampo run --help` work inside the container |
+| `profile-extraction` | `extract_profiles.py` runs and produces valid JSON with profiles |
+| `slice-test` | Real end-to-end slice using `examples/estampo.toml` |
+
+Run it manually before tagging: `gh workflow run release-readiness.yml -f orca_version=2.3.1`
 
 ## Docker images
 
@@ -65,7 +83,7 @@ Pre-built OrcaSlicer images are on [Docker Hub](https://hub.docker.com/r/estampo
 ./scripts/build-docker.sh 2.3.1 --push   # build and push
 ```
 
-estampo auto-detects Docker and uses it for slicing when available, falling back to a local slicer install. Force local with `--local`, or pin a Docker version with `--docker-version 2.3.1`.
+estampo auto-detects Docker and uses it for slicing when available, falling back to a local OrcaSlicer install with a warning. This fallback works even when a slicer version is pinned in config — so running inside a Docker container (e.g. the GitHub Action) works without `--local`. Force local with `--local` if you want to skip the Docker check entirely.
 
 ## Platform support
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md with slicer execution model (host Docker, not Docker-in-Docker), Docker tag rules, release process, and CI workflow table
- Update docs/developing.md with release-readiness pre-tag steps, workflow job descriptions, and updated slicer fallback docs

## Test plan
- [x] All checks pass
- Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)