### PR TITLE
Add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/publish-cloud-bridge.yml
+++ b/.github/workflows/publish-cloud-bridge.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.2.2)"
+        required: true
 
 jobs:
   readiness:
@@ -19,17 +24,21 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Extract version from tag
         id: version
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Verify tag matches pyproject.toml version
         run: |
           TOML_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG_VERSION="${TAG#v}"
           if [[ "$TOML_VERSION" != "$TAG_VERSION" ]]; then
             echo "::error::Tag $TAG_VERSION does not match pyproject.toml version $TOML_VERSION"
             exit 1


### PR DESCRIPTION
## Summary
- Tag push consistently causes `startup_failure` for the release workflow
- Add `workflow_dispatch` as fallback trigger with a `tag` input
- Version extraction uses `inputs.tag || github.ref_name` to work in both contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)