### PR TITLE
Fix CuraEngine slice when machine profile JSON is missing

### DIFF
--- a/changes/345.bugfix
+++ b/changes/345.bugfix
@@ -1,0 +1,1 @@
+Fix CuraEngine slice failing when no separate machine profile JSON exists for the printer

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -619,14 +619,19 @@ def cura_profile_from_config(
     """
     profile = CuraProfile()
 
-    # Load machine definition from JSON
+    # Load machine profile JSON if available (nozzle/material overrides).
+    # Falls back to CuraProfile defaults when no machine profile exists —
+    # the .def.json definition is sufficient for slicing.
     machine_name = printer or "Bambu Lab P1S 0.4 nozzle"
-    machine_data = load_cura_machine_profile(machine_name, project_dir, profiles_dir)
-    for key, value in machine_data.items():
-        if hasattr(profile, key):
-            field_type = type(getattr(profile, key))
-            value = _coerce(value, field_type)
-            setattr(profile, key, value)
+    try:
+        machine_data = load_cura_machine_profile(machine_name, project_dir, profiles_dir)
+        for key, value in machine_data.items():
+            if hasattr(profile, key):
+                field_type = type(getattr(profile, key))
+                value = _coerce(value, field_type)
+                setattr(profile, key, value)
+    except FileNotFoundError:
+        log.debug("No machine profile for '%s', using defaults", machine_name)
 
     if bed_type:
         profile.bed_type = bed_type


### PR DESCRIPTION
## Summary
- `cura_profile_from_config()` now catches `FileNotFoundError` when the machine profile JSON doesn't exist, falling back to `CuraProfile` defaults
- The machine profile only contains `nozzle_diameter` (0.4) and `material_diameter` (1.75) which are already the defaults — the `.def.json` definition provides all essential machine geometry

Previously, after `profiles pin` and `estampo run`, slicing failed with:
```
CuraEngine machine profile 'BambuLab P1S' not found.
```
because the bundled file is `Bambu Lab P1S 0.4 nozzle.json` (nozzle-specific name) but the config has `printer = "BambuLab P1S"` (definition name).

Closes #345

## Test plan
- [x] All existing tests pass (645 passed)
- [ ] Manual: `estampo profiles pin` + `estampo run` with CuraEngine config no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)