### PR TITLE
Fix release-readiness skipping builds on tag pushes

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   detect-changes:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -47,7 +47,7 @@ jobs:
 
   build-estampo-image:
     needs: detect-changes
-    if: always() && !failure() && !cancelled() && (github.event_name != 'push' || needs.detect-changes.outputs.relevant == 'true')
+    if: always() && !failure() && !cancelled() && (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -85,7 +85,7 @@ jobs:
 
   build-cloud-bridge:
     needs: detect-changes
-    if: always() && !failure() && !cancelled() && (github.event_name != 'push' || needs.detect-changes.outputs.relevant == 'true')
+    if: always() && !failure() && !cancelled() && (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased
+
+- Fix release-readiness skipping builds on tag pushes (workflow_call inherits caller's push event)
+
 ## 0.2.1 — 2026-03-29
 
 - Fix profiles extraction: use correct Docker image tag format (`orca-<version>`)


### PR DESCRIPTION
## Summary
- When the release workflow calls release-readiness via `workflow_call`, GitHub passes the caller's `push` event — so `detect-changes` ran, found only changelog changes, and skipped the Docker build
- Downstream jobs (smoke-test, profile-extraction, slice-test) then failed because no artifact existed
- Fix: only run change detection on **branch** pushes (`startsWith(github.ref, 'refs/heads/')`), and use `detect-changes.result == 'skipped'` to always build for tag pushes, schedule, and workflow_dispatch

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, re-tag v0.2.1 (delete + recreate) to trigger release workflow — readiness should build and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)