### PR TITLE
Replace eval() in cura.py with safe AST-based evaluators

### DIFF
--- a/changes/+replace-eval.bugfix
+++ b/changes/+replace-eval.bugfix
@@ -1,0 +1,1 @@
+Replace unsafe ``eval()`` in CuraEngine G-code template substitution with AST-based safe evaluators.

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -404,6 +404,73 @@ def _place_on_bed(
     return out
 
 
+def _safe_eval_arithmetic(expr: str) -> float:
+    """Safely evaluate a simple arithmetic expression (integers and +-*/).
+
+    Uses ``ast`` to parse the expression and only allows numeric literals
+    and basic binary operators.  Raises ``ValueError`` for anything else.
+    """
+    import ast
+    import operator
+
+    _OPS: dict[type, object] = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval_node(node: ast.AST) -> float:
+        if isinstance(node, ast.Expression):
+            return _eval_node(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return float(node.value)
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval_node(node.operand)
+        if isinstance(node, ast.BinOp) and type(node.op) in _OPS:
+            op = _OPS[type(node.op)]
+            return op(  # type: ignore[operator]
+                _eval_node(node.left), _eval_node(node.right)
+            )
+        raise ValueError(f"Unsupported expression node: {ast.dump(node)}")
+
+    tree = ast.parse(expr.strip(), mode="eval")
+    return _eval_node(tree)
+
+
+def _safe_eval_condition(expr: str) -> bool:
+    """Safely evaluate a simple comparison expression (string == string).
+
+    Uses ``ast`` to parse the expression and only allows string/numeric
+    literals and ``==`` / ``!=`` comparisons.  Raises ``ValueError`` for
+    anything else.
+    """
+    import ast
+
+    tree = ast.parse(expr.strip(), mode="eval")
+    node = tree.body
+
+    if not isinstance(node, ast.Compare):
+        raise ValueError(f"Expected comparison, got: {ast.dump(node)}")
+    if len(node.ops) != 1 or len(node.comparators) != 1:
+        raise ValueError(f"Only single comparisons supported: {ast.dump(node)}")
+
+    def _get_value(n: ast.AST) -> object:
+        if isinstance(n, ast.Constant):
+            return n.value
+        raise ValueError(f"Unsupported node in comparison: {ast.dump(n)}")
+
+    left = _get_value(node.left)
+    right = _get_value(node.comparators[0])
+    op = node.ops[0]
+
+    if isinstance(op, ast.Eq):
+        return left == right
+    if isinstance(op, ast.NotEq):
+        return left != right
+    raise ValueError(f"Unsupported comparison operator: {ast.dump(op)}")
+
+
 def _substitute_gcode_templates(gcode_path: Path, profile: CuraProfile) -> None:
     """Replace OrcaSlicer-style ``{variable}`` placeholders in G-code.
 
@@ -435,8 +502,8 @@ def _substitute_gcode_templates(gcode_path: Path, profile: CuraProfile) -> None:
         for k, v in replacements.items():
             expr = expr.replace(k, v)
         try:
-            return str(int(eval(expr)))  # noqa: S307
-        except Exception:
+            return str(int(_safe_eval_arithmetic(expr)))
+        except (ValueError, TypeError, SyntaxError):
             return m.group(0)
 
     text, n = re.subn(r"\{([^}]*\b(?:material_\w+)\b[^}]*)\}", _eval_expr, text)
@@ -455,9 +522,9 @@ def _substitute_gcode_templates(gcode_path: Path, profile: CuraProfile) -> None:
             repr(profile.bed_type.lower().replace(" ", "_")),
         )
         try:
-            if eval(cond_eval):  # noqa: S307
+            if _safe_eval_condition(cond_eval):
                 return body
-        except Exception:
+        except (ValueError, TypeError, SyntaxError):
             pass
         return ""
 

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -10,6 +10,8 @@ from estampo.cura import (
     _patch_gcode_header,
     _place_on_bed,
     _resolve_def_name,
+    _safe_eval_arithmetic,
+    _safe_eval_condition,
     _settings_flags,
     _substitute_gcode_templates,
     cura_docker_image,
@@ -506,3 +508,45 @@ def test_substitute_no_change(tmp_path):
     profile = CuraProfile()
     _substitute_gcode_templates(gcode, profile)
     assert gcode.read_text() == original
+
+
+# --- _safe_eval_arithmetic ---
+
+
+def test_safe_eval_arithmetic_basic():
+    assert _safe_eval_arithmetic("260 - 20") == 240.0
+    assert _safe_eval_arithmetic("100 + 50") == 150.0
+    assert _safe_eval_arithmetic("10 * 3") == 30.0
+    assert _safe_eval_arithmetic("100 / 4") == 25.0
+
+
+def test_safe_eval_arithmetic_negative():
+    assert _safe_eval_arithmetic("-5") == -5.0
+
+
+def test_safe_eval_arithmetic_rejects_function_calls():
+    with pytest.raises(ValueError, match="Unsupported"):
+        _safe_eval_arithmetic("__import__('os').system('rm -rf /')")
+
+
+def test_safe_eval_arithmetic_rejects_names():
+    with pytest.raises(ValueError, match="Unsupported"):
+        _safe_eval_arithmetic("x + 1")
+
+
+# --- _safe_eval_condition ---
+
+
+def test_safe_eval_condition_string_eq():
+    assert _safe_eval_condition("'foo' == 'foo'") is True
+    assert _safe_eval_condition("'foo' == 'bar'") is False
+
+
+def test_safe_eval_condition_string_neq():
+    assert _safe_eval_condition("'foo' != 'bar'") is True
+    assert _safe_eval_condition("'foo' != 'foo'") is False
+
+
+def test_safe_eval_condition_rejects_function_calls():
+    with pytest.raises(ValueError):
+        _safe_eval_condition("__import__('os').system('id') == ''")


### PR DESCRIPTION
## Summary

Closes #330.

- Replace `eval(expr)` (line 438) with `_safe_eval_arithmetic()` — AST-parsed, only allows numeric literals and `+-*/` operators
- Replace `eval(cond_eval)` (line 458) with `_safe_eval_condition()` — AST-parsed, only allows literal `==` and `!=` comparisons
- Malicious expressions (e.g. `__import__('os').system(...)`) now raise `ValueError` instead of executing

## Test plan

- [x] All 40 existing cura tests pass (template substitution behavior unchanged)
- [x] New tests for `_safe_eval_arithmetic` (basic ops, negation, rejects function calls/names)
- [x] New tests for `_safe_eval_condition` (string eq/neq, rejects function calls)
- [x] ruff, mypy: zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)