### PR TITLE
Replace hardcoded OrcaSlicer references with engine-agnostic text

### DIFF
--- a/changes/+slicer-agnostic-messages.misc
+++ b/changes/+slicer-agnostic-messages.misc
@@ -1,0 +1,1 @@
+Replace hardcoded OrcaSlicer references with engine-agnostic text in CLI help, error messages, and 3MF metadata

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -186,7 +186,7 @@ def run(
     ] = False,
     docker_version: Annotated[
         str | None,
-        typer.Option(help="Use a specific OrcaSlicer Docker image version (e.g. 2.3.1)"),
+        typer.Option(help="Use a specific slicer Docker image version (e.g. 2.3.1)"),
     ] = None,
     filament_type: Annotated[
         str | None,
@@ -250,7 +250,7 @@ def watch(
     ] = False,
     docker_version: Annotated[
         str | None,
-        typer.Option(help="Use a specific OrcaSlicer Docker image version"),
+        typer.Option(help="Use a specific slicer Docker image version"),
     ] = None,
     verbose: Annotated[bool, typer.Option("-v", "--verbose", help="Enable debug logging")] = False,
 ) -> None:
@@ -385,7 +385,7 @@ def init(
     ] = False,
     from_3mf: Annotated[
         Path | None,
-        typer.Option("--from-3mf", help="Generate config from an OrcaSlicer .3mf project file"),
+        typer.Option("--from-3mf", help="Generate config from a slicer .3mf project file"),
     ] = None,
     output: Annotated[
         Path | None,

--- a/src/estampo/printer.py
+++ b/src/estampo/printer.py
@@ -58,7 +58,7 @@ def wrap_gcode_3mf(gcode_path: Path, output_path: Path | None = None) -> Path:
         ' xmlns:BambuStudio="http://schemas.bambulab.com/package/2021"'
         ' xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06"'
         ' requiredextensions="p">\n'
-        ' <metadata name="Application">OrcaSlicer</metadata>\n'
+        ' <metadata name="Application">estampo</metadata>\n'
         ' <metadata name="BambuStudio:3mfVersion">1</metadata>\n'
         " <resources/>\n"
         " <build/>\n"

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -195,7 +195,7 @@ def extract_docker_profiles(
     if not _ensure_docker_image(image):
         raise EstampoError(
             f"Docker image {image} is not available and could not be pulled. "
-            "Install OrcaSlicer locally or check your Docker setup."
+            "Check your Docker setup or install the slicer locally."
         )
 
     from estampo import ui

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -68,7 +68,7 @@ def find_slicer(engine: str) -> Path:
         if found:
             return Path(found)
 
-    raise FileNotFoundError(f"OrcaSlicer not found at {path} or on PATH. Is OrcaSlicer installed?")
+    raise FileNotFoundError(f"Slicer ({engine}) not found at {path} or on PATH. Is it installed?")
 
 
 def _write_tmp_profile(data: dict, tmp_dir: Path, name: str) -> Path:
@@ -643,7 +643,7 @@ def slice_plate(
                     f"Docker image '{image}' not found locally or on Docker Hub, "
                     f"and no local slicer installed. Either:\n"
                     f"  docker pull {image}\n"
-                    f"  or install OrcaSlicer locally"
+                    f"  or install the slicer locally"
                 )
     else:
         # Default: try Docker first, fall back to local
@@ -659,8 +659,7 @@ def slice_plate(
                 )
             except FileNotFoundError:
                 raise FileNotFoundError(
-                    "No slicer available. Install OrcaSlicer locally or "
-                    "pull a Docker image: docker pull estampo/estampo:orca-2.3.1"
+                    f"No slicer available. Pull the Docker image:\n  docker pull {image}"
                 )
 
     # Detect and verify slicer version

--- a/todo-slicer.md
+++ b/todo-slicer.md
@@ -1,0 +1,83 @@
+# Slicer-Agnostic TODO
+
+Track remaining work to make estampo properly engine-neutral now that
+CuraEngine exists alongside OrcaSlicer.
+
+## Critical — breaks CuraEngine users
+
+- [x] **G-code parsing** (`src/estampo/gcode.py`)
+  CuraEngine patterns added: `;TIME:`, `;Filament used:`, `;LAYER:`.
+  Detects engine from g-code header and parses accordingly.
+
+- [x] **Status messages say "OrcaSlicer"** (`src/estampo/adapters.py`)
+  Now detects engine from config and shows "CuraEngine" or "OrcaSlicer".
+
+- [x] **CLI help text** (`src/estampo/cli.py`)
+  `--docker-version` now says "slicer Docker image version".
+  `--from-3mf` now says "slicer .3mf project file".
+
+## High — init is OrcaSlicer-only
+
+- [ ] **Wizard hardcodes engine** (`src/estampo/init.py:1074`)
+  `engine = "orca"` — no engine choice offered in interactive wizard.
+
+- [ ] **Version detection OrcaSlicer-only** (`src/estampo/init.py:513-591`)
+  `_detect_orca_version()` with no CuraEngine equivalent.
+  `_prompt_slicer_version()` only mentions OrcaSlicer.
+
+- [ ] **3MF extraction OrcaSlicer-only** (`src/estampo/init.py:1326-1365`)
+  Reads `Metadata/project_settings.config` (OrcaSlicer format).
+  Error message: "open it in OrcaSlicer and re-save".
+  CuraEngine 3MFs have different internal structure.
+
+- [ ] **TOML template hardcodes orca** (`src/estampo/init.py:31`)
+  Generated config always writes `engine = "orca"`.
+
+## Medium — profile system is OrcaSlicer-only
+
+- [ ] **Profile system paths** (`src/estampo/profiles.py:25-35,166`)
+  System directories (macOS/Windows/Linux) and Docker path
+  (`/opt/orca-slicer/resources/profiles/BBL`) only defined for OrcaSlicer.
+  CuraEngine uses inline `CuraProfile` defaults — no equivalent profile
+  discovery needed today, but error messages should not suggest installing
+  OrcaSlicer.
+
+- [ ] **`profiles list` defaults to orca** (`src/estampo/cli.py:780`)
+  Should be engine-aware or require explicit engine flag.
+
+- [x] **Profile error messages** (`src/estampo/profiles.py:198`)
+  Now says "Check your Docker setup or install the slicer locally."
+
+## Medium — local fallback won't work
+
+- [ ] **`find_slicer()` OrcaSlicer-only** (`src/estampo/slicer.py:29-71`)
+  `SLICER_PATHS` only has `"orca"` entries. Executable names only include
+  `orca-slicer`, `OrcaSlicer`, `OrcaSlicer.AppImage`.
+  CuraEngine local fallback (when Docker is unavailable) doesn't exist.
+
+- [x] **Docker fallback messages** (`src/estampo/slicer.py`)
+  Error messages now reference the engine being used and the specific
+  Docker image, not hardcoded "OrcaSlicer".
+
+## Low — cosmetic but confusing
+
+- [x] **3MF metadata** (`src/estampo/printer.py:61`)
+  Changed from `OrcaSlicer` to `estampo` in Application metadata field.
+
+- [ ] **Bambu Cloud header** (`src/estampo/auth.py:17`)
+  `"X-BBL-Client-Name": "OrcaSlicer"` — may not matter in practice but is
+  technically wrong for CuraEngine slices.
+
+## Won't fix (by design)
+
+- **3MF extraction from CuraEngine files**: CuraEngine doesn't produce
+  OrcaSlicer-style project 3MFs. `estampo init --from-3mf` is an OrcaSlicer
+  convenience feature.
+
+- **Profile pin/list for CuraEngine**: CuraEngine has no extractable profile
+  chain — settings are inline in `CuraProfile`. No equivalent to OrcaSlicer's
+  printer/process/filament profile discovery.
+
+- **`auth.py` BBL client name**: This header is for Bambu Cloud API
+  compatibility. Changing it could break authentication. Leave as-is unless
+  Bambu documents alternative values.


### PR DESCRIPTION
## Summary
- CLI help: `--docker-version` and `--from-3mf` no longer say "OrcaSlicer"
- Error messages in slicer.py reference the actual engine and Docker image
- 3MF Application metadata changed from "OrcaSlicer" to "estampo"
- profiles.py error no longer suggests installing OrcaSlicer specifically
- Updated todo-slicer.md tracking doc

## Test plan
- [ ] CI passes (all 582 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)