### PR TITLE
Fix profiles pin using stale local profiles instead of Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## Unreleased
 
 - Fix `profiles pin` inheritance: resolve parent profiles across directories and from Docker-extracted profiles
+- Fix `profiles pin` using stale local system profiles instead of Docker-extracted profiles when `slicer.version` is set
 - Extract full BBL profile tree from Docker (includes root-level base profiles)
 - Log warning when a profile's `inherits` parent cannot be found
 - Add `output_dir` config setting in `estampo.toml` (default: `estampo_output`)

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -473,6 +473,8 @@ def pin_profiles(
 
     Returns list of pinned file paths.
     """
+    import shutil
+
     pinned: list[Path] = []
 
     items: list[tuple[str, str]] = []
@@ -483,50 +485,42 @@ def pin_profiles(
     for f in filaments:
         items.append(("filament", f))
 
-    # Try local resolution first; collect failures for Docker fallback
-    docker_needed: list[tuple[str, str]] = []
-    for category, name in items:
-        if _is_path(name):
-            log.info("Skipping '%s' (already a path)", name)
-            continue
+    # When docker_version is specified, extract Docker profiles upfront so they
+    # take priority over local system profiles.  This ensures pinned profiles
+    # match what the Docker slicer will actually use at slice time.
+    docker_dir: Path | None = None
+    if docker_version:
+        docker_dir = extract_docker_profiles(docker_version)
 
-        dest_dir = project_dir / profiles_dir / category
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        dest = dest_dir / f"{name}.json"
+    try:
+        for category, name in items:
+            if _is_path(name):
+                log.info("Skipping '%s' (already a path)", name)
+                continue
 
-        try:
-            data = resolve_profile_data(name, engine, category, project_dir)
+            dest_dir = project_dir / profiles_dir / category
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            dest = dest_dir / f"{name}.json"
+
+            try:
+                data = resolve_profile_data(
+                    name, engine, category, project_dir, profiles_dir, docker_dir
+                )
+            except FileNotFoundError:
+                if not docker_version:
+                    raise EstampoError(
+                        f"Profile '{name}' not found locally. Set slicer.version in "
+                        "your config or install OrcaSlicer to access profiles."
+                    )
+                raise
+
             with open(dest, "w") as fh:
                 json.dump(data, fh, indent=4)
-            log.info("Pinned %s → %s (flattened)", name, dest)
+            source = "Docker" if docker_dir else "system"
+            log.info("Pinned %s → %s (flattened, from %s)", name, dest, source)
             pinned.append(dest)
-        except FileNotFoundError:
-            docker_needed.append((category, name))
-
-    # Docker fallback for profiles not found locally
-    if docker_needed:
-        if not docker_version:
-            names = ", ".join(f"'{n}'" for _, n in docker_needed)
-            raise EstampoError(
-                f"Profile(s) {names} not found locally. Set slicer.version in your "
-                "config or install OrcaSlicer to access profiles."
-            )
-
-        import shutil
-
-        docker_dir = extract_docker_profiles(docker_version)
-        try:
-            for category, name in docker_needed:
-                dest_dir = project_dir / profiles_dir / category
-                dest_dir.mkdir(parents=True, exist_ok=True)
-                dest = dest_dir / f"{name}.json"
-
-                data = _resolve_profile_data_from_dir(name, category, docker_dir)
-                with open(dest, "w") as fh:
-                    json.dump(data, fh, indent=4)
-                log.info("Pinned %s → %s (from Docker, flattened)", name, dest)
-                pinned.append(dest)
-        finally:
+    finally:
+        if docker_dir:
             shutil.rmtree(docker_dir, ignore_errors=True)
 
     return pinned

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -511,6 +511,180 @@ def test_pin_profiles_docker_fallback(tmp_path):
     assert data["printer_model"] == "test"
 
 
+def test_pin_profiles_docker_overrides_system(tmp_path, monkeypatch):
+    """Docker-extracted profiles take priority over local system profiles."""
+    # Set up a fake system profile dir with a "stale" layer_change_gcode
+    system_dir = tmp_path / "system" / "machine"
+    system_dir.mkdir(parents=True)
+    (system_dir / "TestPrinter.json").write_text(
+        json.dumps(
+            {
+                "type": "machine",
+                "name": "TestPrinter",
+                "from": "system",
+                "layer_change_gcode": "stale gcode from local install",
+            }
+        )
+    )
+    monkeypatch.setattr("estampo.profiles.SYSTEM_DIRS", {"orca": system_dir.parent})
+
+    # Set up Docker-extracted profiles with the correct gcode
+    docker_dir = tmp_path / "docker_profiles"
+    docker_machine = docker_dir / "machine"
+    docker_machine.mkdir(parents=True)
+    (docker_machine / "TestPrinter.json").write_text(
+        json.dumps(
+            {
+                "type": "machine",
+                "name": "TestPrinter",
+                "from": "system",
+                "layer_change_gcode": "correct gcode with G92 E0",
+            }
+        )
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with patch("estampo.profiles.extract_docker_profiles", return_value=docker_dir):
+        pinned = pin_profiles(
+            engine="orca",
+            printer="TestPrinter",
+            process=None,
+            filaments=[],
+            project_dir=project,
+            docker_version="2.3.1",
+        )
+
+    assert len(pinned) == 1
+    data = json.loads(pinned[0].read_text())
+    # Must use Docker profile, NOT the stale system profile
+    assert data["layer_change_gcode"] == "correct gcode with G92 E0"
+
+
+def test_pin_profiles_docker_flattens_inheritance(tmp_path):
+    """Docker pinning walks the full inheritance chain and flattens correctly.
+
+    Regression test: a truncated chain produced pinned profiles missing
+    layer_change_gcode (with G92 E0), causing OrcaSlicer validation errors.
+    """
+    docker_dir = tmp_path / "docker_profiles"
+    machine_dir = docker_dir / "machine"
+    machine_dir.mkdir(parents=True)
+
+    # Root profile — base settings, no layer_change_gcode
+    (machine_dir / "base_common.json").write_text(
+        json.dumps(
+            {
+                "type": "machine",
+                "name": "base_common",
+                "from": "system",
+                "gcode_flavor": "marlin",
+            }
+        )
+    )
+
+    # Mid-chain profile — adds layer_change_gcode with G92 E0
+    (machine_dir / "mid_common.json").write_text(
+        json.dumps(
+            {
+                "type": "machine",
+                "name": "mid_common",
+                "from": "system",
+                "inherits": "base_common",
+                "layer_change_gcode": "M622 J1\nG92 E0\nM623\nM73 L{layer_num+1}",
+            }
+        )
+    )
+
+    # Leaf profile — overrides layer_change_gcode (still has G92 E0)
+    (machine_dir / "MyPrinter 0.4 nozzle.json").write_text(
+        json.dumps(
+            {
+                "type": "machine",
+                "name": "MyPrinter 0.4 nozzle",
+                "from": "system",
+                "inherits": "mid_common",
+                "printer_model": "MyPrinter",
+                "layer_change_gcode": "M622 J1\nG92 E0\nG1 X65\nM623\nM73 L{layer_num+1}",
+            }
+        )
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with patch("estampo.profiles.extract_docker_profiles", return_value=docker_dir):
+        pinned = pin_profiles(
+            engine="orca",
+            printer="MyPrinter 0.4 nozzle",
+            process=None,
+            filaments=[],
+            project_dir=project,
+            docker_version="2.3.1",
+        )
+
+    assert len(pinned) == 1
+    data = json.loads(pinned[0].read_text())
+
+    # Leaf values override parents
+    assert data["printer_model"] == "MyPrinter"
+    assert "G92 E0" in data["layer_change_gcode"]
+    assert "G1 X65" in data["layer_change_gcode"]  # leaf-specific addition
+    # Root values inherited
+    assert data["gcode_flavor"] == "marlin"
+    # Inheritance key must be stripped
+    assert "inherits" not in data
+
+
+def test_pin_profiles_repin_overwrites_stale(tmp_path):
+    """Re-pinning replaces an existing stale pinned profile with Docker data."""
+    # Pre-existing stale pinned profile (missing G92 E0)
+    project = tmp_path / "project"
+    pinned_dir = project / "profiles" / "machine"
+    pinned_dir.mkdir(parents=True)
+    (pinned_dir / "Printer.json").write_text(
+        json.dumps(
+            {
+                "type": "machine",
+                "name": "Printer",
+                "from": "system",
+                "layer_change_gcode": "stale — no G92 E0",
+            }
+        )
+    )
+
+    # Docker profiles with correct data
+    docker_dir = tmp_path / "docker_profiles"
+    docker_machine = docker_dir / "machine"
+    docker_machine.mkdir(parents=True)
+    (docker_machine / "Printer.json").write_text(
+        json.dumps(
+            {
+                "type": "machine",
+                "name": "Printer",
+                "from": "system",
+                "layer_change_gcode": "G92 E0\nM73 L{layer_num+1}",
+            }
+        )
+    )
+
+    with patch("estampo.profiles.extract_docker_profiles", return_value=docker_dir):
+        pinned = pin_profiles(
+            engine="orca",
+            printer="Printer",
+            process=None,
+            filaments=[],
+            project_dir=project,
+            docker_version="2.3.1",
+        )
+
+    assert len(pinned) == 1
+    data = json.loads(pinned[0].read_text())
+    # Docker profile must replace the stale pinned data
+    assert "G92 E0" in data["layer_change_gcode"]
+
+
 def test_pin_profiles_no_docker_version_raises(tmp_path):
     """Without docker_version, missing profiles raise EstampoError."""
     project = tmp_path / "project"

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "estampo"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "bambu-lab-cloud-api" },


### PR DESCRIPTION
## Summary
- `pin_profiles` resolved from local system profiles even when `docker_version` was set, causing pinned profiles to miss critical gcode (e.g. `G92 E0` in `layer_change_gcode`) when the local OrcaSlicer version differed from Docker
- Now extracts Docker profiles upfront so they take priority over system profiles, matching slice-time behavior
- Added 3 regression tests covering Docker priority, inheritance chain flattening, and re-pin overwrites

## Root cause
OrcaSlicer has a bug where `is_BBL_printer()` is set **after** `validate()`, so even BBL printers hit the `use_relative_e_distances` check. The check passes when `layer_change_gcode` contains `G92 E0` — but the pinned profile had a truncated version without it, because it was resolved from a stale local OrcaSlicer install instead of the Docker image.

## Test plan
- [x] `test_pin_profiles_docker_overrides_system` — Docker profiles win over system
- [x] `test_pin_profiles_docker_flattens_inheritance` — full chain walk with G92 E0
- [x] `test_pin_profiles_repin_overwrites_stale` — re-pin replaces bad data
- [x] 541 tests pass, lint/mypy/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)