### PR TITLE
Fix Claude review: raise max-turns to 8, add continue-on-error

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,9 +21,10 @@ jobs:
           fetch-depth: 0
 
       - uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-opus-4-6 --max-turns 4"
+          claude_args: "--model claude-opus-4-6 --max-turns 8"
           prompt: |
             You are reviewing a PR on the estampo project — a 3D printing automation CLI
             that supports OrcaSlicer and CuraEngine backends. All code in this project is

--- a/changes/+fix-claude-review-turns.misc
+++ b/changes/+fix-claude-review-turns.misc
@@ -1,0 +1,1 @@
+Fix Claude PR review workflow: raise max-turns to 8 and add continue-on-error so turn limit never blocks a merge


### PR DESCRIPTION
The review job was failing with `Reached maximum number of turns (4)` and blocking merges.

- Raised `--max-turns` from 4 to 8
- Added `continue-on-error: true` — if turn limit is still hit, it posts whatever was completed and the check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)