### PR TITLE
Fix misleading error when Docker is not running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- Fix `estampo status` showing cryptic "non-JSON output" error when Docker is not running; now reports "Docker is not running. Start Docker..." clearly
 - Fix release-readiness skipping builds on tag pushes (workflow_call inherits caller's push event)
 - Fix profiles job in release workflow: install project before running extract_profiles.py
 - Restructure release workflow: build all artifacts before publishing any of them

--- a/src/estampo/cloud/bridge.py
+++ b/src/estampo/cloud/bridge.py
@@ -121,9 +121,9 @@ def _run_bridge(
     use_docker = bridge is None or platform.system() == "Darwin"
 
     if use_docker:
-        # Check Docker is available
+        # Check Docker is available and running
         try:
-            subprocess.run(
+            docker_info = subprocess.run(
                 ["docker", "info"],
                 capture_output=True,
                 timeout=10,
@@ -133,6 +133,11 @@ def _run_bridge(
                 "Docker is required for Bambu Cloud printing but is not installed. "
                 "Install Docker Desktop from https://www.docker.com/products/docker-desktop/"
             ) from None
+        if docker_info.returncode != 0:
+            raise RuntimeError(
+                "Docker is not running. "
+                "Start Docker (e.g. 'colima start' or Docker Desktop) and try again."
+            )
 
         # Pull image if stale (default: once per 24h). Override with
         # ESTAMPO_DOCKER_PULL=always|never|auto.

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -656,6 +656,20 @@ class TestRunBridgeDockerPull:
             with pytest.raises(RuntimeError, match="Docker is required"):
                 _run_bridge(["status", "DEV123", "/tmp/tok.json"])
 
+    def test_docker_not_running_raises_runtime_error(self):
+        """Docker installed but not running raises RuntimeError with helpful message."""
+        mock_docker_info = MagicMock(returncode=1, stderr="Cannot connect to Docker daemon")
+        with (
+            patch("estampo.cloud.bridge._find_bridge", return_value=None),
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "estampo.cloud.bridge.subprocess.run",
+                return_value=mock_docker_info,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Docker is not running"):
+                _run_bridge(["status", "DEV123", "/tmp/tok.json"])
+
     def test_docker_run_mounts_file_args(self, tmp_path):
         """File arguments should be mounted individually."""
         threemf = tmp_path / "test.3mf"


### PR DESCRIPTION
## Summary
- `estampo status` was showing `"Bridge returned non-JSON output (exit 1): "` when Docker was installed but not running (e.g. Colima stopped)
- Root cause: `_run_bridge` only caught `FileNotFoundError` (Docker not installed), but ignored a non-zero `docker info` return code (Docker not running)
- Fix: check `docker_info.returncode != 0` and raise a clear, actionable error message

## Test plan
- [ ] New test `test_docker_not_running_raises_runtime_error` covers this path
- [ ] All 533 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)