### PR TITLE
Fix profile extraction push when branch already exists

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -205,7 +205,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git commit -m "Update bundled OrcaSlicer profiles (${{ matrix.orca_version }})"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
           gh pr create \
             --title "Update bundled OrcaSlicer ${{ matrix.orca_version }} profiles" \
             --body "Auto-extracted from estampo/estampo:orca-${{ matrix.orca_version }}-test." \
@@ -406,7 +406,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git commit -m "Update bundled CuraEngine definitions (${{ matrix.cura_version }})"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
           gh pr create \
             --title "Update bundled CuraEngine ${{ matrix.cura_version }} definitions" \
             --body "Auto-extracted from estampo/estampo:cura-${{ matrix.cura_version }}-test." \

--- a/changes/+fix-profile-push.bugfix
+++ b/changes/+fix-profile-push.bugfix
@@ -1,0 +1,1 @@
+Fix profile extraction push failure when branch already exists from earlier run


### PR DESCRIPTION
## Summary
- Use `--force-with-lease` for both orca and cura profile extraction push steps in `release-readiness.yml`
- The dated branch name (e.g. `update-cura-definitions-5.12.0-20260406`) can already exist from an earlier run the same day, causing a plain `git push` to be rejected

Closes #361

## Test plan
- [ ] Trigger release-readiness workflow twice on the same day — second run should force-update the branch instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)