### PR TITLE
Improve CI: caching, concurrency, conditional builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,18 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
       - run: uv sync --extra dev
       - run: uv run ruff check src tests
       - run: uv run ruff format --check src tests
@@ -26,6 +32,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
       - run: uv sync --extra dev
       - run: uv run towncrier check --compare-with origin/main
 
@@ -41,6 +49,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
       - run: uv sync --extra dev
       - run: uv run pytest -v
 
@@ -51,6 +60,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
+          enable-cache: true
       - run: uv sync --extra dev
       - run: uv run pytest --cov=estampo --cov-report=xml -v
       - uses: codecov/codecov-action@v5
@@ -63,7 +73,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Check if bridge files changed
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only 2>/dev/null || echo "")
+            if echo "$CHANGED" | grep -qE 'scripts/bambu_cloud_bridge\.cpp|Dockerfile\.cloud-bridge'; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              echo "Skipping: no bridge files changed"
+            fi
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile cloud bridge
+        if: steps.filter.outputs.run == 'true'
         run: g++ -std=c++17 -o bambu_cloud_bridge scripts/bambu_cloud_bridge.cpp -ldl -lpthread
       - name: Verify binary
+        if: steps.filter.outputs.run == 'true'
         run: ./bambu_cloud_bridge --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,22 +39,14 @@ jobs:
             | head -1 || true)
 
           if [[ -n "$VERSION" ]]; then
-            # Verify no existing tag (404 = no tag, which is what we want)
+            # Verify no existing tag (gh exits 0 if ref exists, non-zero if not)
             if gh api "repos/${{ github.repository }}/git/refs/tags/v${VERSION}" >/dev/null 2>&1; then
-              HTTP_CODE="200"
-            else
-              HTTP_CODE="404"
-            fi
-            if [[ "$HTTP_CODE" == "200" ]]; then
               echo "::warning::Tag v${VERSION} already exists — skipping"
               echo "is_release=false" >> "$GITHUB_OUTPUT"
-            elif [[ "$HTTP_CODE" == "404" ]]; then
+            else
               echo "is_release=true" >> "$GITHUB_OUTPUT"
               echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
               echo "::notice::Detected release PR merge for v${VERSION}"
-            else
-              echo "::error::Unexpected API response ($HTTP_CODE) checking tag v${VERSION}"
-              exit 1
             fi
           else
             echo "is_release=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -20,6 +20,10 @@ on:
         required: true
         default: "2.3.1"
 
+concurrency:
+  group: slice-${{ inputs.engine }}-${{ inputs.version }}
+  cancel-in-progress: true
+
 jobs:
   slice-orca:
     if: inputs.engine == 'orca'

--- a/changes/+ci-improvements.misc
+++ b/changes/+ci-improvements.misc
@@ -1,0 +1,1 @@
+Speed up CI with uv dependency caching, concurrency groups, and conditional bridge builds


### PR DESCRIPTION
## Summary
- **uv caching**: Enable `enable-cache: true` on all `astral-sh/setup-uv` steps — avoids re-downloading packages on every run across all 9 test matrix entries + lint + coverage + changelog jobs
- **Concurrency groups**: Cancel in-progress CI runs when new commits push to the same branch. Also prevents duplicate manual slice runs.
- **Conditional bridge build**: Skip C++ bridge compilation on PRs that don't touch `bambu_cloud_bridge.cpp` or `Dockerfile.cloud-bridge` (still always runs on push to main)
- **Simplify release.yml**: Remove unnecessary `HTTP_CODE` variable indirection in tag detection — the `gh api` exit code directly tells us if the tag exists

## Test plan
- [ ] CI passes on this PR (tests the new workflow itself)
- [ ] Verify build-bridge is skipped (this PR doesn't touch bridge files)
- [ ] Verify uv cache is populated on first run, hit on subsequent

🤖 Generated with [Claude Code](https://claude.com/claude-code)