### PR TITLE
Fix CuraEngine slicing: convert 3MF to STL

### DIFF
--- a/changes/+cura-3mf-to-stl.bugfix
+++ b/changes/+cura-3mf-to-stl.bugfix
@@ -1,0 +1,1 @@
+Fix CuraEngine slicing by converting 3MF model data to STL before passing to the engine

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -199,7 +199,6 @@ def slice_stl(
     # -s values can't contain newlines directly.
     settings = _settings_flags(profile)
     inner_cmd = (
-        f"set -ex && "
         f"START=$(cat {c_staging}/start.gcode) && "
         f"END=$(cat {c_staging}/end.gcode) && "
         f"CuraEngine slice "

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -579,28 +579,17 @@ def slice_plate(
         output_dir = output_dir.resolve()
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Extract STL from the 3MF (it's a zip with model files inside)
-        import zipfile
+        # Convert plate 3MF to STL for CuraEngine (which only accepts STL).
+        # The 3MF contains geometry in XML format (3D/3dmodel.model), not STL.
+        import trimesh
 
-        stl_path: Path | None = None
-        with zipfile.ZipFile(input_3mf) as zf:
-            for name in zf.namelist():
-                if name.endswith(".stl"):
-                    stl_path = output_dir / Path(name).name
-                    stl_path.write_bytes(zf.read(name))
-                    break
-            if stl_path is None:
-                # Try .model files (3MF native format)
-                for name in zf.namelist():
-                    if name.endswith(".model"):
-                        stl_path = output_dir / Path(name).name
-                        stl_path.write_bytes(zf.read(name))
-                        break
-
-        if stl_path is None:
-            raise EstampoError(
-                f"No STL or model file found in {input_3mf}. CuraEngine requires an STL input."
-            )
+        scene = trimesh.load(str(input_3mf))
+        if isinstance(scene, trimesh.Scene):
+            mesh = scene.to_geometry()
+        else:
+            mesh = scene
+        stl_path = output_dir / (input_3mf.stem + ".stl")
+        mesh.export(str(stl_path), file_type="stl")
 
         # Determine filament type from first filament profile name.
         # filaments may be a list ["PETG-CF"] or a dict {"default": "PETG-CF"}

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -250,15 +250,15 @@ def test_slice_stl_no_output(tmp_path):
 
 def test_slice_plate_cura_dispatch(tmp_path):
     """slice_plate with engine='cura' dispatches to cura.slice_stl."""
-    import zipfile
+    import trimesh
 
     from estampo.slicer import slice_plate
 
-    # Create a minimal 3MF (zip) with an STL inside
+    # Create a valid 3MF from a simple mesh
     input_3mf = tmp_path / "plate.3mf"
-    stl_content = b"solid cube\nendsolid cube"
-    with zipfile.ZipFile(input_3mf, "w") as zf:
-        zf.writestr("3D/model.stl", stl_content)
+    mesh = trimesh.creation.box(extents=[10, 10, 10])
+    scene = trimesh.Scene(mesh)
+    scene.export(str(input_3mf))
 
     output_dir = tmp_path / "output"
 


### PR DESCRIPTION
## Summary
- CuraEngine only accepts STL files, but estampo's plate packing creates 3MF with XML model data (`3D/3dmodel.model`)
- The previous code tried to extract raw files from the 3MF zip, giving CuraEngine a `.model` file it couldn't read (`Unable to recognize the extension of the file`)
- Now uses trimesh to load the 3MF and export as STL before passing to CuraEngine
- Also removes the debug `set -ex` from the Docker shell command

## Test plan
- [ ] CI passes
- [ ] After merge, trigger release-readiness — cura-slice-test should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)