### PR TITLE
Show preview 3MF export in CLI output

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,4 +7,4 @@
 - [ ] Add `version = "2.3.1"` pin to `examples/gib-tuners-c13-10/estampo.toml` and `examples/peg-multicolour/estampo.toml`
 
 ## CLI Output
-- [ ] Add user-facing output for every file written by the CLI (e.g. `preview_path` is missing from `_STAGE_NODES` in `adapters.py`)
+- [x] Add user-facing output for every file written by the CLI (e.g. `preview_path` is missing from `_STAGE_NODES` in `adapters.py`)

--- a/changes/+preview-output.bugfix
+++ b/changes/+preview-output.bugfix
@@ -1,0 +1,1 @@
+Show preview 3MF export in CLI output (was silently written to disk)

--- a/src/estampo/adapters.py
+++ b/src/estampo/adapters.py
@@ -80,6 +80,7 @@ class ProgressAdapter(NodeExecutionHook):
             "loaded_parts",
             "placements",
             "plate_3mf_path",
+            "preview_path",
             "sliced_output_dir",
             "gcode_stats",
             "print_result",


### PR DESCRIPTION
## Summary
- `preview_path` was missing from `_STAGE_NODES` in `TimingAdapter`, so the preview 3MF was written to disk with no user-facing output
- One-line fix: add `"preview_path"` to the set (the spinner label and output handler already existed)

Users will now see:
```
✔ Preview exported → plate_preview.3mf
```

## Test plan
- [x] All 541 tests pass
- [x] Lint, format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)