### PR TITLE
Replace mutable cloud-bridge:latest with versioned bambu tags

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -55,6 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    strategy:
+      matrix:
+        bambu-version: ["02.05.00.00"]
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v3
@@ -73,7 +76,10 @@ jobs:
           file: Dockerfile.cloud-bridge
           platforms: linux/amd64
           push: true
-          tags: estampo/cloud-bridge:latest
+          tags: |
+            estampo/cloud-bridge:bambu-${{ matrix.bambu-version }}
+            ghcr.io/${{ github.repository }}/cloud-bridge:bambu-${{ matrix.bambu-version }}
+          build-args: BAMBU_SLICER_VERSION=${{ matrix.bambu-version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,12 +201,12 @@ jobs:
           platforms: linux/amd64
           push: false
           load: true
-          tags: estampo/cloud-bridge:latest
+          tags: estampo/cloud-bridge:build
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Save image as artifact
-        run: docker save estampo/cloud-bridge:latest -o cloud-bridge.tar
+        run: docker save estampo/cloud-bridge:build -o cloud-bridge.tar
 
       - uses: actions/upload-artifact@v7
         with:
@@ -341,10 +341,14 @@ jobs:
       - name: Tag and push cloud-bridge
         run: |
           VERSION="${{ needs.version.outputs.version }}"
-          docker tag estampo/cloud-bridge:latest "estampo/cloud-bridge:${VERSION}"
-          docker tag estampo/cloud-bridge:latest "ghcr.io/${{ github.repository }}/cloud-bridge:${VERSION}"
+          BAMBU_VERSION="02.05.00.00"
+          docker tag estampo/cloud-bridge:build "estampo/cloud-bridge:bambu-${BAMBU_VERSION}"
+          docker tag estampo/cloud-bridge:build "estampo/cloud-bridge:${VERSION}"
+          docker tag estampo/cloud-bridge:build "ghcr.io/${{ github.repository }}/cloud-bridge:bambu-${BAMBU_VERSION}"
+          docker tag estampo/cloud-bridge:build "ghcr.io/${{ github.repository }}/cloud-bridge:${VERSION}"
+          docker push "estampo/cloud-bridge:bambu-${BAMBU_VERSION}"
           docker push "estampo/cloud-bridge:${VERSION}"
-          docker push estampo/cloud-bridge:latest
+          docker push "ghcr.io/${{ github.repository }}/cloud-bridge:bambu-${BAMBU_VERSION}"
           docker push "ghcr.io/${{ github.repository }}/cloud-bridge:${VERSION}"
 
   # ── Create GitHub Release ───────────────────────────────────────────

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
 ## Docker Hardening
-- [ ] Remove mutable `cloud-bridge:latest` Docker tag in `publish-docker.yml` — use version-based immutable tags
+- [x] Remove mutable `cloud-bridge:latest` Docker tag in `publish-docker.yml` — use version-based immutable tags
 
 ## Examples
 - [ ] Add `version = "2.3.1"` pin to `examples/gib-tuners-c13-10/estampo.toml` and `examples/peg-multicolour/estampo.toml`

--- a/changes/+cloud-bridge-immutable-tag.misc
+++ b/changes/+cloud-bridge-immutable-tag.misc
@@ -1,0 +1,1 @@
+Replace mutable ``cloud-bridge:latest`` Docker tag with versioned ``cloud-bridge:bambu-<version>`` tags

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -67,7 +67,8 @@ case "$TARGET" in
 
     cloud-bridge)
         PUSH="${2:-}"
-        IMAGE="estampo/cloud-bridge:latest"
+        BAMBU_VERSION="02.05.00.00"
+        IMAGE="estampo/cloud-bridge:bambu-${BAMBU_VERSION}"
         BNL_TOKEN="${BNL_TOKEN:-$(gh auth token 2>/dev/null || true)}"
 
         echo "Building ${IMAGE} ..."

--- a/scripts/cache-bnl.sh
+++ b/scripts/cache-bnl.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 VERSION="${1:-02.05.00.00}"
-IMAGE="estampo/cloud-bridge:latest"
+IMAGE="estampo/cloud-bridge:bambu-${VERSION}"
 TMPFILE=$(mktemp)
 
 echo "Extracting libbambu_networking.so from ${IMAGE} ..."

--- a/src/estampo/cloud/__init__.py
+++ b/src/estampo/cloud/__init__.py
@@ -8,6 +8,7 @@ from estampo.cloud.ams import (
     parse_ams_trays,
 )
 from estampo.cloud.bridge import (
+    DOCKER_IMAGE,
     PersistentBridge,
     _find_bridge,
     _record_pull,
@@ -22,6 +23,7 @@ from estampo.cloud.bridge import (
 )
 
 __all__ = [
+    "DOCKER_IMAGE",
     "PersistentBridge",
     "_build_ams_mapping",
     "_find_bridge",

--- a/src/estampo/cloud/bridge.py
+++ b/src/estampo/cloud/bridge.py
@@ -26,7 +26,8 @@ from estampo.cloud.ams import (
 log = logging.getLogger(__name__)
 
 BRIDGE_NAME = "bambu_cloud_bridge"
-DOCKER_IMAGE = "estampo/cloud-bridge"
+BAMBU_SLICER_VERSION = "02.05.00.00"
+DOCKER_IMAGE = f"estampo/cloud-bridge:bambu-{BAMBU_SLICER_VERSION}"
 
 # Timeouts (seconds)
 BRIDGE_TIMEOUT = 300

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from estampo.cloud import (
+    DOCKER_IMAGE,
     PersistentBridge,
     _build_ams_mapping,
     _build_ams_mapping_from_state,
@@ -446,7 +447,7 @@ class TestRunBridgeDockerPull:
 
             # Second call should be the pull
             pull_cmd = mock_run.call_args_list[1][0][0]
-            assert pull_cmd == ["docker", "pull", "estampo/cloud-bridge"]
+            assert pull_cmd == ["docker", "pull", DOCKER_IMAGE]
 
     def test_skips_pull_when_recent(self):
         """When image was recently pulled, skip the pull."""
@@ -612,7 +613,7 @@ class TestRunBridgeDockerPull:
             # Last call should be docker run
             run_cmd = mock_run.call_args_list[-1][0][0]
             assert run_cmd[0] == "docker"
-            assert "estampo/cloud-bridge" in run_cmd
+            assert DOCKER_IMAGE in run_cmd
 
     def test_uses_local_bridge_on_linux(self):
         """On Linux with local bridge, should use it directly."""


### PR DESCRIPTION
## Summary
Mirrors the orca image tagging pattern (`estampo/estampo:orca-<version>`):

- **publish-docker.yml**: `cloud-bridge:latest` → `cloud-bridge:bambu-02.05.00.00`, also pushes to GHCR
- **release.yml**: builds with temp `:build` tag, publishes as `:bambu-<version>` + `:v<release>`
- **bridge.py**: `DOCKER_IMAGE` now includes the versioned tag (was bare name defaulting to `:latest`)
- **build-docker.sh**, **cache-bnl.sh**: updated to use versioned tags
- **Tests**: use `DOCKER_IMAGE` constant instead of hardcoded strings

## Test plan
- [x] All 541 tests pass
- [x] Lint, format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)