### PR TITLE
Fix TestPyPI dev version collisions on squash merge

### DIFF
--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -15,6 +15,8 @@ jobs:
       id-token: write  # required for PyPI trusted publishing
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history needed for git rev-list --count
 
       - name: Skip if this is a release PR merge
         id: release
@@ -45,7 +47,12 @@ jobs:
         run: |
           pip install build
           VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          DEV_VERSION="${VERSION}.dev${GITHUB_RUN_NUMBER}"
+          # Use total commit count for a strictly increasing dev version.
+          # GITHUB_RUN_NUMBER can collide when PR and push events share
+          # the same counter space (e.g. PR run 249 uploads dev249, then
+          # the merge-push run 250 collides with a prior dev250).
+          COMMIT_COUNT=$(git rev-list --count HEAD)
+          DEV_VERSION="${VERSION}.dev${COMMIT_COUNT}"
           sed -i "s/version = \"$VERSION\"/version = \"$DEV_VERSION\"/" pyproject.toml
           python -m build
 
@@ -54,3 +61,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/changes/+testpypi-versioning.bugfix
+++ b/changes/+testpypi-versioning.bugfix
@@ -1,0 +1,1 @@
+Fix TestPyPI dev version collisions by using git commit count instead of workflow run number.


### PR DESCRIPTION
## Summary
- Use `git rev-list --count HEAD` instead of `GITHUB_RUN_NUMBER` for dev version suffix
- Add `fetch-depth: 0` so full git history is available
- Add `skip-existing: true` as safety net for duplicate uploads

**Root cause**: `GITHUB_RUN_NUMBER` increments per workflow run, not per commit. When a PR event (run #249) uploads `dev249` and the merge-push event (run #250) tries to upload `dev250`, it collides with a prior PR event's `dev250`. The new code was silently not published.

After this fix, version numbers will jump from `dev250` to `dev820` (total git commits), then increase by 1 per merge to main.

## Test plan
- [ ] CI green
- [ ] After merge, verify new dev version appears on TestPyPI
- [ ] Verify `pip install --pre` picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)