### PR TITLE
Fix CuraEngine printer name resolution in profiles pin

### DIFF
--- a/changes/340.bugfix
+++ b/changes/340.bugfix
@@ -1,0 +1,1 @@
+Fix ``profiles pin`` failing for CuraEngine when printer name includes nozzle suffix or different casing

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -49,14 +49,51 @@ def _resolve_def_name(printer_name: str | None) -> str:
     """Map a human printer name to a definition filename stem.
 
     Uses the bundled manifest to map e.g. ``"BambuLab P1S"`` →
-    ``"bambulab_p1s"``.  Falls back to the name as-is if not found.
+    ``"bambulab_p1s"``.  Tries several fallbacks:
+
+    1. Exact match in manifest (``"BambuLab P1S"``).
+    2. Already a known definition ID (``"bambulab_p1s"``).
+    3. Case-insensitive match against manifest names.
+    4. Strip nozzle suffix (``"Bambu Lab P1S 0.4 nozzle"`` → retry).
+
+    Raises :class:`EstampoError` if nothing matches.
     """
     if not printer_name:
         return "bambulab_p1s"
     from estampo.profiles import load_cura_definition_map
 
     def_map = load_cura_definition_map()
-    return def_map.get(printer_name, printer_name)
+
+    # 1. Exact match
+    if printer_name in def_map:
+        return def_map[printer_name]
+
+    # 2. Already a definition ID (value in the map)
+    ids = set(def_map.values())
+    if printer_name in ids:
+        return printer_name
+
+    # 3. Case-insensitive match
+    lower_name = printer_name.lower()
+    for name, def_id in def_map.items():
+        if name.lower() == lower_name:
+            return def_id
+
+    # 4. Strip nozzle suffix pattern like " 0.4 nozzle", " 0.6mm nozzle"
+    stripped = re.sub(r"\s+\d+\.?\d*\s*(mm\s+)?nozzle$", "", printer_name, flags=re.IGNORECASE)
+    if stripped != printer_name:
+        # Retry with stripped name
+        if stripped in def_map:
+            return def_map[stripped]
+        for name, def_id in def_map.items():
+            if name.lower() == stripped.lower():
+                return def_id
+
+    raise EstampoError(
+        f"CuraEngine printer '{printer_name}' not found in the definition manifest. "
+        f"Available printers: {', '.join(sorted(def_map.keys()))}. "
+        f"Run 'estampo init' to pick a valid printer or check your TOML config."
+    )
 
 
 def _resolve_def_chain(

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -9,12 +9,52 @@ from estampo.cura import (
     CuraProfile,
     _patch_gcode_header,
     _place_on_bed,
+    _resolve_def_name,
     _settings_flags,
     _substitute_gcode_templates,
     cura_docker_image,
     cura_profile_from_config,
     slice_stl,
 )
+
+# --- _resolve_def_name ---
+
+
+def test_resolve_def_name_exact_match():
+    """Exact manifest name maps to definition ID."""
+    assert _resolve_def_name("BambuLab P1S") == "bambulab_p1s"
+
+
+def test_resolve_def_name_none_returns_default():
+    """None falls back to bambulab_p1s."""
+    assert _resolve_def_name(None) == "bambulab_p1s"
+
+
+def test_resolve_def_name_already_id():
+    """If the name is already a definition ID, return it as-is."""
+    assert _resolve_def_name("bambulab_p1s") == "bambulab_p1s"
+
+
+def test_resolve_def_name_case_insensitive():
+    """Case-insensitive matching against manifest names."""
+    assert _resolve_def_name("bambulab p1s") == "bambulab_p1s"
+
+
+def test_resolve_def_name_strips_nozzle_suffix():
+    """Machine profile names with nozzle suffix resolve correctly."""
+    assert _resolve_def_name("BambuLab P1S 0.4 nozzle") == "bambulab_p1s"
+
+
+def test_resolve_def_name_strips_nozzle_mm_suffix():
+    """Nozzle suffix with mm unit resolves correctly."""
+    assert _resolve_def_name("BambuLab P1S 0.6mm nozzle") == "bambulab_p1s"
+
+
+def test_resolve_def_name_unknown_raises():
+    """Unknown printer name raises EstampoError."""
+    with pytest.raises(EstampoError, match="not found in the definition manifest"):
+        _resolve_def_name("Totally Unknown Printer XYZ")
+
 
 # --- cura_docker_image ---
 


### PR DESCRIPTION
## Summary
- `_resolve_def_name()` now tries multiple strategies: exact match, already-an-ID, case-insensitive, strip nozzle suffix (e.g. "0.4 nozzle")
- Raises `EstampoError` with available printers instead of silently passing a bad name through
- Adds 7 tests covering all resolution paths

Previously, `estampo profiles pin` with `printer = "Bambu Lab P1S 0.4 nozzle"` (OrcaSlicer-style name) would fail with a confusing "definition not found in temp dir" error because the name was used as-is for the `.def.json` filename.

Closes #340

## Test plan
- [x] `test_resolve_def_name_exact_match` — manifest name works
- [x] `test_resolve_def_name_already_id` — definition ID passthrough
- [x] `test_resolve_def_name_case_insensitive` — case mismatch handled
- [x] `test_resolve_def_name_strips_nozzle_suffix` — "BambuLab P1S 0.4 nozzle" resolves
- [x] `test_resolve_def_name_unknown_raises` — clear error for unknown printers
- [x] Full test suite: 645 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)