### PR TITLE
Remove legacy flat [slicer] config and fabprint aliases (#332)

### DIFF
--- a/changes/+remove-legacy-config.misc
+++ b/changes/+remove-legacy-config.misc
@@ -1,0 +1,1 @@
+Remove legacy flat ``[slicer]`` config format, ``fabprint.toml`` alias, ``FABPRINT_*`` env vars, and ``~/.config/fabprint`` migration.

--- a/src/estampo/__init__.py
+++ b/src/estampo/__init__.py
@@ -12,14 +12,10 @@ class EstampoError(Exception):
     """User-facing error — printed without a traceback."""
 
 
-# Backward-compatible alias (fabprint → estampo migration)
-FabprintError = EstampoError
-
-
 def require_file(path: Path, label: str = "File") -> None:
     """Raise FileNotFoundError if *path* does not exist."""
     if not path.exists():
         raise FileNotFoundError(f"{label} not found: {path}")
 
 
-__all__ = ["EstampoError", "FabprintError", "__version__", "require_file"]
+__all__ = ["EstampoError", "__version__", "require_file"]

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -64,20 +64,10 @@ def _setup_logging(verbose: bool) -> None:
 
 
 def _resolve_config_path(config: Path | None) -> Path:
-    """Resolve config path, defaulting to ./estampo.toml (or ./fabprint.toml)."""
+    """Resolve config path, defaulting to ./estampo.toml."""
     if config is not None:
         return config
     candidate = Path("estampo.toml")
-    if not candidate.exists():
-        legacy = Path("fabprint.toml")
-        if legacy.exists():
-            import sys
-
-            print(
-                "Warning: fabprint.toml is deprecated — rename it to estampo.toml",
-                file=sys.stderr,
-            )
-            return legacy
     if not candidate.exists():
         raise EstampoError(
             "No config file specified and no estampo.toml found in the current directory.\n"

--- a/src/estampo/cloud/bridge.py
+++ b/src/estampo/cloud/bridge.py
@@ -49,18 +49,7 @@ def _should_pull_image() -> bool:
     in auto mode, a timestamp file to avoid pulling more than once
     per ``_PULL_INTERVAL_SECONDS``.
     """
-    mode = os.environ.get("ESTAMPO_DOCKER_PULL")
-    if not mode:
-        mode = os.environ.get("FABPRINT_DOCKER_PULL")
-        if mode:
-            import warnings
-
-            warnings.warn(
-                "FABPRINT_DOCKER_PULL is deprecated — use ESTAMPO_DOCKER_PULL instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-    mode = mode or "auto"
+    mode = os.environ.get("ESTAMPO_DOCKER_PULL", "auto")
     mode = mode.lower()
     if mode == "always":
         return True

--- a/src/estampo/config.py
+++ b/src/estampo/config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import tomllib
-import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -267,35 +266,30 @@ def load_config(path: Path) -> EstampoConfig:
     if engine not in ("orca", "cura"):
         raise EstampoError(f"slicer.engine must be 'orca' or 'cura', got '{engine}'")
 
-    # Detect format: new engine-namespaced sections vs legacy flat keys.
-    # New format has [slicer.orca] and/or [slicer.cura] as dict sub-keys.
+    # Engine-namespaced sections: [slicer.orca] and/or [slicer.cura]
     orca_raw = slicer_raw.get("orca")
     cura_raw = slicer_raw.get("cura")
-    is_new_format = isinstance(orca_raw, dict) or isinstance(cura_raw, dict)
 
-    if is_new_format:
-        orca_cfg = _parse_orca_config(orca_raw or {})
-        cura_cfg = _parse_cura_config(cura_raw or {})
-    else:
-        # Legacy flat format — all keys live directly under [slicer]
-        # Emit deprecation warning if orca-specific keys are at top level
-        _legacy_keys = {
-            "printer",
-            "process",
-            "filaments",
-            "slots",
-            "machine_overrides",
-            "filament_overrides",
-        }
-        if _legacy_keys & slicer_raw.keys():
-            warnings.warn(
-                "Flat [slicer] config is deprecated — move engine-specific settings "
-                "to [slicer.orca] or [slicer.cura]. See 'estampo init' for the new format.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        orca_cfg = _parse_orca_config(slicer_raw)
-        cura_cfg = _parse_cura_config(slicer_raw.get("cura", {}))
+    # Reject legacy flat format (keys directly under [slicer])
+    _legacy_keys = {
+        "printer",
+        "process",
+        "filaments",
+        "slots",
+        "machine_overrides",
+        "filament_overrides",
+    }
+    if _legacy_keys & slicer_raw.keys() and not (
+        isinstance(orca_raw, dict) or isinstance(cura_raw, dict)
+    ):
+        raise EstampoError(
+            "Flat [slicer] config format is no longer supported.\n"
+            "Move engine-specific settings to [slicer.orca] or [slicer.cura].\n"
+            "Run 'estampo init' to generate the new format."
+        )
+
+    orca_cfg = _parse_orca_config(orca_raw or {})
+    cura_cfg = _parse_cura_config(cura_raw or {})
 
     # Populate active-engine facade fields from the selected engine's sub-config
     if engine == "orca":

--- a/src/estampo/credentials.py
+++ b/src/estampo/credentials.py
@@ -55,46 +55,11 @@ PRINTER_TYPES = {
 }
 
 
-def _migrate_config_dir() -> None:
-    """Copy ~/.config/fabprint → ~/.config/estampo if old exists but new doesn't."""
-    import shutil
-
-    if sys.platform == "win32":
-        old_dir = Path.home() / "AppData/Roaming/fabprint"
-        new_dir = Path.home() / "AppData/Roaming/estampo"
-    else:
-        old_dir = Path.home() / ".config/fabprint"
-        new_dir = Path.home() / ".config/estampo"
-
-    if old_dir.exists() and not new_dir.exists() and not old_dir.is_symlink():
-        try:
-            shutil.copytree(old_dir, new_dir)
-        except OSError as exc:
-            log.warning("Config migration failed: %s", exc)
-            return
-        log.info("Migrated config: %s → %s", old_dir, new_dir)
-        print(
-            f"Migrated config from {old_dir} to {new_dir}.\n"
-            f"You can delete {old_dir} once you're satisfied everything works."
-        )
-
-
 def _credentials_path() -> Path:
     """Return the path to the credentials file."""
     env = os.environ.get("ESTAMPO_CREDENTIALS")
-    if not env:
-        env = os.environ.get("FABPRINT_CREDENTIALS")
-        if env:
-            import warnings
-
-            warnings.warn(
-                "FABPRINT_CREDENTIALS is deprecated — use ESTAMPO_CREDENTIALS instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
     if env:
         return Path(env)
-    _migrate_config_dir()
     if sys.platform == "win32":
         return Path.home() / "AppData/Roaming/estampo/credentials.toml"
     return Path.home() / ".config/estampo/credentials.toml"

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -129,25 +129,13 @@ def _load_existing(path: Path) -> _ExistingConfig | None:
     if raw_parts:
         parts = [{"file": p.get("file", ""), **p} for p in raw_parts]
 
-    # Detect new engine-namespaced format vs legacy flat format
-    orca_section = slicer.get("orca")
-    cura_section = slicer.get("cura")
-    is_new_format = isinstance(orca_section, dict) or isinstance(cura_section, dict)
-
-    if is_new_format:
-        orca = orca_section or {}
-        cura = cura_section or {}
-        printer_val = orca.get("printer")
-        process_val = orca.get("process")
-        filaments_val = orca.get("filaments")
-        nozzle_type = orca.get("machine_overrides", {}).get("nozzle_type")
-        overrides = orca.get("overrides") or cura.get("overrides")
-    else:
-        printer_val = slicer.get("printer")
-        process_val = slicer.get("process")
-        filaments_val = slicer.get("filaments")
-        nozzle_type = slicer.get("machine_overrides", {}).get("nozzle_type")
-        overrides = slicer.get("overrides")
+    orca = slicer.get("orca") or {}
+    cura = slicer.get("cura") or {}
+    printer_val = orca.get("printer")
+    process_val = orca.get("process")
+    filaments_val = orca.get("filaments")
+    nozzle_type = orca.get("machine_overrides", {}).get("nozzle_type")
+    overrides = orca.get("overrides") or cura.get("overrides")
 
     if overrides:
         overrides = {k: str(v) for k, v in overrides.items()}

--- a/src/estampo/orca.py
+++ b/src/estampo/orca.py
@@ -574,12 +574,8 @@ def orca_slice_plate(
     # Profiles pinned for one slicer version can crash a different version due
     # to schema changes (array sizes, removed/added keys).
     if project_dir and docker_version:
-        # Check both engine-namespaced and legacy paths for pinned profiles
         engine_pinned = project_dir / profiles_dir / "orca"
-        legacy_pinned = project_dir / profiles_dir
-        has_pinned = (engine_pinned.is_dir() and any(engine_pinned.rglob("*.json"))) or (
-            legacy_pinned.is_dir() and any(legacy_pinned.rglob("*.json"))
-        )
+        has_pinned = engine_pinned.is_dir() and any(engine_pinned.rglob("*.json"))
         if has_pinned:
             pinned_ver = pinned_profiles_version(project_dir, profiles_dir, "orca")
             if pinned_ver and pinned_ver != docker_version:
@@ -898,17 +894,6 @@ def _detect_orca_version() -> str | None:
     where launching OrcaSlicer --help may hang).
     """
     skip_detect = os.environ.get("ESTAMPO_SKIP_SLICER_DETECT")
-    if not skip_detect:
-        skip_detect = os.environ.get("FABPRINT_SKIP_SLICER_DETECT")
-        if skip_detect:
-            import warnings
-
-            warnings.warn(
-                "FABPRINT_SKIP_SLICER_DETECT is deprecated"
-                " — use ESTAMPO_SKIP_SLICER_DETECT instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
     if skip_detect:
         return None
     try:

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -163,7 +163,7 @@ def discover_profile_names(
     if any(system.values()):
         return {cat: sorted(system.get(cat, {}).keys()) for cat in CATEGORIES}, "system"
 
-    # 2. Pinned profiles in repo (engine-namespaced path first, then legacy)
+    # 2. Pinned profiles in repo (engine-namespaced path: profiles/<engine>/)
     if project_dir:
         # CuraEngine uses .def.json files in a definitions/ directory
         if engine == "cura":
@@ -191,17 +191,14 @@ def discover_profile_names(
                     }
                     return pinned_cura, "pinned"
 
-        for base in (
-            project_dir / profiles_dir / engine,  # new: profiles/orca/
-            project_dir / profiles_dir,  # legacy: profiles/
-        ):
-            pinned: dict[str, list[str]] = {}
-            for cat in CATEGORIES:
-                cat_dir = base / cat
-                if cat_dir.is_dir():
-                    pinned[cat] = sorted(f.stem for f in cat_dir.glob("*.json") if f.is_file())
-            if any(pinned.values()):
-                return pinned, "pinned"
+        base = project_dir / profiles_dir / engine
+        pinned: dict[str, list[str]] = {}
+        for cat in CATEGORIES:
+            cat_dir = base / cat
+            if cat_dir.is_dir():
+                pinned[cat] = sorted(f.stem for f in cat_dir.glob("*.json") if f.is_file())
+        if any(pinned.values()):
+            return pinned, "pinned"
 
     # 3. Bundled profiles
     bundled = load_bundled_profiles(engine, version)
@@ -240,16 +237,12 @@ def resolve_profile(
             raise FileNotFoundError(f"Profile path not found: {path}")
         return path
 
-    # Check local pinned profiles (engine-namespaced first, then legacy)
+    # Check local pinned profiles (engine-namespaced path: profiles/<engine>/)
     if project_dir:
-        for base in (
-            project_dir / profiles_dir / engine,  # new: profiles/orca/
-            project_dir / profiles_dir,  # legacy: profiles/
-        ):
-            local = base / category / f"{name_or_path}.json"
-            if local.exists():
-                log.debug("Resolved '%s' from pinned profiles: %s", name_or_path, local)
-                return local
+        local = project_dir / profiles_dir / engine / category / f"{name_or_path}.json"
+        if local.exists():
+            log.debug("Resolved '%s' from pinned profiles: %s", name_or_path, local)
+            return local
 
     # Check Docker-extracted profiles (version-matched)
     if docker_profile_dir:
@@ -338,8 +331,7 @@ def pinned_profiles_version(
 ) -> str | None:
     """Read the slicer version that pinned profiles were created with.
 
-    Checks engine-namespaced path first (``profiles/<engine>/.slicer-version``),
-    then falls back to legacy path (``profiles/.slicer-version``).
+    Checks ``profiles/<engine>/.slicer-version``.
 
     Returns ``None`` if no marker file exists (pre-marker pinned profiles).
     """
@@ -347,10 +339,6 @@ def pinned_profiles_version(
         marker = project_dir / profiles_dir / engine / ".slicer-version"
         if marker.exists():
             return marker.read_text().strip()
-    # Legacy fallback
-    marker = project_dir / profiles_dir / ".slicer-version"
-    if marker.exists():
-        return marker.read_text().strip()
     return None
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -250,12 +250,12 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 
 def test_run_warns_on_unknown_override_keys(tmp_path, capsys):
     """Run should warn when override keys don't exist in the process profile."""
-    profiles = tmp_path / "profiles" / "process"
+    profiles = tmp_path / "profiles" / "orca" / "process"
     profiles.mkdir(parents=True)
     (profiles / "MyProcess.json").write_text(
         '{"type": "process", "layer_height": "0.2", "wall_loops": "2"}'
     )
-    toml = tmp_path / "fabprint.toml"
+    toml = tmp_path / "estampo.toml"
     toml.write_text(f"""
 [plate]
 size = [256, 256]
@@ -473,15 +473,6 @@ def test_resolve_config_path_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     with pytest.raises(EstampoError, match="No config file specified"):
         _resolve_config_path(None)
-
-
-def test_resolve_config_path_legacy_fabprint_toml(tmp_path, monkeypatch, capsys):
-    """Falls back to fabprint.toml with deprecation warning when estampo.toml is absent."""
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "fabprint.toml").write_text("[slicer]\n")
-    result = _resolve_config_path(None)
-    assert result == Path("fabprint.toml")
-    assert "fabprint.toml is deprecated" in capsys.readouterr().err
 
 
 # --- _resolve_status_printers ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,8 @@ padding = 3.0
 
 [slicer]
 engine = "orca"
+
+[slicer.orca]
 printer = "Bambu Lab P1S 0.4 nozzle"
 process = "0.20mm Standard @BBL X1C"
 filaments = ["Generic PLA @base"]
@@ -256,7 +258,7 @@ def test_overrides(tmp_path):
 [slicer]
 engine = "orca"
 
-[slicer.overrides]
+[slicer.orca.overrides]
 sparse_infill_density = "25%"
 wall_loops = 3
 
@@ -487,7 +489,7 @@ def test_filament_by_name_explicit_list(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer]
+[slicer.orca]
 filaments = ["Generic PLA @base", "Generic PETG-CF @base"]
 
 [[parts]]
@@ -505,7 +507,7 @@ def test_filament_by_name_not_in_list(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer]
+[slicer.orca]
 filaments = ["Generic PLA @base"]
 
 [[parts]]
@@ -542,7 +544,7 @@ def test_filament_int_backward_compat(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer]
+[slicer.orca]
 filaments = ["Generic PLA @base", "Generic PETG-CF @base"]
 
 [[parts]]
@@ -578,7 +580,7 @@ def test_slots_direct_feed(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer.slots]
+[slicer.orca.slots]
 5 = "Generic TPU @base"
 
 [[parts]]
@@ -604,7 +606,7 @@ def test_slots_int_ref_with_map(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer.slots]
+[slicer.orca.slots]
 1 = "Generic PLA @base"
 3 = "Generic PETG-CF @base"
 
@@ -625,7 +627,7 @@ def test_slots_mixed_int_and_string(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer.slots]
+[slicer.orca.slots]
 3 = "Generic PETG-CF @base"
 5 = "Generic TPU @base"
 
@@ -649,7 +651,7 @@ def test_slots_int_ref_not_in_map(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer.slots]
+[slicer.orca.slots]
 1 = "Generic PLA @base"
 
 [[parts]]
@@ -667,7 +669,7 @@ def test_slots_bad_slot_number(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer.slots]
+[slicer.orca.slots]
 0 = "Generic PLA @base"
 
 [[parts]]
@@ -685,7 +687,7 @@ def test_slots_duplicate_profile(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer.slots]
+[slicer.orca.slots]
 1 = "Generic PETG-CF @base"
 3 = "Generic PETG-CF @base"
 
@@ -762,7 +764,7 @@ def test_object_filaments_with_explicit_list(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer]
+[slicer.orca]
 filaments = ["Generic PETG-CF @base", "Bambu PLA Basic @BBL X1C"]
 
 [[parts]]
@@ -784,7 +786,7 @@ def test_object_filaments_not_in_list(tmp_path):
     path = _write_toml(
         tmp_path,
         """
-[slicer]
+[slicer.orca]
 filaments = ["Generic PLA @base"]
 
 [[parts]]
@@ -1125,8 +1127,8 @@ file = "cube.stl"
         assert cfg.slicer.orca.printer == "Bambu Lab P1S 0.4 nozzle"
         assert cfg.slicer.orca.filaments == ["Generic PETG"]
 
-    def test_legacy_flat_still_works(self, tmp_path):
-        """Legacy flat format without [slicer.orca] section still works."""
+    def test_legacy_flat_rejected(self, tmp_path):
+        """Legacy flat format without [slicer.orca] section is rejected."""
         path = _write_toml(
             tmp_path,
             """
@@ -1136,21 +1138,13 @@ printer = "Bambu Lab P1S 0.4 nozzle"
 process = "0.20mm Standard @BBL X1C"
 filaments = ["Generic PLA @base"]
 
-[slicer.overrides]
-sparse_infill_density = "25%"
-
 [[parts]]
 file = "cube.stl"
 """,
             create_files=["cube.stl"],
         )
-        with pytest.warns(DeprecationWarning, match="Flat.*slicer.*deprecated"):
-            cfg = load_config(path)
-        assert cfg.slicer.printer == "Bambu Lab P1S 0.4 nozzle"
-        assert cfg.slicer.filaments == ["Generic PLA @base"]
-        assert cfg.slicer.overrides == {"sparse_infill_density": "25%"}
-        # Legacy flat keys are also in the orca sub-config
-        assert cfg.slicer.orca.printer == "Bambu Lab P1S 0.4 nozzle"
+        with pytest.raises(EstampoError, match="no longer supported"):
+            load_config(path)
 
     def test_cura_namespaced_with_orca_machine_overrides(self, tmp_path):
         """Orca sub-config supports machine_overrides and filament_overrides."""

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -291,67 +291,6 @@ class TestCloudTokenJson:
                 assert path.stat().st_mode & 0o777 == 0o600
 
 
-class TestMigrateConfigDir:
-    def test_copies_old_to_new(self, tmp_path, monkeypatch):
-        """Copies ~/.config/fabprint → ~/.config/estampo when old exists, new doesn't."""
-        from estampo.credentials import _migrate_config_dir
-
-        monkeypatch.setattr("sys.platform", "linux")
-        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
-        old_dir = tmp_path / ".config" / "fabprint"
-        old_dir.mkdir(parents=True)
-        (old_dir / "credentials.toml").write_text("test")
-
-        _migrate_config_dir()
-
-        new_dir = tmp_path / ".config" / "estampo"
-        assert new_dir.exists()
-        assert (new_dir / "credentials.toml").read_text() == "test"
-
-    def test_skips_when_new_exists(self, tmp_path, monkeypatch):
-        """Does not overwrite when ~/.config/estampo already exists."""
-        from estampo.credentials import _migrate_config_dir
-
-        monkeypatch.setattr("sys.platform", "linux")
-        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
-        old_dir = tmp_path / ".config" / "fabprint"
-        old_dir.mkdir(parents=True)
-        (old_dir / "credentials.toml").write_text("old")
-        new_dir = tmp_path / ".config" / "estampo"
-        new_dir.mkdir(parents=True)
-        (new_dir / "credentials.toml").write_text("new")
-
-        _migrate_config_dir()
-
-        assert (new_dir / "credentials.toml").read_text() == "new"
-
-    def test_skips_when_old_missing(self, tmp_path, monkeypatch):
-        """No error when old dir doesn't exist."""
-        from estampo.credentials import _migrate_config_dir
-
-        monkeypatch.setattr("sys.platform", "linux")
-        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
-
-        _migrate_config_dir()  # should not raise
-
-    def test_skips_symlink(self, tmp_path, monkeypatch):
-        """Refuses to migrate if old dir is a symlink."""
-        from estampo.credentials import _migrate_config_dir
-
-        monkeypatch.setattr("sys.platform", "linux")
-        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
-        real_dir = tmp_path / "real_config"
-        real_dir.mkdir()
-        (real_dir / "credentials.toml").write_text("test")
-        config_dir = tmp_path / ".config"
-        config_dir.mkdir(parents=True)
-        (config_dir / "fabprint").symlink_to(real_dir)
-
-        _migrate_config_dir()
-
-        assert not (config_dir / "estampo").exists()
-
-
 class TestCredentialsPath:
     def test_env_var_override(self, tmp_path, monkeypatch):
         """ESTAMPO_CREDENTIALS env var overrides default path."""
@@ -359,15 +298,6 @@ class TestCredentialsPath:
 
         custom_path = tmp_path / "custom_creds.toml"
         monkeypatch.setenv("ESTAMPO_CREDENTIALS", str(custom_path))
-        assert _credentials_path() == custom_path
-
-    def test_legacy_env_var_fallback(self, tmp_path, monkeypatch):
-        """FABPRINT_CREDENTIALS env var works as fallback."""
-        from estampo.credentials import _credentials_path
-
-        custom_path = tmp_path / "custom_creds.toml"
-        monkeypatch.delenv("ESTAMPO_CREDENTIALS", raising=False)
-        monkeypatch.setenv("FABPRINT_CREDENTIALS", str(custom_path))
         assert _credentials_path() == custom_path
 
     def test_windows_path(self, monkeypatch):

--- a/tests/test_engine_config_e2e.py
+++ b/tests/test_engine_config_e2e.py
@@ -2,7 +2,7 @@
 
 These tests verify the full flow from TOML loading through config parsing,
 profile resolution, and slicer dispatch for both OrcaSlicer and CuraEngine,
-using both the new engine-namespaced format and the legacy flat format.
+using the engine-namespaced format.
 """
 
 from __future__ import annotations
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 
+from estampo import EstampoError
 from estampo.config import load_config
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -102,8 +103,8 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         # Cura sub-config is empty (not configured)
         assert cfg.slicer.cura.overrides == {}
 
-    def test_legacy_format_emits_deprecation(self, tmp_path):
-        """Legacy flat format still works but emits a DeprecationWarning."""
+    def test_legacy_format_rejected(self, tmp_path):
+        """Legacy flat format is rejected with a clear error."""
         path = _write_toml(
             tmp_path,
             f"""
@@ -117,15 +118,8 @@ filaments = ["Generic PLA @base"]
 file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 """,
         )
-        with pytest.warns(DeprecationWarning, match="Flat.*slicer.*deprecated"):
-            cfg = load_config(path)
-
-        # Legacy config still fully functional
-        assert cfg.slicer.printer == "Bambu Lab P1S 0.4 nozzle"
-        assert cfg.slicer.process == "0.20mm Standard @BBL X1C"
-        assert cfg.slicer.filaments == ["Generic PLA @base"]
-        # Also populated in orca sub-config
-        assert cfg.slicer.orca.printer == "Bambu Lab P1S 0.4 nozzle"
+        with pytest.raises(EstampoError, match="no longer supported"):
+            load_config(path)
 
     def test_legacy_minimal_no_warning(self, tmp_path):
         """Minimal config with only engine= does NOT emit deprecation."""
@@ -153,7 +147,7 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
     def test_orca_profile_resolution_with_pinned(self, tmp_path):
         """New-format config resolves pinned profiles via facade fields."""
         # Create pinned profile
-        profiles = tmp_path / "profiles" / "process"
+        profiles = tmp_path / "profiles" / "orca" / "process"
         profiles.mkdir(parents=True)
         (profiles / "MyProcess.json").write_text(
             json.dumps({"type": "process", "layer_height": "0.20", "wall_loops": "3"})
@@ -189,7 +183,7 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 
     def test_orca_validate_overrides_new_format(self, tmp_path):
         """validate_override_keys works with new-format config facade."""
-        profiles = tmp_path / "profiles" / "process"
+        profiles = tmp_path / "profiles" / "orca" / "process"
         profiles.mkdir(parents=True)
         (profiles / "MyProcess.json").write_text(
             json.dumps({"type": "process", "layer_height": "0.20", "wall_loops": "3"})
@@ -465,18 +459,11 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         assert not any("printer" in w.lower() and "not found" in w.lower() for w in result.warnings)
 
 
-class TestLegacyBackwardCompat:
-    """Legacy flat format backward compatibility through the full stack."""
+class TestLegacyRejection:
+    """Legacy flat format is rejected with a clear error."""
 
-    def test_legacy_orca_slice_dispatch(self, tmp_path):
-        """Legacy flat orca config dispatches to OrcaSlicer correctly."""
-        # Create a minimal pinned profile
-        profiles = tmp_path / "profiles" / "process"
-        profiles.mkdir(parents=True)
-        (profiles / "TestProcess.json").write_text(
-            json.dumps({"type": "process", "layer_height": "0.20"})
-        )
-
+    def test_legacy_orca_rejected(self, tmp_path):
+        """Legacy flat orca config is rejected."""
         path = _write_toml(
             tmp_path,
             f"""
@@ -485,27 +472,15 @@ engine = "orca"
 version = "2.3.2"
 process = "TestProcess"
 
-[slicer.overrides]
-wall_loops = 4
-
 [[parts]]
 file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 """,
         )
-        with pytest.warns(DeprecationWarning, match="Flat.*slicer.*deprecated"):
-            cfg = load_config(path)
+        with pytest.raises(EstampoError, match="no longer supported"):
+            load_config(path)
 
-        # Legacy config values accessible via facade
-        assert cfg.slicer.process == "TestProcess"
-        assert cfg.slicer.overrides == {"wall_loops": 4}
-        # Also in orca sub-config
-        assert cfg.slicer.orca.process == "TestProcess"
-        assert cfg.slicer.orca.overrides == {"wall_loops": 4}
-
-    def test_legacy_cura_no_warning(self, tmp_path):
-        """engine=cura with no orca-specific keys emits no deprecation."""
-        import warnings as warn_mod
-
+    def test_cura_overrides_at_slicer_level_ok(self, tmp_path):
+        """engine=cura with [slicer.overrides] (not a legacy key) is fine."""
         path = _write_toml(
             tmp_path,
             f"""
@@ -513,17 +488,14 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 engine = "cura"
 version = "5.12.0"
 
-[slicer.overrides]
+[slicer.cura]
+
+[slicer.cura.overrides]
 infill_sparse_density = 25
 
 [[parts]]
 file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 """,
         )
-        # overrides without printer/process/filaments is ambiguous but not legacy-orca
-        # The warning only fires when orca-specific keys (printer, process, filaments) are present
-        with warn_mod.catch_warnings():
-            warn_mod.simplefilter("error", DeprecationWarning)
-            cfg = load_config(path)
-
+        cfg = load_config(path)
         assert cfg.slicer.engine == "cura"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -356,12 +356,12 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 
     def test_override_keys_valid_passes(self, tmp_path):
         """Valid override keys produce a pass message."""
-        profiles = tmp_path / "profiles" / "process"
+        profiles = tmp_path / "profiles" / "orca" / "process"
         profiles.mkdir(parents=True)
         (profiles / "MyProcess.json").write_text(
             '{"type": "process", "layer_height": "0.2", "wall_loops": "2"}'
         )
-        toml = tmp_path / "fabprint.toml"
+        toml = tmp_path / "estampo.toml"
         toml.write_text(f"""
 [slicer]
 engine = "orca"
@@ -381,10 +381,10 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 
     def test_override_keys_unknown_warns(self, tmp_path):
         """Unknown override keys produce warnings."""
-        profiles = tmp_path / "profiles" / "process"
+        profiles = tmp_path / "profiles" / "orca" / "process"
         profiles.mkdir(parents=True)
         (profiles / "MyProcess.json").write_text('{"type": "process", "layer_height": "0.2"}')
-        toml = tmp_path / "fabprint.toml"
+        toml = tmp_path / "estampo.toml"
         toml.write_text(f"""
 [slicer]
 engine = "orca"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -53,7 +53,7 @@ def test_resolve_path_directly(tmp_path):
 
 def test_resolve_pinned_first(tmp_path):
     """Pinned profiles should take precedence over system profiles."""
-    pinned_dir = tmp_path / "profiles" / "machine"
+    pinned_dir = tmp_path / "profiles" / "orca" / "machine"
     pinned_dir.mkdir(parents=True)
     pinned = pinned_dir / "MyProfile.json"
     pinned.write_text("{}")
@@ -229,7 +229,7 @@ def test_discover_profile_names_system_first():
 
 def test_discover_profile_names_pinned_fallback(tmp_path):
     """Falls back to pinned profiles when system is empty."""
-    pinned_dir = tmp_path / "profiles" / "machine"
+    pinned_dir = tmp_path / "profiles" / "orca" / "machine"
     pinned_dir.mkdir(parents=True)
     (pinned_dir / "MyPrinter.json").write_text("{}")
 
@@ -344,7 +344,7 @@ def test_resolve_profile_data_docker_dir_fallback(tmp_path):
     """Parent profile is found in docker_profile_dir during chain walk."""
     # Set up: child in project pinned profiles, parent only in docker dir
     project = tmp_path / "project"
-    pinned = project / "profiles" / "process"
+    pinned = project / "profiles" / "orca" / "process"
     pinned.mkdir(parents=True)
     (pinned / "Child.json").write_text(json.dumps({"inherits": "DockerParent", "wall_loops": 4}))
 
@@ -372,7 +372,7 @@ def test_resolve_profile_data_warns_missing_parent(tmp_path, caplog):
     import logging
 
     project = tmp_path / "project"
-    pinned = project / "profiles" / "process"
+    pinned = project / "profiles" / "orca" / "process"
     pinned.mkdir(parents=True)
     (pinned / "Lonely.json").write_text(json.dumps({"inherits": "Ghost", "layer_height": 0.2}))
 
@@ -953,7 +953,7 @@ def test_load_cura_definition_map():
 
 def test_validate_override_keys_valid(tmp_path):
     """Known keys produce no warnings."""
-    profiles = tmp_path / "profiles" / "process"
+    profiles = tmp_path / "profiles" / "orca" / "process"
     profiles.mkdir(parents=True)
     (profiles / "Fast.json").write_text(
         json.dumps({"type": "process", "layer_height": "0.3", "wall_loops": "2"})
@@ -969,7 +969,7 @@ def test_validate_override_keys_valid(tmp_path):
 
 def test_validate_override_keys_unknown(tmp_path):
     """Unknown keys produce warnings."""
-    profiles = tmp_path / "profiles" / "process"
+    profiles = tmp_path / "profiles" / "orca" / "process"
     profiles.mkdir(parents=True)
     (profiles / "Fast.json").write_text(json.dumps({"type": "process", "layer_height": "0.3"}))
     warnings = validate_override_keys(
@@ -1008,10 +1008,10 @@ def test_validate_override_keys_unresolvable_profile():
 
 def test_pinned_profiles_version_reads_marker(tmp_path):
     """Reads version from .slicer-version marker file."""
-    profiles = tmp_path / "profiles"
-    profiles.mkdir()
+    profiles = tmp_path / "profiles" / "orca"
+    profiles.mkdir(parents=True)
     (profiles / ".slicer-version").write_text("2.3.2\n")
-    assert pinned_profiles_version(tmp_path) == "2.3.2"
+    assert pinned_profiles_version(tmp_path, engine="orca") == "2.3.2"
 
 
 def test_pinned_profiles_version_returns_none_without_marker(tmp_path):
@@ -1046,35 +1046,22 @@ class TestEngineNamespacedProfiles:
         assert source == "pinned"
         assert "MyPrinter" in names.get("machine", [])
 
-    def test_discover_names_legacy_fallback(self, tmp_path):
-        """Legacy profiles/<category>/ still found when no engine subdir."""
+    def test_discover_names_no_legacy_fallback(self, tmp_path):
+        """Profiles in legacy profiles/<category>/ (without engine subdir) are NOT found."""
         legacy_machine = tmp_path / "profiles" / "machine"
         legacy_machine.mkdir(parents=True)
         (legacy_machine / "OldPrinter.json").write_text('{"type": "machine"}')
 
-        with patch.dict("estampo.profiles.SYSTEM_DIRS", {}, clear=True):
+        with (
+            patch.dict("estampo.profiles.SYSTEM_DIRS", {}, clear=True),
+            patch(
+                "estampo.profiles.load_bundled_profiles",
+                return_value={"machine": [], "process": [], "filament": []},
+            ),
+        ):
             names, source = discover_profile_names("orca", project_dir=tmp_path)
 
-        assert source == "pinned"
-        assert "OldPrinter" in names.get("machine", [])
-
-    def test_discover_names_engine_takes_precedence(self, tmp_path):
-        """Engine-namespaced profiles take precedence over legacy flat."""
-        # Create both paths
-        (tmp_path / "profiles" / "orca" / "machine").mkdir(parents=True)
-        (tmp_path / "profiles" / "orca" / "machine" / "NewPrinter.json").write_text(
-            '{"type": "machine"}'
-        )
-        (tmp_path / "profiles" / "machine").mkdir(parents=True)
-        (tmp_path / "profiles" / "machine" / "OldPrinter.json").write_text('{"type": "machine"}')
-
-        with patch.dict("estampo.profiles.SYSTEM_DIRS", {}, clear=True):
-            names, source = discover_profile_names("orca", project_dir=tmp_path)
-
-        assert source == "pinned"
-        assert "NewPrinter" in names.get("machine", [])
-        # Legacy profile NOT included — engine-namespaced found first
-        assert "OldPrinter" not in names.get("machine", [])
+        assert source == "none"
 
     def test_resolve_profile_engine_namespaced(self, tmp_path):
         """resolve_profile finds profiles in profiles/<engine>/<category>/."""
@@ -1086,28 +1073,14 @@ class TestEngineNamespacedProfiles:
         result = resolve_profile("MyProcess", "orca", "process", tmp_path)
         assert result == expected
 
-    def test_resolve_profile_legacy_fallback(self, tmp_path):
-        """resolve_profile falls back to legacy profiles/<category>/."""
+    def test_resolve_profile_no_legacy_fallback(self, tmp_path):
+        """resolve_profile does NOT fall back to legacy profiles/<category>/."""
         legacy_process = tmp_path / "profiles" / "process"
         legacy_process.mkdir(parents=True)
-        expected = legacy_process / "OldProcess.json"
-        expected.write_text('{"type": "process"}')
+        (legacy_process / "OldProcess.json").write_text('{"type": "process"}')
 
-        result = resolve_profile("OldProcess", "orca", "process", tmp_path)
-        assert result == expected
-
-    def test_resolve_profile_engine_over_legacy(self, tmp_path):
-        """Engine-namespaced profile found before legacy."""
-        (tmp_path / "profiles" / "orca" / "process").mkdir(parents=True)
-        engine_path = tmp_path / "profiles" / "orca" / "process" / "MyProcess.json"
-        engine_path.write_text('{"layer_height": "0.12"}')
-
-        (tmp_path / "profiles" / "process").mkdir(parents=True)
-        legacy_path = tmp_path / "profiles" / "process" / "MyProcess.json"
-        legacy_path.write_text('{"layer_height": "0.20"}')
-
-        result = resolve_profile("MyProcess", "orca", "process", tmp_path)
-        assert result == engine_path
+        with pytest.raises(FileNotFoundError):
+            resolve_profile("OldProcess", "orca", "process", tmp_path)
 
     def test_pin_profiles_writes_engine_namespaced(self, tmp_path):
         """pin_profiles writes to profiles/<engine>/<category>/."""
@@ -1171,13 +1144,13 @@ class TestEngineNamespacedProfiles:
 
         assert pinned_profiles_version(tmp_path, engine="orca") == "2.3.2"
 
-    def test_pinned_profiles_version_legacy_fallback(self, tmp_path):
-        """pinned_profiles_version falls back to profiles/.slicer-version."""
+    def test_pinned_profiles_version_no_legacy_fallback(self, tmp_path):
+        """pinned_profiles_version does NOT fall back to profiles/.slicer-version."""
         profiles = tmp_path / "profiles"
         profiles.mkdir(parents=True)
         (profiles / ".slicer-version").write_text("2.3.1\n")
 
-        assert pinned_profiles_version(tmp_path, engine="orca") == "2.3.1"
+        assert pinned_profiles_version(tmp_path, engine="orca") is None
 
     def test_pinned_profiles_version_engine_over_legacy(self, tmp_path):
         """Engine-namespaced version marker takes precedence."""

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -78,7 +78,7 @@ def test_apply_overrides():
 
 def test_resolve_profiles_all_filaments_resolved(tmp_path):
     """All filament slots are resolved to their actual profiles."""
-    profiles_dir = tmp_path / "profiles" / "filament"
+    profiles_dir = tmp_path / "profiles" / "orca" / "filament"
     profiles_dir.mkdir(parents=True)
     (profiles_dir / "PLA.json").write_text('{"name": "PLA"}')
     (profiles_dir / "PETG-CF.json").write_text('{"name": "PETG-CF"}')
@@ -110,9 +110,9 @@ def test_resolve_profiles_all_filaments_resolved(tmp_path):
 
 def test_resolve_profiles_machine_overrides(tmp_path: Path):
     """Machine overrides are applied to the machine profile, broadcasting to arrays."""
-    profiles_dir = tmp_path / "profiles" / "filament"
+    profiles_dir = tmp_path / "profiles" / "orca" / "filament"
     profiles_dir.mkdir(parents=True)
-    machine_dir = tmp_path / "profiles" / "machine"
+    machine_dir = tmp_path / "profiles" / "orca" / "machine"
     machine_dir.mkdir(parents=True)
     (machine_dir / "My Printer.json").write_text(
         '{"name": "My Printer", "type": "machine", '
@@ -143,7 +143,7 @@ def test_resolve_profiles_machine_overrides(tmp_path: Path):
 
 def test_resolve_profiles_machine_overrides_scalar_broadcast(tmp_path: Path):
     """Scalar nozzle_type in profile is broadcast to array based on sibling fields."""
-    machine_dir = tmp_path / "profiles" / "machine"
+    machine_dir = tmp_path / "profiles" / "orca" / "machine"
     machine_dir.mkdir(parents=True)
     # nozzle_type is scalar (as happens after inheritance resolution on some
     # pinned profiles), but other fields are 2-element arrays.
@@ -700,7 +700,7 @@ def test_slice_plate_errors_on_stale_pinned_profiles_no_marker(tmp_path):
     input_3mf.write_text("fake")
 
     # Create pinned profiles without version marker
-    profiles = tmp_path / "profiles" / "machine"
+    profiles = tmp_path / "profiles" / "orca" / "machine"
     profiles.mkdir(parents=True)
     (profiles / "Printer.json").write_text('{"name": "Printer"}')
 
@@ -723,10 +723,10 @@ def test_slice_plate_errors_on_version_mismatch(tmp_path):
     input_3mf.write_text("fake")
 
     # Create pinned profiles with mismatched version marker
-    profiles = tmp_path / "profiles" / "machine"
+    profiles = tmp_path / "profiles" / "orca" / "machine"
     profiles.mkdir(parents=True)
     (profiles / "Printer.json").write_text('{"name": "Printer"}')
-    (tmp_path / "profiles" / ".slicer-version").write_text("2.3.1\n")
+    (tmp_path / "profiles" / "orca" / ".slicer-version").write_text("2.3.1\n")
 
     with (
         patch("estampo.slicer._ensure_docker_image", return_value=True),
@@ -748,10 +748,10 @@ def test_slice_plate_ok_with_matching_version(tmp_path):
     output_dir = tmp_path / "output"
 
     # Create pinned profiles with matching version marker
-    profiles = tmp_path / "profiles" / "machine"
+    profiles = tmp_path / "profiles" / "orca" / "machine"
     profiles.mkdir(parents=True)
     (profiles / "Printer.json").write_text('{"type": "machine", "name": "Printer"}')
-    (tmp_path / "profiles" / ".slicer-version").write_text("2.3.2\n")
+    (tmp_path / "profiles" / "orca" / ".slicer-version").write_text("2.3.2\n")
 
     with (
         patch("estampo.slicer._ensure_docker_image", return_value=True),


### PR DESCRIPTION
## Summary
- Reject legacy flat `[slicer]` config format with a clear `EstampoError` (was deprecation warning)
- Remove `fabprint.toml` filename alias, `FABPRINT_*` env vars, `~/.config/fabprint` migration, `FabprintError` alias
- Remove legacy `profiles/<category>/` path fallback — profiles must be in `profiles/<engine>/<category>/`
- Remove legacy `profiles/.slicer-version` fallback — marker must be in `profiles/<engine>/.slicer-version`
- Net -244 lines of code

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — zero errors
- [x] `uv run mypy src/estampo` — zero errors
- [x] `uv run pytest` — 645 passed, 9 skipped

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)