### PR TITLE
Add CuraEngine to local slicer discovery

### DIFF
--- a/changes/+cura-local-fallback.feature
+++ b/changes/+cura-local-fallback.feature
@@ -1,0 +1,1 @@
+Support CuraEngine in local slicer discovery (``find_slicer``) for all platforms

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -27,15 +27,18 @@ def _slicer_paths() -> dict[str, Path]:
     if sys.platform == "darwin":
         return {
             "orca": Path("/Applications/OrcaSlicer.app/Contents/MacOS/OrcaSlicer"),
+            "cura": Path("/Applications/UltiMaker Cura.app/Contents/MacOS/CuraEngine"),
         }
     elif sys.platform == "win32":
         pf = Path("C:/Program Files")
         return {
             "orca": pf / "OrcaSlicer/orca-slicer.exe",
+            "cura": pf / "UltiMaker Cura/CuraEngine.exe",
         }
     else:  # Linux and other Unix
         return {
             "orca": Path("/usr/bin/orca-slicer"),
+            "cura": Path("/usr/local/bin/CuraEngine"),
         }
 
 
@@ -63,7 +66,11 @@ def find_slicer(engine: str) -> Path:
         return path
 
     # Fall back to PATH lookup (handles AppImage, Flatpak, AUR, custom installs)
-    for name in ("orca-slicer", "OrcaSlicer", "OrcaSlicer.AppImage"):
+    path_names = {
+        "orca": ("orca-slicer", "OrcaSlicer", "OrcaSlicer.AppImage"),
+        "cura": ("CuraEngine", "curaengine"),
+    }
+    for name in path_names.get(engine, ()):
         found = shutil.which(name)
         if found:
             return Path(found)

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -30,7 +30,7 @@ def test_find_orca():
 
 def test_find_unknown():
     with pytest.raises(ValueError, match="Unknown slicer"):
-        find_slicer("cura")
+        find_slicer("nonexistent")
 
 
 def test_find_slicer_path_fallback():

--- a/todo-slicer.md
+++ b/todo-slicer.md
@@ -50,10 +50,8 @@ CuraEngine exists alongside OrcaSlicer.
 
 ## Medium — local fallback won't work
 
-- [ ] **`find_slicer()` OrcaSlicer-only** (`src/estampo/slicer.py:29-71`)
-  `SLICER_PATHS` only has `"orca"` entries. Executable names only include
-  `orca-slicer`, `OrcaSlicer`, `OrcaSlicer.AppImage`.
-  CuraEngine local fallback (when Docker is unavailable) doesn't exist.
+- [x] **`find_slicer()` OrcaSlicer-only** (`src/estampo/slicer.py:29-71`)
+  Now includes CuraEngine paths and PATH lookup names for all platforms.
 
 - [x] **Docker fallback messages** (`src/estampo/slicer.py`)
   Error messages now reference the engine being used and the specific


### PR DESCRIPTION
## Summary
- Add CuraEngine default paths to `SLICER_PATHS` for macOS, Windows, and Linux
- Add CuraEngine executable names (`CuraEngine`, `curaengine`) to PATH fallback lookup
- Enables local CuraEngine fallback when Docker is unavailable

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)