### PR TITLE
Add engine choice to init wizard

### DIFF
--- a/changes/+init-engine-choice.feature
+++ b/changes/+init-engine-choice.feature
@@ -1,0 +1,1 @@
+``estampo init`` wizard now prompts for slicer engine (OrcaSlicer or CuraEngine) and adapts version detection and profile discovery accordingly.

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -28,8 +28,8 @@ size = [256, 256]       # bed size in mm [x, y]
 padding = 5.0           # gap between parts in mm
 
 [slicer]
-engine = "orca"
-# version = "2.3.1"                        # pin OrcaSlicer version for reproducibility
+engine = "orca"                            # "orca" (OrcaSlicer) or "cura" (CuraEngine)
+# version = "2.3.1"                        # pin slicer version for reproducibility
 printer = "Bambu Lab P1S 0.4 nozzle"       # machine profile name
 process = "0.20mm Standard @BBL X1C"       # process/quality profile
 filaments = ["Generic PLA @base"]          # filament profiles (one per AMS slot)
@@ -579,7 +579,7 @@ def _prompt_slicer_version() -> str | None:
         idx = pick - 1
         if 0 <= idx < len(available):
             version = available[idx]
-            ui.success(f"OrcaSlicer {version}")
+            ui.success(f"OrcaSlicer v{version}")
             return version
         return None
 
@@ -1015,7 +1015,7 @@ def _wizard_pick_plate(machine_info: _MachineInfo) -> tuple[int, int]:
     return plate_x, plate_y
 
 
-def _wizard_pick_slicer_version() -> str | None:
+def _wizard_pick_slicer_version(engine: str = "orca") -> str | None:
     """Pick slicer version to pin.
 
     Returns the version string, or ``None`` if skipped.
@@ -1023,6 +1023,16 @@ def _wizard_pick_slicer_version() -> str | None:
     from estampo import ui
 
     ui.heading("Slicer Version")
+    if engine == "cura":
+        from estampo.cura import CURAENGINE_VERSION
+
+        version = _prompt_str(
+            f"CuraEngine version to pin (default: {CURAENGINE_VERSION})",
+            CURAENGINE_VERSION,
+        )
+        ui.console.print()
+        return version or None
+
     slicer_version = _prompt_slicer_version()
     ui.console.print()
 
@@ -1071,11 +1081,33 @@ def run_wizard(output: Path | None = None) -> str:
     ui.heading("estampo init")
     ui.console.print()
 
-    engine = "orca"
+    # --- Engine choice ---
+    existing_engine = None
+    dest = output or Path("estampo.toml")
+    existing_pre = _load_existing(dest)
+    if existing_pre and hasattr(existing_pre, "engine"):
+        existing_engine = existing_pre.engine
+
+    engines = ["orca", "cura"]
+    engine_labels = {"orca": "OrcaSlicer", "cura": "CuraEngine"}
+    default_engine = existing_engine or "orca"
+    default_idx = engines.index(default_engine) + 1 if default_engine in engines else 1
+    ui.info("Select slicer engine:")
+    for i, eng in enumerate(engines, 1):
+        marker = " ←" if eng == existing_engine else ""
+        ui.info(f"  {i}. {engine_labels[eng]}{marker}")
+    engine_pick = _prompt_str(
+        f"Pick engine (default: {engine_labels[default_engine]})", str(default_idx)
+    ).strip()
+    if engine_pick.isdigit() and 1 <= int(engine_pick) <= len(engines):
+        engine = engines[int(engine_pick) - 1]
+    else:
+        engine = default_engine
+    ui.info(f"  → {engine_labels[engine]}")
+    ui.console.print()
 
     # --- Load existing config for pre-population ---
-    dest = output or Path("estampo.toml")
-    existing = _load_existing(dest)
+    existing = existing_pre
     if existing:
         ui.info(f"Found existing {dest.name} — values shown as defaults")
         ui.console.print()
@@ -1106,21 +1138,29 @@ def run_wizard(output: Path | None = None) -> str:
         ams_future = _ams_pool.submit(_query_ams_trays, configured)
 
     # --- Discover profiles (needed for picker and machine info) ---
-    profiles, profile_source = discover_profile_names(engine)
-    if profile_source == "bundled":
-        ui.info("Using bundled profile list — install OrcaSlicer locally for full access")
-        ui.console.print()
-    elif profile_source == "none":
-        ui.warn("No profiles found — profile names will need to be entered manually")
-        ui.console.print()
+    if engine == "cura":
+        # CuraEngine uses inline CuraProfile defaults — no profile chain
+        profiles: dict[str, list[str]] = {}
+        printer_profile = None
+        process_profile = None
+        machine_info = _MachineInfo()
+        plate_x, plate_y = _wizard_pick_plate(machine_info)
+    else:
+        profiles, profile_source = discover_profile_names(engine)
+        if profile_source == "bundled":
+            ui.info("Using bundled profile list — install the slicer locally for full access")
+            ui.console.print()
+        elif profile_source == "none":
+            ui.warn("No profiles found — profile names will need to be entered manually")
+            ui.console.print()
 
-    # --- Step 4: Plate size ---
-    # Pick printer profile first to auto-detect plate size from machine info
-    printer_profile, process_profile, machine_info = _wizard_pick_profiles(engine, profiles)
-    plate_x, plate_y = _wizard_pick_plate(machine_info)
+        # --- Step 4: Plate size ---
+        # Pick printer profile first to auto-detect plate size from machine info
+        printer_profile, process_profile, machine_info = _wizard_pick_profiles(engine, profiles)
+        plate_x, plate_y = _wizard_pick_plate(machine_info)
 
     # --- Step 5: Slicer version ---
-    slicer_version = _wizard_pick_slicer_version()
+    slicer_version = _wizard_pick_slicer_version(engine)
 
     # --- Step 6: Filaments (AMS auto-detect or manual) ---
     ams_trays: list[dict] = []

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -672,6 +672,7 @@ class TestWizard:
         _mock_ui_inputs(
             monkeypatch,
             [
+                "1",  # Engine choice (OrcaSlicer)
                 "my-project",  # Project name
                 "1",  # Select files
                 "1",  # copies
@@ -716,6 +717,7 @@ class TestWizard:
         _mock_ui_inputs(
             monkeypatch,
             [
+                "1",  # Engine choice (OrcaSlicer)
                 "",  # Project name (use default)
                 "my-part.stl",  # Part file path
                 "n",  # Connect a printer? -> no

--- a/todo-slicer.md
+++ b/todo-slicer.md
@@ -18,20 +18,22 @@ CuraEngine exists alongside OrcaSlicer.
 
 ## High — init is OrcaSlicer-only
 
-- [ ] **Wizard hardcodes engine** (`src/estampo/init.py:1074`)
-  `engine = "orca"` — no engine choice offered in interactive wizard.
+- [x] **Wizard hardcodes engine** (`src/estampo/init.py:1074`)
+  Wizard now prompts user to choose OrcaSlicer or CuraEngine.
+  CuraEngine path skips OrcaSlicer-specific profile discovery.
 
-- [ ] **Version detection OrcaSlicer-only** (`src/estampo/init.py:513-591`)
-  `_detect_orca_version()` with no CuraEngine equivalent.
-  `_prompt_slicer_version()` only mentions OrcaSlicer.
+- [x] **Version detection OrcaSlicer-only** (`src/estampo/init.py:513-591`)
+  `_wizard_pick_slicer_version()` now handles both engines.
+  CuraEngine prompts with `CURAENGINE_VERSION` default.
 
 - [ ] **3MF extraction OrcaSlicer-only** (`src/estampo/init.py:1326-1365`)
   Reads `Metadata/project_settings.config` (OrcaSlicer format).
   Error message: "open it in OrcaSlicer and re-save".
   CuraEngine 3MFs have different internal structure.
 
-- [ ] **TOML template hardcodes orca** (`src/estampo/init.py:31`)
-  Generated config always writes `engine = "orca"`.
+- [x] **TOML template hardcodes orca** (`src/estampo/init.py:31`)
+  Template comment now documents both engines: `"orca" or "cura"`.
+  Engine value set from wizard choice.
 
 ## Medium — profile system is OrcaSlicer-only
 


### PR DESCRIPTION
## Summary
- `estampo init` wizard now prompts user to choose OrcaSlicer or CuraEngine at the start
- CuraEngine path skips OrcaSlicer-specific profile discovery and uses `CURAENGINE_VERSION` for version pinning
- TOML template comment documents both engine options (`"orca"` or `"cura"`)
- Updated wizard tests to include engine choice input

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — all formatted
- [x] `uv run mypy src/estampo` — zero errors
- [x] `uv run pytest` — 582 passed, 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)