### PR TITLE
Extract Bambu 3MF fixup into printer-specific packaging stage

### DIFF
--- a/changes/+printer-packaging.feature
+++ b/changes/+printer-packaging.feature
@@ -1,0 +1,1 @@
+Extract Bambu Connect 3MF fixup into a ``packaged_output`` pipeline stage so printer-specific packaging is explicit and only runs for Bambu printers

--- a/src/estampo/adapters.py
+++ b/src/estampo/adapters.py
@@ -82,6 +82,7 @@ class ProgressAdapter(NodeExecutionHook):
             "plate_3mf_path",
             "preview_path",
             "sliced_output_dir",
+            "packaged_output",
             "gcode_stats",
             "print_result",
         }
@@ -93,6 +94,7 @@ class ProgressAdapter(NodeExecutionHook):
         "plate_3mf_path": "Exporting plate",
         "preview_path": "Exporting preview",
         "sliced_output_dir": "Slicing",
+        "packaged_output": "Printer-specific packaging",
         "gcode_stats": "Reading gcode",
         "print_result": "Sending to printer",
     }
@@ -227,6 +229,13 @@ class ProgressAdapter(NodeExecutionHook):
                 gcode_files = list(result.glob("*.gcode"))
                 if gcode_files:
                     self._console.print(f"  [dim]→ {gcode_files[0].name}[/dim]")
+
+        elif node_name == "packaged_output":
+            cfg = node_kwargs.get("config")
+            printer_name = ""
+            if cfg and cfg.printer:
+                printer_name = f' for "{cfg.printer.name}"'
+            self._ok(f"Packaged{printer_name}", elapsed)
 
         elif node_name == "gcode_stats":
             parts: list[str] = []

--- a/src/estampo/pipeline.py
+++ b/src/estampo/pipeline.py
@@ -42,7 +42,7 @@ STAGE_OUTPUTS: dict[str, list[str]] = {
     "load": ["loaded_parts", "part_summary"],
     "arrange": ["placements"],
     "plate": ["plate_3mf_path", "preview_path"],
-    "slice": ["sliced_output_dir", "gcode_stats"],
+    "slice": ["sliced_output_dir", "packaged_output", "gcode_stats"],
     "gcode-info": ["gcode_stats"],  # kept for backward compat
     "print": ["print_result"],
 }
@@ -51,7 +51,7 @@ STAGE_OUTPUTS: dict[str, list[str]] = {
 # be resolved from disk artifacts.  Each value is (node_name, description).
 STAGE_REQUIRES: dict[str, list[tuple[str, str]]] = {
     "slice": [("plate_3mf_path", "plate 3MF file")],
-    "gcode-info": [("sliced_output_dir", "slicer output directory")],
+    "gcode-info": [("packaged_output", "slicer output directory")],
     "print": [("gcode_path", "sliced gcode file")],
 }
 
@@ -110,7 +110,7 @@ def resolve_overrides(
             if not plate_files:
                 raise FileNotFoundError(f"--only {only}: requires {description} in {output_dir}")
             overrides[node_name] = plate_files[0]
-        elif node_name == "sliced_output_dir":
+        elif node_name in ("sliced_output_dir", "packaged_output"):
             if not output_dir.exists():
                 raise FileNotFoundError(f"--only {only}: requires {description} at {output_dir}")
             overrides[node_name] = output_dir
@@ -400,17 +400,43 @@ def sliced_output_dir(
     )
 
 
-def gcode_stats(sliced_output_dir: Path) -> dict:
+def packaged_output(
+    sliced_output_dir: Path,
+    plate_3mf_path: Path,
+    config: EstampoConfig,
+) -> Path:
+    """Printer-specific post-processing of slicer output.
+
+    For Bambu printers: patches the .gcode.3mf so Bambu Connect accepts it.
+    For other printers: no-op (returns the output directory unchanged).
+    """
+    from estampo.slicer import package_for_printer
+
+    printer_type: str | None = None
+    if config.printer:
+        from estampo.credentials import load_printer_credentials
+
+        try:
+            creds = load_printer_credentials(config.printer.name)
+            printer_type = creds.get("type")
+        except Exception:
+            log.debug("Could not load printer credentials for packaging", exc_info=True)
+
+    package_for_printer(sliced_output_dir, plate_3mf_path, printer_type)
+    return sliced_output_dir
+
+
+def gcode_stats(packaged_output: Path) -> dict:
     """Parse print time and filament usage from sliced gcode, write stats JSON."""
     import json
 
     from estampo.gcode import analyze_gcode
     from estampo.slicer import parse_gcode_stats
 
-    stats: dict = dict(parse_gcode_stats(sliced_output_dir))
+    stats: dict = dict(parse_gcode_stats(packaged_output))
 
     # Enrich with layer/filament analysis
-    gcode_files = list(sliced_output_dir.glob("*.gcode"))
+    gcode_files = list(packaged_output.glob("*.gcode"))
     if gcode_files:
         info = analyze_gcode(gcode_files[0])
         stats["layer_count"] = info.layer_count
@@ -420,18 +446,18 @@ def gcode_stats(sliced_output_dir: Path) -> dict:
             stats["filament_usage_g"] = info.filament_usage_g
 
     # Write to output dir for CI/action consumption
-    stats_path = sliced_output_dir / "stats.json"
+    stats_path = packaged_output / "stats.json"
     stats_path.write_text(json.dumps(stats, indent=2) + "\n")
     log.info("Wrote build stats to %s", stats_path)
 
     return stats
 
 
-def gcode_path(sliced_output_dir: Path) -> Path:
+def gcode_path(packaged_output: Path) -> Path:
     """Find the gcode file in the slicer output directory."""
-    gcode_files = list(sliced_output_dir.glob("*.gcode"))
+    gcode_files = list(packaged_output.glob("*.gcode"))
     if not gcode_files:
-        raise RuntimeError(f"No gcode files found in {sliced_output_dir}")
+        raise RuntimeError(f"No gcode files found in {packaged_output}")
     return gcode_files[0]
 
 

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -451,6 +451,41 @@ def _fix_sliced_3mf(path: Path, plate_3mf: Path | None = None) -> None:
     log.info("Patched sliced 3mf for Bambu Connect compatibility")
 
 
+def package_for_printer(
+    sliced_output_dir: Path,
+    plate_3mf: Path | None = None,
+    printer_type: str | None = None,
+) -> Path:
+    """Printer-specific post-processing of slicer output.
+
+    For Bambu printers: patches the .gcode.3mf so Bambu Connect accepts it
+    (missing keys, short filament arrays, thumbnails).
+
+    For other printers: returns the plain .gcode path unchanged.
+
+    Returns the path to the deliverable file.
+    """
+    is_bambu = printer_type in ("bambu-lan", "bambu-cloud")
+
+    if is_bambu:
+        sliced_3mfs = list(sliced_output_dir.glob("*_sliced.gcode.3mf"))
+        if sliced_3mfs:
+            _fix_sliced_3mf(sliced_3mfs[0], plate_3mf)
+            return sliced_3mfs[0]
+
+    # Non-Bambu or no 3MF found: return plain gcode
+    gcode_files = list(sliced_output_dir.glob("*.gcode"))
+    if gcode_files:
+        return gcode_files[0]
+
+    # Fallback: return whatever is available
+    sliced_3mfs = list(sliced_output_dir.glob("*_sliced.gcode.3mf"))
+    if sliced_3mfs:
+        return sliced_3mfs[0]
+
+    raise FileNotFoundError(f"No gcode or 3MF output found in {sliced_output_dir}")
+
+
 def slice_plate(
     input_3mf: Path,
     engine: str = "orca",
@@ -632,7 +667,6 @@ def slice_plate(
                 image,
                 allow_mix_temp,
             )
-            _fix_sliced_3mf(result_dir / (input_3mf.stem + "_sliced.gcode.3mf"), input_3mf)
             return result_dir
 
         # Local slicer path
@@ -683,7 +717,6 @@ def slice_plate(
             )
 
         log.info("Slicer stdout:\n%s", result.stdout)
-        _fix_sliced_3mf(output_dir / sliced_3mf_name, input_3mf)
         log.info("Slicing complete. Output in %s", output_dir)
         return output_dir
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -185,7 +185,7 @@ def test_resolve_outputs_only():
 
     stages = ["load", "arrange", "plate", "slice", "print"]
     outputs = resolve_outputs(stages, only="slice")
-    assert outputs == ["sliced_output_dir", "gcode_stats"]
+    assert outputs == ["sliced_output_dir", "packaged_output", "gcode_stats"]
 
 
 def test_resolve_outputs_unknown_stage():
@@ -243,11 +243,11 @@ def test_resolve_overrides_slice_missing_plate(tmp_path):
 
 
 def test_resolve_overrides_gcode_info_finds_dir(tmp_path):
-    """--only gcode-info resolves sliced_output_dir from disk."""
+    """--only gcode-info resolves packaged_output from disk."""
     from estampo.pipeline import resolve_overrides
 
     overrides = resolve_overrides("gcode-info", tmp_path)
-    assert overrides["sliced_output_dir"] == tmp_path
+    assert overrides["packaged_output"] == tmp_path
 
 
 def test_resolve_overrides_print_finds_gcode(tmp_path):
@@ -386,7 +386,7 @@ class TestResolveOverridesArtifacts:
         from estampo.pipeline import resolve_overrides
 
         overrides = resolve_overrides("gcode-info", tmp_path)
-        assert overrides["sliced_output_dir"] == tmp_path
+        assert overrides["packaged_output"] == tmp_path
 
     def test_print_finds_first_gcode(self, tmp_path):
         """--only print picks a gcode file from the directory."""


### PR DESCRIPTION
## Summary
- The Bambu Connect 3MF fixup was running unconditionally on every sliced output, injecting Bambu-specific keys even for non-Bambu printers
- New `packaged_output` Hamilton node checks printer type and only applies the fixup for `bambu-lan`/`bambu-cloud` printers
- `slice_plate` no longer does any printer-specific post-processing — clean separation of concerns
- ProgressAdapter shows "Printer-specific packaging" spinner during the new stage

## Pipeline DAG change
```
Before:  sliced_output_dir (+ hidden fixup) → gcode_stats → gcode_path → print_result
After:   sliced_output_dir → packaged_output → gcode_stats → gcode_path → print_result
```

## Test plan
- [x] All 548 tests pass, lint/format/mypy clean
- [ ] Verify Bambu cloud print still works (3MF fixup applied)
- [ ] Verify non-Bambu path skips fixup cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)