### PR TITLE
Fix profile commit: detect new untracked profile files

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -173,12 +173,12 @@ jobs:
       - name: Commit updated profiles
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
-          git diff --quiet src/estampo/data/ && echo "No profile changes" && exit 0
+          git add src/estampo/data/
+          git diff --cached --quiet src/estampo/data/ && echo "No profile changes" && exit 0
           BRANCH="update-orca-profiles-$(date +%Y%m%d)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add src/estampo/data/
           git commit -m "Update bundled OrcaSlicer profiles (${{ env.ORCA_VERSION }})"
           git push origin "$BRANCH"
           gh pr create \


### PR DESCRIPTION
## Summary
`git diff --quiet` only detects changes to tracked files. Since the profiles JSON didn't exist in the repo yet, the diff showed nothing and the commit step exited early with "No profile changes."

Fix: `git add` first, then `git diff --cached --quiet` to detect both new and changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)