### PR TITLE
Fix OrcaSlicer 2.3.2 Docker segfault on Colima

### DIFF
--- a/Dockerfile.orca-base
+++ b/Dockerfile.orca-base
@@ -49,6 +49,12 @@ RUN --mount=type=cache,id=apt-runtime,target=/var/cache/apt \
 COPY --from=orca /opt/orca-slicer /opt/orca-slicer
 RUN ln -s /opt/orca-slicer/bin/orca-slicer /usr/bin/orca-slicer
 
+# Prevent OrcaSlicer from attempting Wayland GL init in headless mode.
+# Without this, glfwInit tries to connect to a Wayland display and may
+# segfault on some Docker runtimes (e.g. Colima on macOS).
+ENV XDG_SESSION_TYPE=x11
+ENV DISPLAY=:0
+
 # Wire up system profiles so estampo can discover them
 # estampo looks at ~/.config/OrcaSlicer/system/BBL on Linux
 ENV HOME=/home/estampo

--- a/changes/+wayland-segfault.bugfix
+++ b/changes/+wayland-segfault.bugfix
@@ -1,0 +1,1 @@
+Fix OrcaSlicer 2.3.2 segfault in Docker on Colima by preventing Wayland GL init


### PR DESCRIPTION
## Summary
- OrcaSlicer 2.3.2 added GL/thumbnail init at startup that 2.3.1 didn't have
- In headless Docker, `glfwInit` tries the Wayland backend (Ubuntu 24.04 default)
- On Colima's Lima VM (macOS), this **segfaults** (exit 139 / SIGSEGV)
- On Linux Docker it fails gracefully, masking the bug

## Fix
Set `XDG_SESSION_TYPE=x11` and `DISPLAY=:0` in `Dockerfile.orca-base` so OrcaSlicer uses the X11 codepath, which handles a missing display without attempting any GL init at all.

## Test plan
- [x] Verified 2.3.2 without fix shows Wayland GL errors in Docker on Linux
- [x] Verified 2.3.2 with fix produces zero GL/Wayland errors
- [x] Sliced decoy-case successfully with fixed image (38m 23s, 10.51g PETG)
- [ ] Verify segfault is gone on Colima (macOS)
- [x] All tests pass, lint/format/mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)