### PR TITLE
Use RELEASE_PAT in prepare-release for automatic CI

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -84,6 +84,8 @@ jobs:
           head -30 CHANGELOG.md
 
       - name: Commit and push
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           VERSION="${{ inputs.version }}"
           BRANCH="release/v${VERSION}"
@@ -91,11 +93,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml CHANGELOG.md changes/
           git commit -m "Release v${VERSION}"
+          # Push with PAT so the push event triggers CI on the PR
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push --force origin "$BRANCH"
 
       - name: Create or update pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           VERSION="${{ inputs.version }}"
           BRANCH="release/v${VERSION}"

--- a/changes/+prepare-release-pat.misc
+++ b/changes/+prepare-release-pat.misc
@@ -1,0 +1,1 @@
+Use ``RELEASE_PAT`` in prepare-release workflow so CI triggers on release PRs automatically


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN`-created PRs don't trigger CI workflows (GitHub security restriction)
- This meant every release PR required a manual close/reopen to get CI running
- Now uses `RELEASE_PAT` for both the branch push and PR creation steps
- CI will trigger automatically on release PRs going forward

## Test plan
- [x] All 541 tests pass
- [x] Lint, format, mypy clean
- [ ] Next release: run `prepare-release.yml` and verify CI triggers without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)