### PR TITLE
Update tagline to "The build system for 3D prints"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![codecov](https://codecov.io/gh/estampo/estampo/branch/main/graph/badge.svg)](https://codecov.io/gh/estampo/estampo)
 
-**Reproducible 3D print builds.**
+**The build system for 3D prints.**
 
 3D printing has a reproducibility problem:
 

--- a/changes/+build-system-tagline.misc
+++ b/changes/+build-system-tagline.misc
@@ -1,0 +1,1 @@
+Update tagline to "The build system for 3D prints"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "estampo"
 version = "0.2.2"
-description = "Reproducible 3D print builds. Define parts, slicer settings, and printer targets in code."
+description = "The build system for 3D prints. Define parts, slicer settings, and printer targets in code."
 readme = "README.md"
 requires-python = ">=3.11"
 license = {file = "LICENSE"}

--- a/src/estampo/__init__.py
+++ b/src/estampo/__init__.py
@@ -1,4 +1,4 @@
-"""estampo — Reproducible 3D print builds."""
+"""estampo — The build system for 3D prints."""
 
 from __future__ import annotations
 

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 app = typer.Typer(
     name="estampo",
-    help="Reproducible 3D print builds.",
+    help="The build system for 3D prints.",
     no_args_is_help=True,
 )
 


### PR DESCRIPTION
## Summary
- Update tagline from "Reproducible 3D print builds" to "The build system for 3D prints" across:
  - README.md
  - `pyproject.toml` description (shows on PyPI)
  - CLI help text (`estampo --help`)
  - Module docstring

Positions estampo as a build system — a concept immediately understood by the target audience (engineers) — rather than describing a property (reproducibility).

## Test plan
- [x] All 541 tests pass
- [x] Lint, format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)