### PR TITLE
Show status spinners during slow Docker operations

### DIFF
--- a/changes/+status-spinners.feature
+++ b/changes/+status-spinners.feature
@@ -1,0 +1,1 @@
+Show animated status spinners during slow Docker operations (image pull, profile extraction)

--- a/src/estampo/cloud/bridge.py
+++ b/src/estampo/cloud/bridge.py
@@ -143,12 +143,15 @@ def _run_bridge(
         # Pull image if stale (default: once per 24h). Override with
         # ESTAMPO_DOCKER_PULL=always|never|auto.
         if _should_pull_image():
-            pull = subprocess.run(
-                ["docker", "pull", DOCKER_IMAGE],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+            from estampo import ui
+
+            with ui.status(f"Checking for updated Docker image [bold]{DOCKER_IMAGE}[/bold]"):
+                pull = subprocess.run(
+                    ["docker", "pull", DOCKER_IMAGE],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
             if pull.returncode == 0:
                 _record_pull()
                 if "Downloaded newer image" in pull.stdout:

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -198,59 +198,62 @@ def extract_docker_profiles(
             "Install OrcaSlicer locally or check your Docker setup."
         )
 
+    from estampo import ui
+
     tmp_dir = Path(tempfile.mkdtemp(prefix="estampo_profiles_"))
     container_id = None
     try:
-        # Create a stopped container (does not start it)
-        result = subprocess.run(
-            ["docker", "create", "--platform", "linux/amd64", image, "true"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode != 0:
-            raise EstampoError(f"docker create failed: {result.stderr.strip()}")
-        container_id = result.stdout.strip()
-
-        # Copy the entire BBL profile tree (includes root-level base profiles
-        # that category profiles may inherit from).
-        # docker cp copies directory contents into the destination, so
-        # the result is bbl_dest/{machine,process,filament,...}
-        bbl_dest = tmp_dir / "_bbl"
-        cp_result = subprocess.run(
-            ["docker", "cp", f"{container_id}:{_DOCKER_PROFILE_ROOT}/.", str(bbl_dest)],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if cp_result.returncode == 0 and bbl_dest.is_dir():
-            # Move category dirs up to tmp_dir for backwards compatibility
-            for category in CATEGORIES:
-                src_cat = bbl_dest / category
-                dest_cat = tmp_dir / category
-                if src_cat.is_dir():
-                    src_cat.rename(dest_cat)
-            # Move any remaining files/dirs (root-level base profiles, common/, etc.)
-            for item in list(bbl_dest.iterdir()):
-                item.rename(tmp_dir / item.name)
-            if not any(bbl_dest.iterdir()):
-                bbl_dest.rmdir()
-        else:
-            log.debug(
-                "Bulk docker cp failed, falling back to per-category copy: %s",
-                cp_result.stderr.strip(),
+        with ui.status("Extracting profiles from Docker image"):
+            # Create a stopped container (does not start it)
+            result = subprocess.run(
+                ["docker", "create", "--platform", "linux/amd64", image, "true"],
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
-            for category in CATEGORIES:
-                src = f"{container_id}:{_DOCKER_PROFILE_ROOT}/{category}"
-                dest = tmp_dir / category
-                cat_result = subprocess.run(
-                    ["docker", "cp", src, str(dest)],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
+            if result.returncode != 0:
+                raise EstampoError(f"docker create failed: {result.stderr.strip()}")
+            container_id = result.stdout.strip()
+
+            # Copy the entire BBL profile tree (includes root-level base profiles
+            # that category profiles may inherit from).
+            # docker cp copies directory contents into the destination, so
+            # the result is bbl_dest/{machine,process,filament,...}
+            bbl_dest = tmp_dir / "_bbl"
+            cp_result = subprocess.run(
+                ["docker", "cp", f"{container_id}:{_DOCKER_PROFILE_ROOT}/.", str(bbl_dest)],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if cp_result.returncode == 0 and bbl_dest.is_dir():
+                # Move category dirs up to tmp_dir for backwards compatibility
+                for category in CATEGORIES:
+                    src_cat = bbl_dest / category
+                    dest_cat = tmp_dir / category
+                    if src_cat.is_dir():
+                        src_cat.rename(dest_cat)
+                # Move any remaining files/dirs (root-level base profiles, common/, etc.)
+                for item in list(bbl_dest.iterdir()):
+                    item.rename(tmp_dir / item.name)
+                if not any(bbl_dest.iterdir()):
+                    bbl_dest.rmdir()
+            else:
+                log.debug(
+                    "Bulk docker cp failed, falling back to per-category copy: %s",
+                    cp_result.stderr.strip(),
                 )
-                if cat_result.returncode != 0:
-                    log.debug("docker cp %s failed: %s", category, cat_result.stderr.strip())
+                for category in CATEGORIES:
+                    src = f"{container_id}:{_DOCKER_PROFILE_ROOT}/{category}"
+                    dest = tmp_dir / category
+                    cat_result = subprocess.run(
+                        ["docker", "cp", src, str(dest)],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+                    if cat_result.returncode != 0:
+                        log.debug("docker cp %s failed: %s", category, cat_result.stderr.strip())
 
     finally:
         # Clean up the container

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -146,14 +146,17 @@ def _has_docker_image(image: str) -> bool:
 
 def _pull_docker_image(image: str) -> bool:
     """Pull a Docker image from the registry. Returns True on success."""
+    from estampo import ui
+
     log.info("Pulling Docker image %s ...", image)
     try:
-        r = subprocess.run(
-            ["docker", "pull", image],
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
+        with ui.status(f"Pulling Docker image [bold]{image}[/bold] (not cached locally)"):
+            r = subprocess.run(
+                ["docker", "pull", image],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
         if r.returncode == 0:
             return True
         log.debug("docker pull failed: %s", r.stderr.strip())
@@ -236,7 +239,10 @@ def _slice_via_docker(
 
     log.info("Slicing via Docker (%s): %s", image, " ".join(cmd))
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    from estampo import ui
+
+    with ui.status("Slicing"):
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
 
     if result.returncode != 0:
         log.error("Docker slicer stderr:\n%s", result.stderr)
@@ -660,12 +666,15 @@ def slice_plate(
 
         log.info("Slicing with %s: %s", engine, " ".join(cmd))
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
+        from estampo import ui
+
+        with ui.status("Slicing"):
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
 
         if result.returncode != 0:
             log.error("Slicer stderr:\n%s", result.stderr)

--- a/src/estampo/ui.py
+++ b/src/estampo/ui.py
@@ -50,6 +50,17 @@ def info(text: str) -> None:
     console.print(f"  [dim]{text}[/dim]")
 
 
+def status(message: str):  # noqa: ANN201 — returns rich.status.Status
+    """Return a Rich Status spinner context manager for slow operations.
+
+    Usage::
+
+        with ui.status("Pulling Docker image"):
+            do_slow_thing()
+    """
+    return console.status(f"  {message}", spinner="dots")
+
+
 def prompt_str(prompt: str, default: str | None = None) -> str:
     """Prompt for a string value with optional default."""
     result = Prompt.ask(f"  {prompt}", default=default, console=console)


### PR DESCRIPTION
## Summary
- Add `ui.status()` helper wrapping Rich's animated `Status` spinner
- Show spinner during Docker image pulls (slicer + cloud bridge)
- Show spinner during Docker profile extraction (create/cp/rm cycle)

Previously these operations ran in silence — now the user sees an animated dots spinner so they know something is happening.

## Test plan
- [x] All 548 tests pass, lint/format/mypy clean
- [ ] Visual check: `estampo run` with uncached Docker image shows spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)