### PR TITLE
Fix CuraEngine squash to keep inherits for unresolved parents

### DIFF
--- a/changes/347.bugfix
+++ b/changes/347.bugfix
@@ -1,0 +1,1 @@
+Fix CuraEngine squashed definitions preserving ``inherits`` for unresolved base definitions like ``fdmprinter``

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -648,17 +648,22 @@ def _squash_cura_def(def_id: str, defs_dir: Path) -> dict:
     """Walk the inheritance chain for a CuraEngine definition and squash it.
 
     Reads ``*.def.json`` files from *defs_dir*, follows ``inherits`` links,
-    and deep-merges overrides from root to leaf.  Returns a standalone
-    definition dict with ``inherits`` removed.
+    and deep-merges overrides from root to leaf.  If the chain ends at an
+    unresolved parent (e.g. ``fdmprinter`` which ships inside the CuraEngine
+    Docker image), ``inherits`` is preserved so CuraEngine can resolve it
+    at runtime via its ``-d`` search path.
     """
     chain: list[dict] = []
     current_id: str | None = def_id
     seen: set[str] = set()
+    unresolved_parent: str | None = None
 
     while current_id and current_id not in seen:
         seen.add(current_id)
         path = defs_dir / f"{current_id}.def.json"
         if not path.exists():
+            # Parent not available locally — CuraEngine resolves it at runtime
+            unresolved_parent = current_id
             break
         with open(path) as f:
             data = json.load(f)
@@ -678,13 +683,14 @@ def _squash_cura_def(def_id: str, defs_dir: Path) -> dict:
 
     # Build squashed result from the leaf definition
     leaf = chain[0]
-    squashed = {
+    squashed: dict = {
         "version": leaf.get("version", 2),
         "name": leaf.get("name", def_id),
         "metadata": merged_metadata,
         "overrides": merged_overrides,
     }
-    # No "inherits" — it's fully resolved
+    if unresolved_parent:
+        squashed["inherits"] = unresolved_parent
     return squashed
 
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -815,6 +815,7 @@ def test_squash_cura_def(tmp_path):
     (tmp_path / "child.def.json").write_text(json.dumps(child))
 
     squashed = _squash_cura_def("child", tmp_path)
+    # Both definitions are local — fully resolved, no inherits
     assert "inherits" not in squashed
     assert squashed["name"] == "Child Printer"
     # Child overrides parent
@@ -826,6 +827,40 @@ def test_squash_cura_def(tmp_path):
     # Metadata merged (child visible overrides parent)
     assert squashed["metadata"]["visible"] is True
     assert squashed["metadata"]["author"] == "test"
+
+
+def test_squash_cura_def_keeps_unresolved_parent(tmp_path):
+    """Squashing preserves inherits when the root parent is not available locally."""
+    from estampo.profiles import _squash_cura_def
+
+    # child → base → fdmprinter (not available locally)
+    base = {
+        "version": 2,
+        "name": "Base",
+        "inherits": "fdmprinter",
+        "metadata": {"visible": False},
+        "overrides": {
+            "speed_print": {"value": 100},
+            "acceleration_infill": {"value": "acceleration_print"},
+        },
+    }
+    child = {
+        "version": 2,
+        "name": "My Printer",
+        "inherits": "base",
+        "metadata": {"visible": True},
+        "overrides": {"machine_width": {"value": 256}},
+    }
+    (tmp_path / "base.def.json").write_text(json.dumps(base))
+    (tmp_path / "child.def.json").write_text(json.dumps(child))
+
+    squashed = _squash_cura_def("child", tmp_path)
+    # fdmprinter is not local — keep inherits so CuraEngine resolves at runtime
+    assert squashed["inherits"] == "fdmprinter"
+    assert squashed["name"] == "My Printer"
+    assert squashed["overrides"]["machine_width"] == {"value": 256}
+    assert squashed["overrides"]["speed_print"] == {"value": 100}
+    assert squashed["overrides"]["acceleration_infill"] == {"value": "acceleration_print"}
 
 
 def test_add_profile_cura_def(tmp_path):
@@ -862,7 +897,8 @@ def test_pin_cura_definitions_from_bundled(tmp_path):
     assert dest.parent.name == "definitions"
 
     squashed = json.loads(dest.read_text())
-    assert "inherits" not in squashed
+    # fdmprinter is not bundled — kept so CuraEngine resolves at runtime
+    assert squashed.get("inherits") == "fdmprinter"
     assert squashed["name"] == "BambuLab P1S"
     # Should have overrides from both P1S and base merged
     assert "machine_width" in squashed["overrides"]


### PR DESCRIPTION
## Summary
- `_squash_cura_def()` now preserves `inherits` when the chain ends at a parent not available locally (e.g. `fdmprinter`)
- CuraEngine resolves `fdmprinter.def.json` at runtime from its Docker image via the `-d` search path
- Eliminates hundreds of "has no [default_]value" warnings caused by formula expressions that reference `fdmprinter` settings

Previously the squash stripped all `inherits`, leaving formula expressions like `"acceleration_print/8"` unresolvable.

Closes #347

## Test plan
- [x] New test: `test_squash_cura_def_keeps_unresolved_parent` — verifies `inherits` preserved
- [x] Updated test: `test_pin_cura_definitions_from_bundled` — expects `inherits: fdmprinter`
- [x] Existing test: `test_squash_cura_def` — fully local chain still has no `inherits`
- [x] Full suite: 646 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)