### PR TITLE
Fix release-readiness jobs skipping on manual dispatch

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -59,7 +59,7 @@ jobs:
 
   build-estampo-image:
     needs: resolve-versions
-    if: needs.resolve-versions.result == 'success'
+    if: always() && needs.resolve-versions.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -100,7 +100,7 @@ jobs:
 
   build-cloud-bridge:
     needs: resolve-versions
-    if: needs.resolve-versions.result == 'success'
+    if: always() && needs.resolve-versions.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -117,7 +117,7 @@ jobs:
 
   smoke-test:
     needs: [resolve-versions, build-estampo-image]
-    if: needs.build-estampo-image.result == 'success'
+    if: always() && needs.build-estampo-image.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -142,7 +142,7 @@ jobs:
 
   profile-extraction:
     needs: [resolve-versions, build-estampo-image]
-    if: needs.build-estampo-image.result == 'success'
+    if: always() && needs.build-estampo-image.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -213,7 +213,7 @@ jobs:
 
   slice-test:
     needs: [resolve-versions, build-estampo-image]
-    if: needs.build-estampo-image.result == 'success'
+    if: always() && needs.build-estampo-image.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -274,7 +274,7 @@ jobs:
 
   build-cura-image:
     needs: resolve-versions
-    if: needs.resolve-versions.result == 'success'
+    if: always() && needs.resolve-versions.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -316,7 +316,7 @@ jobs:
 
   cura-smoke-test:
     needs: build-cura-image
-    if: needs.build-cura-image.result == 'success'
+    if: always() && needs.build-cura-image.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -341,7 +341,7 @@ jobs:
 
   cura-slice-test:
     needs: build-cura-image
-    if: needs.build-cura-image.result == 'success'
+    if: always() && needs.build-cura-image.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/changes/+release-readiness-dispatch.misc
+++ b/changes/+release-readiness-dispatch.misc
@@ -1,0 +1,1 @@
+Fix release-readiness jobs skipping on manual dispatch and nightly schedule


### PR DESCRIPTION
## Summary
- All build/test jobs in release-readiness.yml were skipping on `workflow_dispatch` and `schedule` triggers
- Root cause: `detect-changes` job skips on non-push events, and its `skipped` status propagated through the `needs` chain to all downstream jobs
- Fix: add `always() &&` to all job `if` conditions that depend on `resolve-versions` or build jobs

This also means the CuraEngine smoke/slice tests will run on the next push to main, verifying the libssl fix from #284.

## Test plan
- [ ] `workflow_dispatch` trigger runs all jobs (not just resolve-versions)
- [ ] Push-to-main trigger still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)