### PR TITLE
Add post-release reminder to redeploy estampo.dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,3 +385,7 @@ jobs:
             ARGS+=("$WHEEL")
           fi
           "${ARGS[@]}"
+
+      - name: Remind to update website
+        run: |
+          echo "::notice::Release complete! Remember to redeploy estampo.dev — run the deploy workflow at https://github.com/estampo/website/actions/workflows/deploy.yml"

--- a/changes/+website-release-reminder.misc
+++ b/changes/+website-release-reminder.misc
@@ -1,0 +1,1 @@
+Add post-release reminder to redeploy estampo.dev


### PR DESCRIPTION
## Summary
- Adds a `::notice::` step at the end of the release workflow reminding to redeploy the estampo.dev website after each release

## Test plan
- [ ] CI passes
- [ ] On next release, verify the notice appears in the workflow summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)