### PR TITLE
Extract constants and migrate example configs to namespaced format

### DIFF
--- a/changes/+add-constants.misc
+++ b/changes/+add-constants.misc
@@ -1,0 +1,1 @@
+Extract shared magic numbers into ``constants.py`` and migrate example configs to engine-namespaced ``[slicer.orca]``/``[slicer.cura]`` format

--- a/examples/decoy-case/estampo-231.toml
+++ b/examples/decoy-case/estampo-231.toml
@@ -13,12 +13,14 @@ padding = 5.0
 [slicer]
 engine = "orca"
 version = "2.3.1"
+bed_type = "Textured PEI Plate"
+
+[slicer.orca]
 printer = "Bambu Lab P1S 0.4 nozzle"
 process = "0.20mm Standard @BBL X1C"
 filaments = ["Generic PETG"]
-bed_type = "Textured PEI Plate"
 
-[slicer.overrides]
+[slicer.orca.overrides]
 sparse_infill_density = "30%"
 sparse_infill_pattern = "gyroid"
 

--- a/examples/decoy-case/estampo-232.toml
+++ b/examples/decoy-case/estampo-232.toml
@@ -14,12 +14,14 @@ padding = 5.0
 [slicer]
 engine = "orca"
 version = "2.3.2"
+bed_type = "Textured PEI Plate"
+
+[slicer.orca]
 printer = "Bambu Lab P1S 0.4 nozzle"
 process = "0.20mm Standard @BBL X1C"
 filaments = ["Generic PETG"]
-bed_type = "Textured PEI Plate"
 
-[slicer.overrides]
+[slicer.orca.overrides]
 sparse_infill_density = "30%"
 sparse_infill_pattern = "gyroid"
 

--- a/examples/estampo-231.toml
+++ b/examples/estampo-231.toml
@@ -8,6 +8,8 @@ padding = 5.0
 [slicer]
 engine = "orca"
 version = "2.3.1"
+
+[slicer.orca]
 printer = "Bambu Lab P1S 0.4 nozzle"
 process = "0.20mm Standard @BBL X1C"
 

--- a/examples/estampo-232.toml
+++ b/examples/estampo-232.toml
@@ -8,6 +8,8 @@ padding = 5.0
 [slicer]
 engine = "orca"
 version = "2.3.2"
+
+[slicer.orca]
 printer = "Bambu Lab P1S 0.4 nozzle"
 process = "0.20mm Standard @BBL X1C"
 

--- a/examples/estampo-cura.toml
+++ b/examples/estampo-cura.toml
@@ -10,11 +10,9 @@ engine = "cura"
 version = "5.12.0"
 bed_type = "Textured PEI Plate"
 
-[slicer.filaments]
-default = "PETG-CF"
+[slicer.cura]
 
 [[parts]]
 file = "../tests/fixtures/cube_10mm.stl"
 copies = 2
 orient = "flat"
-filament = "default"

--- a/examples/gib-tuners-c13-10/estampo.toml
+++ b/examples/gib-tuners-c13-10/estampo.toml
@@ -5,7 +5,6 @@
 stages = ["load", "arrange", "plate", "slice", "print"]
 
 [printer]
-mode = "cloud-bridge"
 name = "workshop"  # references [printers.workshop] in ~/.config/estampo/credentials.toml
 
 [plate]
@@ -14,9 +13,12 @@ padding = 5.0
 
 [slicer]
 engine = "orca"
+
+[slicer.orca]
 printer = "Bambu Lab P1S 0.4 nozzle"
 process = "0.20mm Standard @BBL X1C"
-[slicer.overrides]
+
+[slicer.orca.overrides]
 enable_support = 1
 curr_bed_type = "Textured PEI Plate"
 

--- a/examples/peg-multicolour/estampo.toml
+++ b/examples/peg-multicolour/estampo.toml
@@ -11,6 +11,8 @@ padding = 5.0
 
 [slicer]
 engine = "orca"
+
+[slicer.orca]
 printer = "Bambu Lab P1S 0.4 nozzle"
 process = "0.20mm Standard @BBL X1C"
 filaments = ["Generic PLA @base", "Generic PLA @base"]

--- a/src/estampo/config.py
+++ b/src/estampo/config.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from estampo import EstampoError
+from estampo.constants import DEFAULT_PLATE_SIZE
 
 log = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ VALID_ORIENTS = {"flat", "upright", "side", "upside-down"}
 
 @dataclass
 class PlateConfig:
-    size: tuple[float, float] = (256.0, 256.0)
+    size: tuple[float, float] = DEFAULT_PLATE_SIZE
     padding: float = 5.0
 
 
@@ -255,7 +256,7 @@ def load_config(path: Path) -> EstampoConfig:
 
     # Plate config
     plate_raw = raw.get("plate", {})
-    size = tuple(plate_raw.get("size", [256.0, 256.0]))
+    size = tuple(plate_raw.get("size", list(DEFAULT_PLATE_SIZE)))
     if len(size) != 2 or any(s <= 0 for s in size):
         raise EstampoError(f"plate.size must be two positive numbers, got {size}")
     plate = PlateConfig(size=size, padding=float(plate_raw.get("padding", 5.0)))

--- a/src/estampo/constants.py
+++ b/src/estampo/constants.py
@@ -1,3 +1,13 @@
 """Shared constants for the estampo package."""
 
 NS_3MF = "http://schemas.microsoft.com/3dmanufacturing/core/2015/02"
+
+# Default plate dimensions (mm) — Bambu Lab standard build volume
+DEFAULT_PLATE_SIZE: tuple[float, float] = (256.0, 256.0)
+
+# Thumbnail size (px) — used in 3MF preview generation
+DEFAULT_THUMBNAIL_SIZE: int = 256
+
+# Minimum filament slot array length in BBL 3MF metadata.
+# P1S has a 4-slot AMS + 1 external spool = 5 slots.
+MIN_FILAMENT_SLOTS: int = 5

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from estampo import EstampoError
+from estampo.constants import DEFAULT_PLATE_SIZE
 
 log = logging.getLogger(__name__)
 
@@ -183,7 +184,7 @@ def resolve_cura_bed_size(
         except (json.JSONDecodeError, OSError):
             continue
 
-    return (width or 256.0, depth or 256.0)
+    return (width or DEFAULT_PLATE_SIZE[0], depth or DEFAULT_PLATE_SIZE[1])
 
 
 def cura_docker_image(version: str | None = None) -> str:
@@ -593,7 +594,10 @@ def _patch_gcode_header(gcode_path: Path, stderr: str) -> None:
 
 
 def _place_on_bed(
-    stl_path: Path, staging_dir: Path, bed_width: float = 256, bed_depth: float = 256
+    stl_path: Path,
+    staging_dir: Path,
+    bed_width: float = DEFAULT_PLATE_SIZE[0],
+    bed_depth: float = DEFAULT_PLATE_SIZE[1],
 ) -> Path:
     """Copy STL into staging, ensuring the mesh sits on the bed (Z>=0)
     and is centered on the build plate.

--- a/src/estampo/orca.py
+++ b/src/estampo/orca.py
@@ -17,6 +17,11 @@ import tempfile
 from pathlib import Path
 
 from estampo import EstampoError
+from estampo.constants import (
+    DEFAULT_PLATE_SIZE,
+    DEFAULT_THUMBNAIL_SIZE,
+    MIN_FILAMENT_SLOTS,
+)
 
 log = logging.getLogger(__name__)
 
@@ -327,10 +332,7 @@ _BC_DEFAULT_KEYS: dict[str, object] = {
     "thumbnails_format": "BTT_TFT",
 }
 
-# Minimum array length for filament-related settings in project_settings.
-# Bambu Connect rejects files where these arrays are shorter than the
-# printer's AMS slot count. 5 covers P1S (4-slot AMS + external spool).
-_MIN_FILAMENT_SLOTS = 5
+_MIN_FILAMENT_SLOTS = MIN_FILAMENT_SLOTS  # backward-compat alias
 
 
 def _fix_sliced_3mf(path: Path, plate_3mf: Path | None = None) -> None:
@@ -408,10 +410,11 @@ def _fix_sliced_3mf(path: Path, plate_3mf: Path | None = None) -> None:
         # A valid PNG is > 1KB; broken headless ones are empty or tiny.
         _THUMB_MIN_SIZE = 1024
         thumbnail_overrides: dict[str, bytes] = {}
+        _ts = DEFAULT_THUMBNAIL_SIZE
         thumb_files = {
-            "Metadata/plate_1.png": (256, 256),
-            "Metadata/plate_no_light_1.png": (256, 256),
-            "Metadata/plate_1_small.png": (128, 128),
+            "Metadata/plate_1.png": (_ts, _ts),
+            "Metadata/plate_no_light_1.png": (_ts, _ts),
+            "Metadata/plate_1_small.png": (_ts // 2, _ts // 2),
         }
         for fname, (w, h) in thumb_files.items():
             try:
@@ -1012,7 +1015,7 @@ def extract_from_3mf(path: Path) -> str:
         machine_overrides["nozzle_type"] = nozzle_type
 
     # --- Plate size from printable_area ---
-    plate_size = (256, 256)  # fallback
+    plate_size = (int(DEFAULT_PLATE_SIZE[0]), int(DEFAULT_PLATE_SIZE[1]))
     printable_area = settings.get("printable_area")
     if isinstance(printable_area, list) and len(printable_area) >= 3:
         # printable_area is ["0x0", "256x0", "256x256", "0x256"]

--- a/src/estampo/plate.py
+++ b/src/estampo/plate.py
@@ -13,7 +13,7 @@ import trimesh
 from defusedxml import ElementTree as SafeET  # safe fromstring for untrusted 3MF XML
 
 from estampo.arrange import Placement
-from estampo.constants import NS_3MF
+from estampo.constants import DEFAULT_PLATE_SIZE, NS_3MF
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def _encode_paint_color(extruder_idx: int) -> str:
 
 def build_plate(
     placements: list[Placement],
-    plate_size: tuple[float, float] = (256.0, 256.0),
+    plate_size: tuple[float, float] = DEFAULT_PLATE_SIZE,
     include_bed: bool = False,
 ) -> trimesh.Scene:
     """Build a trimesh Scene from placed meshes.

--- a/src/estampo/thumbnails.py
+++ b/src/estampo/thumbnails.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from estampo.constants import DEFAULT_THUMBNAIL_SIZE
+
 log = logging.getLogger(__name__)
 
 
 def generate_plate_thumbnail(
-    width: int = 256, height: int = 256, plate_3mf: Path | None = None
+    width: int = DEFAULT_THUMBNAIL_SIZE,
+    height: int = DEFAULT_THUMBNAIL_SIZE,
+    plate_3mf: Path | None = None,
 ) -> bytes:
     """Render an isometric thumbnail of the plate using trimesh + Pillow.
 
@@ -156,7 +160,10 @@ def _render_plate_thumbnail(width: int, height: int, plate_3mf: Path) -> bytes:
     return buf.getvalue()
 
 
-def placeholder_thumbnail(width: int = 256, height: int = 256) -> bytes:
+def placeholder_thumbnail(
+    width: int = DEFAULT_THUMBNAIL_SIZE,
+    height: int = DEFAULT_THUMBNAIL_SIZE,
+) -> bytes:
     """Generate a minimal branded placeholder PNG (no mesh data needed)."""
     import struct
     import zlib as _zlib

--- a/src/estampo/viewer.py
+++ b/src/estampo/viewer.py
@@ -8,13 +8,15 @@ from pathlib import Path
 
 import trimesh
 
+from estampo.constants import DEFAULT_PLATE_SIZE
+
 log = logging.getLogger(__name__)
 
 
 def show_plate(
     meshes: list[trimesh.Trimesh],
     names: list[str] | None = None,
-    plate_size: tuple[float, float] = (256, 256),
+    plate_size: tuple[float, float] = DEFAULT_PLATE_SIZE,
 ) -> None:
     """Display arranged meshes, trying ocp_vscode first, then trimesh viewer."""
     if _try_ocp(meshes, names, plate_size):


### PR DESCRIPTION
## Summary
- Extracts hardcoded magic numbers (plate size 256x256, thumbnail size 256, min filament slots 5) into `constants.py`
- Migrates all 7 example TOML configs from the removed flat `[slicer]` format to the new `[slicer.orca]`/`[slicer.cura]` namespaced format
- Fixes lint (E402, E501) and mypy errors in the constants refactoring

Closes #359

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — all formatted
- [x] `uv run mypy src/estampo` — zero errors
- [x] `uv run pytest` — 645 passed, 9 skipped
- [ ] CI release-readiness slice-test jobs should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)