### PR TITLE
Fix release profiles job: install project dependency

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -154,9 +154,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install project
+        run: |
+          pip install uv
+          uv sync
+
       - name: Extract profiles for all OrcaSlicer versions
         run: |
-          python scripts/extract_profiles.py 2.3.1
+          uv run python scripts/extract_profiles.py 2.3.1
 
       - name: Open PR for bundled profile updates
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## Unreleased
 
 - Fix release-readiness skipping builds on tag pushes (workflow_call inherits caller's push event)
+- Fix profiles job in release workflow: install project before running extract_profiles.py
 
 ## 0.2.1 — 2026-03-29
 


### PR DESCRIPTION
## Summary
- The `profiles` job in the release workflow runs `extract_profiles.py` which imports from `estampo`, but never installed the project
- Add `uv sync` step and use `uv run` for the script

This caused the profiles extraction to fail in the v0.2.1 release (everything else succeeded — PyPI publish, Docker images).

## Test plan
- [ ] CI passes
- [ ] After merge, re-tag v0.2.1 to retrigger release — profiles job should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)