### PR TITLE
Remove named pypi environment from fabprint publish workflow

### DIFF
--- a/.github/workflows/publish-fabprint.yml
+++ b/.github/workflows/publish-fabprint.yml
@@ -54,7 +54,6 @@ jobs:
     needs: [build, publish-testpypi]
     if: inputs.dry_run == false
     runs-on: ubuntu-latest
-    environment: pypi
     permissions:
       id-token: write
     steps:

--- a/changes/+fabprint-publish-env.bugfix
+++ b/changes/+fabprint-publish-env.bugfix
@@ -1,0 +1,1 @@
+Fix ``publish-fabprint`` workflow to match repo environment configuration


### PR DESCRIPTION
## Summary
- Removes `environment: pypi` from `publish-fabprint.yml` to match the main release workflow, which uses no named environment for PyPI publish (only `testpypi` for the dry-run gate)

## Test plan
- [ ] Merge, then run `publish-fabprint.yml` with `dry_run: true` to validate TestPyPI upload
- [ ] Run with `dry_run: false` to publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)