### PR TITLE
Make profile system engine-aware for CuraEngine

### DIFF
--- a/changes/+profiles-engine-aware.misc
+++ b/changes/+profiles-engine-aware.misc
@@ -1,0 +1,1 @@
+Profile system now handles CuraEngine gracefully — ``profiles list --engine cura`` explains that CuraEngine uses inline settings instead of showing empty results.

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -785,7 +785,15 @@ def profiles_list(
 ) -> None:
     """List available profiles."""
     _setup_logging(verbose)
-    from estampo.profiles import CATEGORIES, discover_profiles
+    from estampo.profiles import (
+        _INLINE_ENGINES,
+        CATEGORIES,
+        discover_profiles,
+    )
+
+    if engine in _INLINE_ENGINES:
+        print(f"Engine '{engine}' uses inline settings — no extractable profiles.")
+        raise typer.Exit(0)
 
     profiles = discover_profiles(engine)
     categories = [category] if category else list(CATEGORIES)
@@ -803,7 +811,7 @@ def profiles_pin(
 ) -> None:
     """Pin profiles from config into local profiles/ dir.
 
-    Extracts profiles from Docker if OrcaSlicer is not installed locally.
+    Extracts profiles from Docker if the slicer is not installed locally.
     """
     _setup_logging(verbose)
     import tomllib

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -44,14 +44,22 @@ def _is_path(value: str) -> bool:
     return "/" in value or "\\" in value
 
 
+# Engines that use inline settings and have no extractable profile chain.
+_INLINE_ENGINES = frozenset({"cura"})
+
+
 def discover_profiles(engine: str) -> dict[str, dict[str, Path]]:
     """Scan system directories for available profiles.
 
     Returns {"machine": {"Name": Path, ...}, "process": {...}, "filament": {...}}
     """
+    if engine in _INLINE_ENGINES:
+        return {cat: {} for cat in CATEGORIES}
+
     base = SYSTEM_DIRS.get(engine)
     if base is None:
-        raise ValueError(f"Unknown engine: '{engine}'. Supported: {list(SYSTEM_DIRS)}")
+        supported = sorted({*SYSTEM_DIRS, *_INLINE_ENGINES})
+        raise ValueError(f"Unknown engine: '{engine}'. Supported: {supported}")
 
     # Expected JSON "type" field for each category.
     # machine_model profiles (e.g. "Bambu Lab P1S") define the printer
@@ -524,7 +532,7 @@ def pin_profiles(
                 if not docker_version:
                     raise EstampoError(
                         f"Profile '{name}' not found locally. Set slicer.version in "
-                        "your config or install OrcaSlicer to access profiles."
+                        "your config or install the slicer locally to access profiles."
                     )
                 raise
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -74,7 +74,13 @@ def test_resolve_path_traversal_rejected():
 
 def test_discover_unknown_engine():
     with pytest.raises(ValueError, match="Unknown engine"):
-        discover_profiles("cura")
+        discover_profiles("nonexistent")
+
+
+def test_discover_cura_returns_empty():
+    """CuraEngine uses inline settings — discover_profiles returns empty dicts."""
+    result = discover_profiles("cura")
+    assert all(v == {} for v in result.values())
 
 
 @pytest.mark.skipif(not _has_orca(), reason="OrcaSlicer not installed")

--- a/todo-slicer.md
+++ b/todo-slicer.md
@@ -37,15 +37,13 @@ CuraEngine exists alongside OrcaSlicer.
 
 ## Medium — profile system is OrcaSlicer-only
 
-- [ ] **Profile system paths** (`src/estampo/profiles.py:25-35,166`)
-  System directories (macOS/Windows/Linux) and Docker path
-  (`/opt/orca-slicer/resources/profiles/BBL`) only defined for OrcaSlicer.
-  CuraEngine uses inline `CuraProfile` defaults — no equivalent profile
-  discovery needed today, but error messages should not suggest installing
-  OrcaSlicer.
+- [x] **Profile system paths** (`src/estampo/profiles.py:25-35,166`)
+  `discover_profiles("cura")` now returns empty dicts instead of raising.
+  Error messages no longer suggest installing OrcaSlicer specifically.
 
-- [ ] **`profiles list` defaults to orca** (`src/estampo/cli.py:780`)
-  Should be engine-aware or require explicit engine flag.
+- [x] **`profiles list` defaults to orca** (`src/estampo/cli.py:780`)
+  `profiles list --engine cura` now prints a clear message that CuraEngine
+  uses inline settings and has no extractable profiles.
 
 - [x] **Profile error messages** (`src/estampo/profiles.py:198`)
   Now says "Check your Docker setup or install the slicer locally."


### PR DESCRIPTION
## Summary
- `discover_profiles("cura")` returns empty dicts instead of raising `ValueError` — CuraEngine uses inline settings with no extractable profile chain
- `profiles list --engine cura` prints a clear message explaining this instead of showing empty category lists
- `profiles pin` docstring and error message no longer reference OrcaSlicer specifically
- Test updated: `test_discover_unknown_engine` now uses `"nonexistent"` instead of `"cura"`, added `test_discover_cura_returns_empty`

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — all formatted
- [x] `uv run mypy src/estampo` — zero errors
- [x] `uv run pytest` — 583 passed, 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)