### PR TITLE
Disable OrcaSlicer 2.3.2 builds (segfault)

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -100,7 +100,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        orca-version: ["2.3.1", "2.3.2"]
+        orca-version: ["2.3.1"]  # 2.3.2 disabled: segfaults on slice (exit 139)
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v3
@@ -134,7 +134,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        orca-version: ["2.3.1", "2.3.2"]
+        orca-version: ["2.3.1"]  # 2.3.2 disabled: segfaults on slice (exit 139)
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v3

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -54,7 +54,7 @@ jobs:
           if [ -n "${{ inputs.orca_version }}" ]; then
             echo 'versions=["${{ inputs.orca_version }}"]' >> "$GITHUB_OUTPUT"
           else
-            echo 'versions=["2.3.1","2.3.2"]' >> "$GITHUB_OUTPUT"
+            echo 'versions=["2.3.1"]' >> "$GITHUB_OUTPUT"  # 2.3.2 disabled: segfaults on slice
           fi
 
   build-estampo-image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        orca-version: ["2.3.1", "2.3.2"]
+        orca-version: ["2.3.1"]  # 2.3.2 disabled: segfaults on slice (exit 139)
     steps:
       - uses: actions/checkout@v6
         with:
@@ -361,7 +361,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        orca-version: ["2.3.1", "2.3.2"]
+        orca-version: ["2.3.1"]  # 2.3.2 disabled: segfaults on slice (exit 139)
     steps:
       - uses: actions/download-artifact@v7
         with:

--- a/changes/+disable-orca-232.misc
+++ b/changes/+disable-orca-232.misc
@@ -1,0 +1,1 @@
+Disable OrcaSlicer 2.3.2 builds (segfaults on slice); re-enable when upstream fixes it


### PR DESCRIPTION
## Summary
- Remove 2.3.2 from all workflow matrices (publish-docker, release, release-readiness)
- OrcaSlicer 2.3.2 segfaults during slicing (exit 139) — every CI run that includes it fails
- Example configs and Dockerfile parameterization preserved — just add `"2.3.2"` back to the matrices when upstream fixes it

## Test plan
- [ ] CI passes
- [ ] Release-readiness runs cleanly with only 2.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)