### PR TITLE
Automate release testing: nightly + gate release

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -5,7 +5,14 @@ on:
     tags: ["v*"]
 
 jobs:
+  readiness:
+    uses: ./.github/workflows/release-readiness.yml
+    with:
+      orca_version: "2.3.1"
+    secrets: inherit
+
   release:
+    needs: readiness
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -3,11 +3,19 @@ name: Release Readiness
 on:
   push:
     branches: [main]
+  schedule:
+    - cron: "0 6 * * *"  # nightly at 06:00 UTC
   workflow_dispatch:
     inputs:
       orca_version:
         description: "OrcaSlicer version to test"
         required: true
+        default: "2.3.1"
+  workflow_call:
+    inputs:
+      orca_version:
+        description: "OrcaSlicer version to test"
+        type: string
         default: "2.3.1"
 
 concurrency:
@@ -39,7 +47,7 @@ jobs:
 
   build-estampo-image:
     needs: detect-changes
-    if: always() && (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.relevant == 'true')
+    if: always() && !failure() && !cancelled() && (github.event_name != 'push' || needs.detect-changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -77,7 +85,7 @@ jobs:
 
   build-cloud-bridge:
     needs: detect-changes
-    if: always() && (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.relevant == 'true')
+    if: always() && !failure() && !cancelled() && (github.event_name != 'push' || needs.detect-changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project are documented here.
 - Fix profile extraction: use direct path instead of symlink in Docker container
 - Slicer now falls back to local OrcaSlicer when Docker image is unavailable (even with pinned version)
 - Remove forced `use_relative_e_distances=0` — let OrcaSlicer profile chain decide
+- Add nightly schedule to release-readiness workflow
+- Gate release workflow on release-readiness passing first
 
 ## 0.2.1 — 2026-03-29
 


### PR DESCRIPTION
## Summary
- Add nightly cron schedule (06:00 UTC) to `release-readiness.yml` so breakages are caught early
- Make `release-readiness.yml` callable as a reusable workflow via `workflow_call`
- Gate the release workflow (`publish-cloud-bridge.yml`) on release-readiness passing — all 5 e2e jobs must be green before PyPI publish, Docker push, or profile extraction runs
- Update build job conditions to correctly run for schedule and workflow_call triggers

## Test plan
- [ ] Trigger release-readiness manually via `workflow_dispatch` — all 5 jobs should pass
- [ ] Verify nightly schedule appears in GitHub Actions UI
- [ ] On next tag push, release workflow should first run release-readiness, then proceed to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)