### PR TITLE
Add OrcaSlicer 2.3.2 support

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -93,7 +93,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        orca-version: ["2.3.1"]
+        orca-version: ["2.3.1", "2.3.2"]
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v3
@@ -127,7 +127,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        orca-version: ["2.3.1"]
+        orca-version: ["2.3.1", "2.3.2"]
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        orca-version: ["2.3.1"]
+        orca-version: ["2.3.1", "2.3.2"]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -301,7 +301,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        orca-version: ["2.3.1"]
+        orca-version: ["2.3.1", "2.3.2"]
     steps:
       - uses: actions/download-artifact@v7
         with:

--- a/changes/+orca-2.3.2.feature
+++ b/changes/+orca-2.3.2.feature
@@ -1,0 +1,1 @@
+Add OrcaSlicer 2.3.2 Docker image builds alongside 2.3.1


### PR DESCRIPTION
## Summary
- Add OrcaSlicer 2.3.2 to the `orca-version` matrix in `publish-docker.yml` and `release.yml`
- Both 2.3.1 and 2.3.2 Docker images will now be built and published
- Default remains 2.3.1 — users opt into 2.3.2 via `version = "2.3.2"` in their `estampo.toml`
- 2.3.2 was previously reverted due to an upstream CLI segfault with `--load-filaments`; re-adding after improvements

Once merged, the `release-readiness` workflow will build the `orca-base:2.3.2` image and extract bundled profiles. You'll need to run `publish-docker.yml` with `rebuild-base: true` to push the new orca-base image.

## Test plan
- [x] All 541 tests pass
- [x] Lint, format, mypy clean
- [ ] After merge: trigger `publish-docker.yml` with rebuild-base to build orca-base:2.3.2
- [ ] Test a slice with `version = "2.3.2"` in estampo.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)