### PR TITLE
Skip printer setup and print stage for CuraEngine in init

### DIFF
--- a/changes/380.bugfix
+++ b/changes/380.bugfix
@@ -1,0 +1,1 @@
+Skip printer setup and print stage for CuraEngine in ``estampo init``

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -1014,8 +1014,13 @@ def run_wizard(output: Path | None = None) -> str:
     # --- Step 2: CAD files (copies, orient — filament slots assigned later) ---
     parts_config = _wizard_pick_parts(existing_parts=existing.parts if existing else None)
 
-    # --- Step 3: Printer connection (optional) ---
-    printer_name = _wizard_pick_printer()
+    # --- Step 3: Printer connection (optional, OrcaSlicer only) ---
+    printer_name = None
+    if engine == "orca":
+        printer_name = _wizard_pick_printer()
+    else:
+        ui.info("Printing is not yet supported for CuraEngine — skipping printer setup.")
+        ui.console.print()
 
     # Build pipeline stages — include "print" only if printer selected
     stages = list(DEFAULT_STAGES)


### PR DESCRIPTION
## Summary
- When `engine == "cura"`, skip printer connection step and show info message
- Don't add `print` to pipeline stages for CuraEngine configs
- Stopgap until bambox extraction makes the packaging path engine-agnostic

Closes #380

## Test plan
- [x] All init tests pass (52/52)
- [x] ruff/mypy/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)