### PR TITLE
Fix CuraEngine reporting zero filament usage

### DIFF
--- a/changes/+cura-filament-usage.bugfix
+++ b/changes/+cura-filament-usage.bugfix
@@ -1,0 +1,1 @@
+Fix CuraEngine reporting zero filament usage — CuraEngine CLI writes placeholder G-code header values that are not updated after slicing; patch with real values from stderr and fall back to E-value analysis.

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -11,6 +11,7 @@ packaged in a minimal Docker image (~95 MB) with bundled definitions.
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -146,6 +147,44 @@ def _settings_flags(profile: CuraProfile) -> list[str]:
     return flags
 
 
+def _patch_gcode_header(gcode_path: Path, stderr: str) -> None:
+    """Patch CuraEngine placeholder header with real values from stderr.
+
+    When invoked via CLI with our AppImage-extracted binary, CuraEngine
+    writes placeholder values (``TIME:6666``, ``Filament used: 0m``) to
+    the G-code header and does not seek back to update them after slicing.
+    The real values are logged to stderr.  This function extracts the
+    real header from stderr and replaces the placeholder block in the
+    G-code file.
+    """
+    m = re.search(
+        r"Gcode header after slicing:\s*(;FLAVOR:.*?;TARGET_MACHINE\.NAME:\S+)",
+        stderr,
+        re.DOTALL,
+    )
+    if not m:
+        log.debug("Could not find real header in CuraEngine stderr; skipping patch")
+        return
+
+    real_header = m.group(1).strip() + "\n"
+
+    text = gcode_path.read_text()
+    # The placeholder block starts with ";FLAVOR:" and ends before the blank
+    # line / ";Generated with" line.
+    patched = re.sub(
+        r";FLAVOR:.*?;TARGET_MACHINE\.NAME:\S+\n",
+        real_header,
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+    if patched != text:
+        gcode_path.write_text(patched)
+        log.info("Patched G-code header with real values from CuraEngine stderr")
+    else:
+        log.debug("G-code header patch had no effect")
+
+
 def slice_stl(
     stl_path: Path,
     output_dir: Path,
@@ -243,6 +282,11 @@ def slice_stl(
     if not output_gcode.exists() or output_gcode.stat().st_size < 100:
         combined = (result.stdout + "\n" + result.stderr).strip()
         raise EstampoError(f"CuraEngine produced no output:\n{combined[:500]}")
+
+    # CuraEngine CLI writes placeholder values in the G-code header
+    # (TIME:6666, Filament used: 0m) and does not update them after slicing.
+    # The real values are logged to stderr.  Parse and patch the file.
+    _patch_gcode_header(output_gcode, result.stderr)
 
     log.info("CuraEngine output: %s (%d bytes)", output_gcode, output_gcode.stat().st_size)
     return output_dir

--- a/src/estampo/gcode.py
+++ b/src/estampo/gcode.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 import zipfile
 from dataclasses import dataclass, field
@@ -12,6 +13,43 @@ from estampo import require_file
 # Number of lines to scan from the start/end of gcode for metadata
 GCODE_HEADER_LINES = 300
 GCODE_TAIL_LINES = 50
+
+# Filament constants (1.75mm diameter, PLA/PETG average density)
+_DIAMETER_CM = 0.175
+_DENSITY_G_CM3 = 1.24
+
+# Regex for extracting E values from G1 moves (absolute extrusion)
+_E_VALUE_RE = re.compile(r"E([\d.]+)")
+
+
+def _max_e_value(lines: list[str]) -> float:
+    """Find the maximum E value in G-code (absolute extrusion mode).
+
+    Scans for ``G1 ... E<value>`` moves, tracking ``G92 E0`` resets.
+    Returns total mm of filament extruded.  Falls back to 0 if the
+    gcode uses relative extrusion (``M83``).
+    """
+    total = 0.0
+    max_e = 0.0
+    relative = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "M83":
+            relative = True
+        elif stripped == "M82":
+            relative = False
+        elif stripped.startswith("G92"):
+            if m := _E_VALUE_RE.search(stripped):
+                # E reset — accumulate what we had and restart
+                total += max_e
+                max_e = float(m.group(1))
+        elif not relative and stripped.startswith("G1"):
+            if m := _E_VALUE_RE.search(stripped):
+                e = float(m.group(1))
+                if e > max_e:
+                    max_e = e
+    total += max_e
+    return total
 
 
 def _format_seconds(secs: int) -> str:
@@ -56,15 +94,9 @@ def parse_gcode_metadata(gcode_path: Path) -> dict[str, str | float | int]:
         # CuraEngine: ;Filament used: 1.23456m
         elif m := re.match(r";Filament used:\s*([\d.]+)m", line):
             meters = float(m.group(1))
-            # Convert meters of 1.75mm filament to cm³ and grams
-            # Volume = length * pi * (d/2)^2; density ~1.24 g/cm³ (PLA/PETG avg)
-            diameter_cm = 0.175
-            import math
-
-            cm3 = meters * 100 * math.pi * (diameter_cm / 2) ** 2
+            cm3 = meters * 100 * math.pi * (_DIAMETER_CM / 2) ** 2
             stats["filament_cm3"] = round(cm3, 2)
-            # Approximate grams (density varies by material, ~1.24 is reasonable)
-            stats["filament_g"] = round(cm3 * 1.24, 2)
+            stats["filament_g"] = round(cm3 * _DENSITY_G_CM3, 2)
 
     # Scan tail for OrcaSlicer filament stats (CuraEngine puts them in header).
     # OrcaSlicer emits one line per slot (including 0.00 for unused slots)
@@ -90,6 +122,16 @@ def parse_gcode_metadata(gcode_path: Path) -> dict[str, str | float | int]:
         stats["filament_g"] = g
     if cm3 > 0:
         stats["filament_cm3"] = cm3
+
+    # Fallback: if no filament stats found (or zero), compute from E moves.
+    # This covers CuraEngine's placeholder-header bug and any other slicer
+    # that doesn't embed filament stats in the G-code.
+    if not stats.get("filament_g"):
+        e_mm = _max_e_value(lines)
+        if e_mm > 0:
+            e_cm3 = (e_mm / 10) * math.pi * (_DIAMETER_CM / 2) ** 2
+            stats["filament_cm3"] = round(e_cm3, 2)
+            stats["filament_g"] = round(e_cm3 * _DENSITY_G_CM3, 2)
 
     # Convert time string like "1h 7m 32s" to seconds (if not already set)
     if "print_time" in stats and "print_time_secs" not in stats:
@@ -174,18 +216,21 @@ def analyze_gcode(path: Path) -> GcodeInfo:
             # CuraEngine material index (single extruder)
             pass  # filament type not encoded here
         elif m := re.match(r";Filament used:\s*([\d.]+)m", line):
-            # Convert meters to approximate grams for single-extruder
-            import math
-
             meters = float(m.group(1))
-            diameter_cm = 0.175
-            cm3 = meters * 100 * math.pi * (diameter_cm / 2) ** 2
-            info.filament_usage_g = [round(cm3 * 1.24, 2)]
+            cm3 = meters * 100 * math.pi * (_DIAMETER_CM / 2) ** 2
+            info.filament_usage_g = [round(cm3 * _DENSITY_G_CM3, 2)]
 
     # Parse per-slot filament usage from tail (OrcaSlicer)
     for line in lines[-GCODE_TAIL_LINES:]:
         if m := re.match(r";\s*filament used \[g\]\s*=\s*(.+)", line):
             info.filament_usage_g = [float(v.strip()) for v in m.group(1).split(",")]
+
+    # Fallback: compute from E moves if no filament usage found (or zero)
+    if not info.filament_usage_g or all(v == 0 for v in info.filament_usage_g):
+        e_mm = _max_e_value(lines)
+        if e_mm > 0:
+            e_cm3 = (e_mm / 10) * math.pi * (_DIAMETER_CM / 2) ** 2
+            info.filament_usage_g = [round(e_cm3 * _DENSITY_G_CM3, 2)]
 
     # Walk gcode for layers and tool changes.
     # OrcaSlicer: Z_HEIGHT appears immediately after CHANGE_LAYER.

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -7,6 +7,7 @@ import pytest
 from estampo import EstampoError
 from estampo.cura import (
     CuraProfile,
+    _patch_gcode_header,
     _render_bbl_gcode,
     _settings_flags,
     cura_docker_image,
@@ -283,3 +284,46 @@ def test_slice_plate_cura_dispatch(tmp_path):
     assert profile.layer_height == 0.12
     assert profile.filament_type == "PLA"
     assert "estampo/estampo:cura-5.12.0" in str(call_kwargs)
+
+
+# --- _patch_gcode_header ---
+
+
+def test_patch_gcode_header_replaces_placeholder(tmp_path):
+    """Placeholder header (TIME:6666, 0m) is replaced with real values from stderr."""
+    gcode = tmp_path / "test.gcode"
+    gcode.write_text(
+        ";FLAVOR:Marlin\n"
+        ";TIME:6666\n"
+        ";Filament used: 0m\n"
+        ";Layer height: 0.2\n"
+        ";MINX:2.14748e+06\n;MINY:2.14748e+06\n;MINZ:2.14748e+06\n"
+        ";MAXX:-2.14748e+06\n;MAXY:-2.14748e+06\n;MAXZ:-2.14748e+06\n"
+        ";TARGET_MACHINE.NAME:Unknown\n"
+        "\n;Generated with Cura_SteamEngine 5.12.0\nG28\n"
+    )
+    stderr = (
+        "[info] Gcode header after slicing: ;FLAVOR:Marlin\n"
+        ";TIME:1519\n"
+        ";Filament used: 0.714216m\n"
+        ";Layer height: 0.2\n"
+        ";MINX:128.2\n;MINY:128.2\n;MINZ:0.3\n"
+        ";MAXX:147.8\n;MAXY:147.8\n;MAXZ:19.9\n"
+        ";TARGET_MACHINE.NAME:Unknown\n"
+    )
+    _patch_gcode_header(gcode, stderr)
+    text = gcode.read_text()
+    assert ";TIME:1519" in text
+    assert ";Filament used: 0.714216m" in text
+    assert ";MINX:128.2" in text
+    assert ";TIME:6666" not in text
+    assert ";Filament used: 0m" not in text
+
+
+def test_patch_gcode_header_no_match(tmp_path):
+    """If stderr doesn't contain the expected header, file is unchanged."""
+    gcode = tmp_path / "test.gcode"
+    original = ";FLAVOR:Marlin\n;TIME:6666\n;Filament used: 0m\n;TARGET_MACHINE.NAME:X\nG28\n"
+    gcode.write_text(original)
+    _patch_gcode_header(gcode, "some random stderr output")
+    assert gcode.read_text() == original

--- a/tests/test_gcode.py
+++ b/tests/test_gcode.py
@@ -94,6 +94,67 @@ def test_analyze_cura_layers(tmp_path):
     assert info.spans[0].extruder == 0
 
 
+def test_e_value_fallback_when_header_reports_zero(tmp_path):
+    """When header says ;Filament used: 0m, fall back to E-value calculation."""
+    lines = [
+        ";FLAVOR:Marlin",
+        ";TIME:1000",
+        ";Filament used: 0m",
+        ";Generated with Cura_SteamEngine 5.12.0",
+        "M82 ;absolute extrusion mode",
+        "G92 E0",
+        "G1 X10 Y10 E5.0 F1000",
+        "G1 X20 Y20 E10.0",
+        "G1 X30 Y30 E15.0",
+    ]
+    gcode = tmp_path / "test.gcode"
+    gcode.write_text("\n".join(lines))
+    stats = parse_gcode_metadata(gcode)
+    # Should have computed filament from E values, not from the 0m header
+    assert stats["filament_g"] > 0
+    assert stats["filament_cm3"] > 0
+
+
+def test_e_value_fallback_analyze_gcode(tmp_path):
+    """analyze_gcode also falls back to E values for zero filament header."""
+    lines = [
+        ";Generated with Cura_SteamEngine 5.12.0",
+        ";TIME:600",
+        ";Filament used: 0m",
+        ";LAYER_COUNT:2",
+        ";LAYER:0",
+        "G0 Z0.2",
+        "M82",
+        "G92 E0",
+        "G1 X10 Y10 E5.0 F1000",
+        ";LAYER:1",
+        "G0 Z0.4",
+        "G1 X20 Y20 E10.0",
+    ]
+    gcode = tmp_path / "test.gcode"
+    gcode.write_text("\n".join(lines))
+    info = analyze_gcode(gcode)
+    assert info.filament_usage_g
+    assert info.filament_usage_g[0] > 0
+
+
+def test_e_value_tracks_g92_resets(tmp_path):
+    """E-value fallback correctly handles G92 E0 resets."""
+    lines = [
+        ";Filament used: 0m",
+        "M82",
+        "G92 E0",
+        "G1 X10 E100.0",
+        "G92 E0",  # reset — 100mm accumulated
+        "G1 X20 E50.0",
+    ]
+    gcode = tmp_path / "test.gcode"
+    gcode.write_text("\n".join(lines))
+    stats = parse_gcode_metadata(gcode)
+    # Total E = 100 + 50 = 150mm
+    assert stats["filament_g"] > 0
+
+
 # --- analyze_gcode ---
 
 


### PR DESCRIPTION
## Summary
- CuraEngine 5.12 has a bug: writes placeholder header (`TIME:6666`, `Filament used: 0m`) to the G-code file but logs the real values to stderr
- `_patch_gcode_header()` in `cura.py` now parses the real header from stderr and patches the file after slicing
- `gcode.py` adds E-value fallback: when header reports 0m filament, scans G-code for max absolute E position to compute usage
- Filament conversion constants deduplicated into `_DIAMETER_CM` and `_DENSITY_G_CM3`

## Root cause
Confirmed via Docker testing: CuraEngine 5.12 writes a placeholder header before slicing, then fails to seek back and update it. The correct values appear in the `[info] Gcode header after slicing:` stderr log.

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — all formatted
- [x] `uv run mypy src/estampo` — zero errors
- [x] `uv run pytest` — 588 passed, 9 skipped (+5 new tests)
- [x] New tests: `test_patch_gcode_header_replaces_placeholder`, `test_patch_gcode_header_no_match`, `test_e_value_fallback_when_header_reports_zero`, `test_e_value_fallback_analyze_gcode`, `test_e_value_tracks_g92_resets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)