### PR TITLE
Fix Docker slicer input staging and extension handling

### DIFF
--- a/changes/+docker-staging.bugfix
+++ b/changes/+docker-staging.bugfix
@@ -1,0 +1,1 @@
+Stage Docker slicer input inside output directory and preserve file extension to fix bind-mount issues

--- a/scripts/compare_engines.py
+++ b/scripts/compare_engines.py
@@ -90,20 +90,35 @@ def _gcode_structure(gcode_path: Path) -> dict[str, bool]:
     }
 
 
-def _slice_orca(stl_path: Path, output_base: Path) -> Path:
-    """Slice with OrcaSlicer via Docker."""
+def _stl_to_3mf(stl_path: Path, output_dir: Path) -> Path:
+    """Package an STL into a 3MF that OrcaSlicer can load.
+
+    Uses estampo's own plate builder which produces 3MFs with the
+    metadata structure OrcaSlicer expects (plain trimesh 3MF export
+    is not sufficient).
+    """
     import trimesh
 
+    from estampo.arrange import Placement
+    from estampo.plate import build_plate, export_plate
+
+    mesh = trimesh.load(str(stl_path), force="mesh")
+    # Center on plate, touching the bed
+    mesh.vertices -= mesh.bounds[0]
+    placement = Placement(mesh=mesh, name=stl_path.stem, x=128.0, y=128.0)
+    scene = build_plate([placement], plate_size=(256.0, 256.0))
+    out = output_dir / (stl_path.stem + ".3mf")
+    export_plate(scene, out)
+    return out
+
+
+def _slice_orca(stl_path: Path, output_base: Path) -> Path:
+    """Slice with OrcaSlicer via Docker."""
     output_dir = output_base / "orca"
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # OrcaSlicer needs a 3MF input
-    mesh = trimesh.load(str(stl_path))
-    if isinstance(mesh, trimesh.Scene):
-        mesh = mesh.to_geometry()
-    input_3mf = output_dir / "input.3mf"
-    scene = trimesh.Scene(mesh)
-    scene.export(str(input_3mf))
+    # OrcaSlicer CLI requires 3MF input — package the STL properly
+    input_3mf = _stl_to_3mf(stl_path, output_dir)
 
     result = slice_plate(
         input_3mf,

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -227,13 +227,19 @@ def _slice_via_docker(
 ) -> Path:
     """Run the slicer inside the estampo Docker container.
 
-    Profile files live under output_dir/.profiles/ so they're accessible
-    via the same volume mount as the output directory. No separate mount
-    needed (avoids macOS Docker temp-dir visibility issues).
+    The input file and profiles are staged under output_dir so
+    everything is accessible via a single volume mount.  This avoids
+    macOS issues where separate temp-dir bind-mounts aren't visible
+    to Docker, and reduces the number of mount points.
     """
     input_3mf = input_3mf.resolve()
     output_dir = output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage input inside output_dir — a single bind-mount for all I/O.
+    staged_input = output_dir / f".input{input_3mf.suffix}"
+    shutil.copy2(input_3mf, staged_input)
+    container_input = f"/work/output/.input{input_3mf.suffix}"
 
     # Profile dir is under output_dir, so rewrite paths relative to /work/output
     host_prefix = str(profile_dir)
@@ -245,8 +251,6 @@ def _slice_via_docker(
         "--rm",
         "--platform",
         "linux/amd64",
-        "-v",
-        f"{input_3mf}:/work/input.3mf:ro",
         "-v",
         f"{output_dir}:/work/output",
         "--entrypoint",
@@ -277,7 +281,7 @@ def _slice_via_docker(
             "--min-save",
             "--outputdir",
             "/work/output",
-            "/work/input.3mf",
+            container_input,
         ]
     )
 
@@ -287,6 +291,9 @@ def _slice_via_docker(
 
     with ui.status("Slicing"):
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+    # Clean up staged input regardless of outcome
+    staged_input.unlink(missing_ok=True)
 
     if result.returncode != 0:
         log.error("Docker slicer stderr:\n%s", result.stderr)

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -336,6 +336,94 @@ def test_slice_via_docker_command(tmp_path):
     assert str(profile_dir) not in cmd[settings_idx]
 
 
+def test_slice_via_docker_stages_input_in_output_dir(tmp_path):
+    """Input file is copied into output_dir for single-mount Docker access."""
+    input_3mf = tmp_path / "plate.3mf"
+    input_3mf.write_text("fake-3mf-content")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    profile_dir = output_dir / ".profiles"
+    profile_dir.mkdir()
+
+    mock_result = MagicMock(returncode=0, stdout="", stderr="")
+    staged_content = None
+
+    def capture_staged(cmd, **kwargs):
+        nonlocal staged_content
+        staged = output_dir / ".input.3mf"
+        if staged.exists():
+            staged_content = staged.read_text()
+        return mock_result
+
+    with patch("estampo.slicer.subprocess.run", side_effect=capture_staged):
+        _slice_via_docker(input_3mf, output_dir, profile_dir, None, None, "estampo:latest")
+
+    # Input was staged inside output_dir during Docker run
+    assert staged_content == "fake-3mf-content"
+    # Staged input is cleaned up after slicing
+    assert not (output_dir / ".input.3mf").exists()
+    # Only one volume mount (output_dir), no separate input mount
+    # (verified by absence of second -v flag with input path)
+
+
+def test_slice_via_docker_preserves_file_extension(tmp_path):
+    """File extension is preserved so OrcaSlicer parses the correct format."""
+    input_stl = tmp_path / "model.stl"
+    input_stl.write_text("fake-stl")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    profile_dir = output_dir / ".profiles"
+    profile_dir.mkdir()
+
+    mock_result = MagicMock(returncode=0, stdout="", stderr="")
+    with patch("estampo.slicer.subprocess.run", return_value=mock_result) as mock_run:
+        _slice_via_docker(input_stl, output_dir, profile_dir, None, None, "estampo:latest")
+
+    cmd = mock_run.call_args[0][0]
+    # Container input path uses .stl extension, not hardcoded .3mf
+    assert "/work/output/.input.stl" in cmd
+    assert ".input.3mf" not in " ".join(cmd)
+    # Staged file in output_dir also uses .stl extension
+    assert not (output_dir / ".input.3mf").exists()
+
+
+def test_slice_via_docker_single_volume_mount(tmp_path):
+    """Only one -v mount (output_dir) — no separate input file mount."""
+    input_3mf = tmp_path / "plate.3mf"
+    input_3mf.write_text("fake")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    profile_dir = output_dir / ".profiles"
+    profile_dir.mkdir()
+
+    mock_result = MagicMock(returncode=0, stdout="", stderr="")
+    with patch("estampo.slicer.subprocess.run", return_value=mock_result) as mock_run:
+        _slice_via_docker(input_3mf, output_dir, profile_dir, None, None, "estampo:latest")
+
+    cmd = mock_run.call_args[0][0]
+    volume_args = [cmd[i + 1] for i, v in enumerate(cmd) if v == "-v"]
+    assert len(volume_args) == 1
+    assert volume_args[0] == f"{output_dir}:/work/output"
+
+
+def test_slice_via_docker_cleans_staged_input_on_failure(tmp_path):
+    """Staged input is cleaned up even when slicer fails."""
+    input_3mf = tmp_path / "plate.3mf"
+    input_3mf.write_text("fake")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    profile_dir = output_dir / ".profiles"
+    profile_dir.mkdir()
+
+    mock_result = MagicMock(returncode=1, stdout="", stderr="some error")
+    with patch("estampo.slicer.subprocess.run", return_value=mock_result):
+        with pytest.raises(RuntimeError, match="Docker slicer failed"):
+            _slice_via_docker(input_3mf, output_dir, profile_dir, None, None, "estampo:latest")
+
+    # Staged input must be cleaned up even on failure
+    assert not (output_dir / ".input.3mf").exists()
+
+
 def test_slice_via_docker_failure(tmp_path):
     """Verify Docker slicer failure raises RuntimeError."""
     input_3mf = tmp_path / "plate.3mf"


### PR DESCRIPTION
## Summary
- Stage Docker slicer input inside output_dir instead of separate bind-mount — fixes Docker-in-Docker environments where file mounts become empty directories
- Preserve input file extension (was hardcoded to `.3mf`) so STL files parse correctly
- Clean up staged input file after slicing (including on failure)
- Update `compare_engines.py` to use estampo's plate builder for proper OrcaSlicer-compatible 3MFs

## Test plan
- [x] 4 new tests: staging behavior, extension preservation, single-mount verification, cleanup-on-failure
- [x] All 622 tests pass locally
- [x] Lint, format, mypy all clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)