### PR TITLE
Fix OrcaSlicer 2.3.2: revert xvfb-run, pass --allow-mix-temp unconditionally

### DIFF
--- a/changes/+allow-mix-temp-gate.bugfix
+++ b/changes/+allow-mix-temp-gate.bugfix
@@ -1,1 +1,1 @@
-Only pass ``--allow-mix-temp`` to OrcaSlicer 2.3.2+; older versions reject the unknown flag.
+Pass ``--allow-mix-temp`` unconditionally on OrcaSlicer 2.3.2+ to fix grouping errors; gate the flag off for older versions.

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -650,14 +650,11 @@ def slice_plate(
         docker_profile_dir = extract_docker_profiles(version=docker_version)
         log.info("Extracted Docker image profiles to %s", docker_profile_dir)
 
-    # AMS printers can have multiple filament types loaded.  OrcaSlicer 2.3.2+
-    # rejects mixed-temperature filaments by default.  Pass --allow-mix-temp
-    # when the config declares more than one distinct filament name.
+    # OrcaSlicer 2.3.2+ has stricter filament-grouping validation that
+    # rejects filaments even in single-filament configs.  Pass
+    # --allow-mix-temp unconditionally on 2.3.2+ to disable the check.
     # The flag was added in 2.3.2 — older versions reject it as unknown.
-    _has_allow_mix_temp = detected_version and detected_version >= "2.3.2"
-    allow_mix_temp = bool(
-        _has_allow_mix_temp and filaments and len(set(f for f in filaments if f)) > 1
-    )
+    allow_mix_temp = bool(detected_version and detected_version >= "2.3.2")
 
     try:
         settings_arg, filament_arg = _resolve_profiles(

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -445,7 +445,7 @@ def test_slice_plate_docker_fallback_to_local(tmp_path):
 
 
 def test_slice_plate_allow_mix_temp_on_232(tmp_path):
-    """--allow-mix-temp is passed for OrcaSlicer 2.3.2+ with mixed filaments."""
+    """--allow-mix-temp is always passed for OrcaSlicer 2.3.2+."""
     input_3mf = tmp_path / "plate.3mf"
     input_3mf.write_text("fake")
     output_dir = tmp_path / "output"
@@ -496,8 +496,8 @@ def test_slice_plate_no_allow_mix_temp_on_231(tmp_path):
     assert "--allow-mix-temp" not in cmd
 
 
-def test_slice_plate_no_allow_mix_temp_single_filament(tmp_path):
-    """--allow-mix-temp is NOT passed with only one filament type."""
+def test_slice_plate_allow_mix_temp_single_filament_232(tmp_path):
+    """--allow-mix-temp is passed even with one filament on 2.3.2+."""
     input_3mf = tmp_path / "plate.3mf"
     input_3mf.write_text("fake")
     output_dir = tmp_path / "output"
@@ -519,7 +519,7 @@ def test_slice_plate_no_allow_mix_temp_single_filament(tmp_path):
         )
 
     cmd = mock_run.call_args[0][0]
-    assert "--allow-mix-temp" not in cmd
+    assert "--allow-mix-temp" in cmd
 
 
 # --- slice_plate: stale pinned profiles ---


### PR DESCRIPTION
## Summary
- **Revert xvfb-run wrapping** — OrcaSlicer handles missing GL gracefully (logs errors, skips thumbnails, slices fine). xvfb-run actually caused the segfault by triggering real GL init.
- **Pass `--allow-mix-temp` unconditionally on 2.3.2+** — the stricter filament-grouping validation rejects even single-filament configs ("PETG-CF can not be placed in the right nozzle"). Previously the flag was only passed for multi-filament configs.

## Test plan
- [x] 554 tests pass, lint/format/mypy clean
- [x] `test_slice_plate_allow_mix_temp_on_232` — flag passed with mixed filaments
- [x] `test_slice_plate_allow_mix_temp_single_filament_232` — flag passed with single filament
- [x] `test_slice_plate_no_allow_mix_temp_on_231` — flag NOT passed on 2.3.1
- [ ] User to verify locally that 2.3.2 slices successfully with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)