### PR TITLE
Add [slicer.filament_overrides] for nozzle HRC bypass

### DIFF
--- a/changes/+filament-overrides.feature
+++ b/changes/+filament-overrides.feature
@@ -1,0 +1,1 @@
+Add ``[slicer.filament_overrides]`` to patch all filament profiles (e.g. ``required_nozzle_HRC``)

--- a/src/estampo/config.py
+++ b/src/estampo/config.py
@@ -28,6 +28,7 @@ class SlicerConfig:
     bed_type: str | None = None  # e.g. "Textured PEI Plate", "Engineering Plate"
     overrides: dict[str, object] = field(default_factory=dict)
     machine_overrides: dict[str, object] = field(default_factory=dict)
+    filament_overrides: dict[str, object] = field(default_factory=dict)
     profiles_dir: str = "profiles"
 
 
@@ -214,6 +215,7 @@ def load_config(path: Path) -> EstampoConfig:
         bed_type=slicer_raw.get("bed_type"),
         overrides=slicer_raw.get("overrides", {}),
         machine_overrides=slicer_raw.get("machine_overrides", {}),
+        filament_overrides=slicer_raw.get("filament_overrides", {}),
         profiles_dir=slicer_raw.get("profiles_dir", "profiles"),
     )
     if slicer.engine != "orca":

--- a/src/estampo/pipeline.py
+++ b/src/estampo/pipeline.py
@@ -392,6 +392,7 @@ def sliced_output_dir(
         filament_ids=resolved_filaments.filament_ids,
         overrides=config.slicer.overrides or None,
         machine_overrides=config.slicer.machine_overrides or None,
+        filament_overrides=config.slicer.filament_overrides or None,
         project_dir=config.base_dir,
         local=slicer_local,
         docker_version=docker_version,

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -304,6 +304,7 @@ def _resolve_profiles(
     profiles_dir: str = "profiles",
     docker_profile_dir: Path | None = None,
     bed_type: str | None = None,
+    filament_overrides: dict[str, object] | None = None,
 ) -> tuple[str | None, str | None]:
     """Resolve and flatten all profiles into tmp_dir.
 
@@ -347,6 +348,8 @@ def _resolve_profiles(
                 data = resolve_profile_data(
                     f, engine, "filament", project_dir, profiles_dir, docker_profile_dir
                 )
+                if filament_overrides:
+                    data = _apply_overrides(data, filament_overrides, f)
                 path = _write_tmp_profile(data, tmp_dir, f"filament_{i}")
                 resolved.append(str(path))
                 if first_path is None:
@@ -536,6 +539,7 @@ def slice_plate(
     filament_ids: list[int] | None = None,
     overrides: dict[str, object] | None = None,
     machine_overrides: dict[str, object] | None = None,
+    filament_overrides: dict[str, object] | None = None,
     project_dir: Path | None = None,
     local: bool = False,
     docker_version: str | None = None,
@@ -548,6 +552,7 @@ def slice_plate(
     Profile names are resolved via profiles.resolve_profile_data().
     If overrides are provided, they are patched into the process profile.
     If machine_overrides are provided, they are patched into the machine profile.
+    If filament_overrides are provided, they are patched into every filament profile.
 
     Slicer selection:
       local=True           - force local slicer, fail if not installed
@@ -699,6 +704,7 @@ def slice_plate(
             profiles_dir,
             docker_profile_dir,
             bed_type,
+            filament_overrides,
         )
 
         if use_docker:


### PR DESCRIPTION
## Summary
- OrcaSlicer 2.3.2 dynamically recomputes `filament_printable` from `required_nozzle_HRC` vs `nozzle_type`, ignoring values loaded via `--load-settings` and `--load-filaments`
- `[slicer.machine_overrides]` alone cannot fix the "Grouping error: PETG-CF can not be placed in the right nozzle" error
- Adds `[slicer.filament_overrides]` — key-value overrides applied to every filament profile before passing to OrcaSlicer
- Users with hardened steel nozzles can set `required_nozzle_HRC = "0"` to bypass the check

### Usage
```toml
[slicer.machine_overrides]
nozzle_type = "hardened_steel"

[slicer.filament_overrides]
required_nozzle_HRC = "0"
```

## Test plan
- [x] All 560 tests pass
- [x] Lint, format, mypy clean
- [ ] Manual test: slice PETG-CF on P1S with hardened steel nozzle and filament_overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)