### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,93 @@ All notable changes to this project are documented here.
 
 <!-- towncrier release notes start -->
 
+## 0.3.0 — 2026-04-06
+
+### Features
+
+- Add CuraEngine slicer backend (``engine = "cura"``) as alternative to OrcaSlicer ([#282](https://github.com/estampo/estampo/pull/282))
+- Build CuraEngine from source instead of extracting from AppImage, eliminating placeholder G-code header issue ([#299](https://github.com/estampo/estampo/pull/299))
+- Add Bambu Lab P1S machine definition for CuraEngine with proper start/end G-code ([#301](https://github.com/estampo/estampo/pull/301))
+- Add OrcaSlicer 2.3.2 Docker image builds alongside 2.3.1
+- Add ``--engine cura`` support to profile extraction script and CI workflow for automated CuraEngine printer definition discovery
+- Add ``EngineConfig`` base class, ``SlicerConfig.active`` property, top-level ``[filaments]`` table for material aliases, and ``PartConfig.material`` field; remove facade fields from ``SlicerConfig``
+- Add ``[slicer.filament_overrides]`` to patch all filament profiles (e.g. ``required_nozzle_HRC``)
+- Add ``[slicer.machine_overrides]`` for overriding machine profile settings (e.g. ``nozzle_type = "hardened_steel"`` for carbon-fiber filaments).
+- Add ``bed_type`` config option to set plate type for filament compatibility
+- CuraEngine machine definitions are now stored as JSON files (bundled ``Bambu Lab P1S 0.4 nozzle.json``); add custom printers via ``estampo profiles add``; ``profiles pin`` and ``profiles add`` no longer misroute Cura profiles; override values from config are now coerced to the correct type.
+- CuraEngine printer definitions: discoverable selection during ``estampo init``, configurable via ``[slicer.cura] printer``, and dynamic definition resolution at slice time
+- Engine-namespaced TOML config: ``[slicer.orca]`` and ``[slicer.cura]`` sections for per-engine settings with backward-compatible legacy format support
+- Engine-namespaced profile directories: ``profiles/<engine>/<category>/`` with backward-compatible legacy path fallback
+- Extract Bambu Connect 3MF fixup into a ``packaged_output`` pipeline stage so printer-specific packaging is explicit and only runs for Bambu printers
+- Show animated status spinners during slow Docker operations (image pull, profile extraction)
+- Support CuraEngine in local slicer discovery (``find_slicer``) for all platforms
+- ``estampo init`` wizard now prompts for slicer engine (OrcaSlicer or CuraEngine) and adapts version detection and profile discovery accordingly.
+
+### Bugfixes
+
+- Fix CuraEngine Docker image breaking Python by isolating bundled libssl/libcrypto ([#283](https://github.com/estampo/estampo/pull/283))
+- Fix CuraEngine Docker image Python access for unprivileged estampo user ([#286](https://github.com/estampo/estampo/pull/286))
+- Show CuraEngine error output instead of suppressing stderr ([#288](https://github.com/estampo/estampo/pull/288))
+- Show rich UI output (checkmarks, print summary) alongside debug logs in verbose mode ([#300](https://github.com/estampo/estampo/pull/300))
+- Fix ``ValueError`` when CuraEngine override values include a ``%`` suffix (e.g. ``sparse_infill_density = "35%"``). ([#310](https://github.com/estampo/estampo/pull/310))
+- Fix ``profiles pin`` failing for CuraEngine when printer name includes nozzle suffix or different casing ([#340](https://github.com/estampo/estampo/pull/340))
+- Fix CuraEngine slice failing when no separate machine profile JSON exists for the printer ([#345](https://github.com/estampo/estampo/pull/345))
+- Fix CuraEngine squashed definitions preserving ``inherits`` for unresolved base definitions like ``fdmprinter`` ([#347](https://github.com/estampo/estampo/pull/347))
+- Fix profile extraction push failure when bot-managed branch already exists ([#363](https://github.com/estampo/estampo/pull/363))
+- Remove Bambu-specific AMS auto-detect from ``estampo init`` wizard ([#367](https://github.com/estampo/estampo/pull/367))
+- Skip printer setup and print stage for CuraEngine in ``estampo init`` ([#380](https://github.com/estampo/estampo/pull/380))
+- Broadcast scalar machine overrides to arrays when profile has per-extruder fields
+- Error when pinned profiles don't match the target slicer version instead of silently crashing
+- Fix CuraEngine binary "not found" by patching ELF interpreter and replace missing ``bambu_3mf`` dependency with inline G-code generation
+- Fix CuraEngine reporting zero filament usage — CuraEngine CLI writes placeholder G-code header values that are not updated after slicing; patch with real values from stderr and fall back to E-value analysis.
+- Fix CuraEngine slicing by converting 3MF model data to STL before passing to the engine
+- Fix CuraEngine slicing: place mesh on bed, resolve G-code template variables, fix header patching
+- Fix CuraEngine: disable default brim, center mesh on build plate
+- Fix OrcaSlicer 2.3.2 segfault in Docker on Colima by preventing Wayland GL init
+- Fix TestPyPI dev version collisions by using git commit count instead of workflow run number.
+- Fix filament weight reporting: correct multi-value regex, M83 relative extrusion support, newest-file selection, and layer count in output summary.
+- Fix profile extraction push failure when branch already exists from earlier run
+- Fix release workflow checkout ref that prevented manual release dispatch
+- Fix release workflow job skip cascade on manual dispatch
+- Fix release workflow tag-check that used curl flags with ``gh api``
+- Narrow bare ``except Exception`` handlers to specific exception types for better debuggability.
+- Pass ``--allow-mix-temp`` for multi-filament AMS configurations on OrcaSlicer 2.3.2
+- Pass ``--allow-mix-temp`` unconditionally on OrcaSlicer 2.3.2+ to fix grouping errors; gate the flag off for older versions.
+- Replace unsafe ``eval()`` in CuraEngine G-code template substitution with AST-based safe evaluators.
+- Revert ``xvfb-run`` wrapping that caused OrcaSlicer 2.3.2 to segfault on GL init.
+- Set ``infill_line_distance`` directly so CuraEngine respects infill density overrides
+- Stage Docker slicer input inside output directory and preserve file extension to fix bind-mount issues
+
+### Misc
+
+- Run e2e slice test from host to match real user flow (Docker-based slicing). ([#275](https://github.com/estampo/estampo/pull/275))
+- Fix lint errors in ``scripts/bambu_cloud_login.py`` and ``scripts/test_cloud_print.py`` ([#331](https://github.com/estampo/estampo/pull/331))
+- Populate bundled CuraEngine 5.12.0 printer definition manifest with full machine list extracted from Docker image ([#354](https://github.com/estampo/estampo/pull/354))
+- Add ADR-006 defining the slicer plugin protocol: each engine is a self-contained module; top-level files are pure dispatch layers; clear contract for adding new slicers
+- Add Architecture Decision Records, ROADMAP.md, and module ownership table to CLAUDE.md for long-term architectural coherence
+- Add GitHub issue templates, labels, and milestones for structured backlog tracking
+- Add ``scripts/compare_engines.py`` utility to compare OrcaSlicer vs CuraEngine G-code output
+- Add automatic Claude PR review workflow — checks ADR compliance, exception handling, eval() usage, and missing changelog fragments on every PR
+- Add slicer engine research doc: Bambu P1S multi-material support across CuraEngine, PrusaSlicer, and Kiri:Moto.
+- Consolidate ``bambu-3mf`` + ``bambu-cloud`` into single ``bambox`` package in docs and ADR-005
+- Disable OrcaSlicer 2.3.2 builds (segfaults on slice); re-enable when upstream fixes it
+- Extract OrcaSlicer-specific logic from ``slicer.py``, ``profiles.py``, and ``init.py`` into new ``orca.py`` engine module per ADR-006.
+- Extract shared magic numbers into ``constants.py`` and migrate example configs to engine-namespaced ``[slicer.orca]``/``[slicer.cura]`` format
+- Fix Claude PR review workflow: add missing id-token: write permission for OIDC authentication
+- Fix Claude PR review workflow: raise max-turns to 8 and add continue-on-error so turn limit never blocks a merge
+- Fix release-readiness jobs skipping on manual dispatch and nightly schedule
+- Improve CuraEngine error reporting to include both stdout and stderr
+- Mark all ``todo-slicer.md`` items as resolved — slicer-agnostic work is complete.
+- Move CuraEngine definition pinning and profile logic from ``profiles.py`` into ``cura.py`` engine module.
+- Profile system now handles CuraEngine gracefully — ``profiles list --engine cura`` explains that CuraEngine uses inline settings instead of showing empty results.
+- Remove Claude PR review workflow — not working reliably
+- Remove legacy flat ``[slicer]`` config format, ``fabprint.toml`` alias, ``FABPRINT_*`` env vars, and ``~/.config/fabprint`` migration.
+- Replace hardcoded OrcaSlicer references with engine-agnostic text in CLI help, error messages, and 3MF metadata
+- Speed up CI with uv dependency caching, concurrency groups, and conditional bridge builds
+- Update docs and README to use engine-namespaced ``[slicer.orca]``/``[slicer.cura]`` config format and document ``[filaments]`` table
+- Use ``RELEASE_PAT`` in prepare-release workflow so CI triggers on release PRs automatically
+
+
 ## 0.2.3 — 2026-03-31
 
 ### Features

--- a/changes/+add-constants.misc
+++ b/changes/+add-constants.misc
@@ -1,1 +1,0 @@
-Extract shared magic numbers into ``constants.py`` and migrate example configs to engine-namespaced ``[slicer.orca]``/``[slicer.cura]`` format

--- a/changes/+allow-mix-temp-gate.bugfix
+++ b/changes/+allow-mix-temp-gate.bugfix
@@ -1,1 +1,0 @@
-Pass ``--allow-mix-temp`` unconditionally on OrcaSlicer 2.3.2+ to fix grouping errors; gate the flag off for older versions.

--- a/changes/+architecture-docs.misc
+++ b/changes/+architecture-docs.misc
@@ -1,1 +1,0 @@
-Add Architecture Decision Records, ROADMAP.md, and module ownership table to CLAUDE.md for long-term architectural coherence

--- a/changes/+bambox-rename.misc
+++ b/changes/+bambox-rename.misc
@@ -1,1 +1,0 @@
-Consolidate ``bambu-3mf`` + ``bambu-cloud`` into single ``bambox`` package in docs and ADR-005

--- a/changes/+bed-type.feature
+++ b/changes/+bed-type.feature
@@ -1,1 +1,0 @@
-Add ``bed_type`` config option to set plate type for filament compatibility

--- a/changes/+ci-improvements.misc
+++ b/changes/+ci-improvements.misc
@@ -1,1 +1,0 @@
-Speed up CI with uv dependency caching, concurrency groups, and conditional bridge builds

--- a/changes/+claude-pr-review.misc
+++ b/changes/+claude-pr-review.misc
@@ -1,1 +1,0 @@
-Add automatic Claude PR review workflow — checks ADR compliance, exception handling, eval() usage, and missing changelog fragments on every PR

--- a/changes/+compare-engines-script.misc
+++ b/changes/+compare-engines-script.misc
@@ -1,1 +1,0 @@
-Add ``scripts/compare_engines.py`` utility to compare OrcaSlicer vs CuraEngine G-code output

--- a/changes/+create-orca-module.misc
+++ b/changes/+create-orca-module.misc
@@ -1,1 +1,0 @@
-Extract OrcaSlicer-specific logic from ``slicer.py``, ``profiles.py``, and ``init.py`` into new ``orca.py`` engine module per ADR-006.

--- a/changes/+cura-3mf-to-stl.bugfix
+++ b/changes/+cura-3mf-to-stl.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine slicing by converting 3MF model data to STL before passing to the engine

--- a/changes/+cura-adhesion-centering.bugfix
+++ b/changes/+cura-adhesion-centering.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine: disable default brim, center mesh on build plate

--- a/changes/+cura-engine-exec.bugfix
+++ b/changes/+cura-engine-exec.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine binary "not found" by patching ELF interpreter and replace missing ``bambu_3mf`` dependency with inline G-code generation

--- a/changes/+cura-error-diag.misc
+++ b/changes/+cura-error-diag.misc
@@ -1,1 +1,0 @@
-Improve CuraEngine error reporting to include both stdout and stderr

--- a/changes/+cura-filament-usage.bugfix
+++ b/changes/+cura-filament-usage.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine reporting zero filament usage — CuraEngine CLI writes placeholder G-code header values that are not updated after slicing; patch with real values from stderr and fall back to E-value analysis.

--- a/changes/+cura-geometry-templates.bugfix
+++ b/changes/+cura-geometry-templates.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine slicing: place mesh on bed, resolve G-code template variables, fix header patching

--- a/changes/+cura-infill-override.bugfix
+++ b/changes/+cura-infill-override.bugfix
@@ -1,1 +1,0 @@
-Set ``infill_line_distance`` directly so CuraEngine respects infill density overrides

--- a/changes/+cura-local-fallback.feature
+++ b/changes/+cura-local-fallback.feature
@@ -1,1 +1,0 @@
-Support CuraEngine in local slicer discovery (``find_slicer``) for all platforms

--- a/changes/+cura-machine-profiles.feature
+++ b/changes/+cura-machine-profiles.feature
@@ -1,1 +1,0 @@
-CuraEngine machine definitions are now stored as JSON files (bundled ``Bambu Lab P1S 0.4 nozzle.json``); add custom printers via ``estampo profiles add``; ``profiles pin`` and ``profiles add`` no longer misroute Cura profiles; override values from config are now coerced to the correct type.

--- a/changes/+cura-manifest-extraction.feature
+++ b/changes/+cura-manifest-extraction.feature
@@ -1,1 +1,0 @@
-Add ``--engine cura`` support to profile extraction script and CI workflow for automated CuraEngine printer definition discovery

--- a/changes/+cura-printer-definitions.feature
+++ b/changes/+cura-printer-definitions.feature
@@ -1,1 +1,0 @@
-CuraEngine printer definitions: discoverable selection during ``estampo init``, configurable via ``[slicer.cura] printer``, and dynamic definition resolution at slice time

--- a/changes/+disable-orca-232.misc
+++ b/changes/+disable-orca-232.misc
@@ -1,1 +1,0 @@
-Disable OrcaSlicer 2.3.2 builds (segfaults on slice); re-enable when upstream fixes it

--- a/changes/+docker-staging.bugfix
+++ b/changes/+docker-staging.bugfix
@@ -1,1 +1,0 @@
-Stage Docker slicer input inside output directory and preserve file extension to fix bind-mount issues

--- a/changes/+docs-config-format.misc
+++ b/changes/+docs-config-format.misc
@@ -1,1 +1,0 @@
-Update docs and README to use engine-namespaced ``[slicer.orca]``/``[slicer.cura]`` config format and document ``[filaments]`` table

--- a/changes/+engine-namespaced-config.feature
+++ b/changes/+engine-namespaced-config.feature
@@ -1,1 +1,0 @@
-Engine-namespaced TOML config: ``[slicer.orca]`` and ``[slicer.cura]`` sections for per-engine settings with backward-compatible legacy format support

--- a/changes/+engine-namespaced-profiles.feature
+++ b/changes/+engine-namespaced-profiles.feature
@@ -1,1 +1,0 @@
-Engine-namespaced profile directories: ``profiles/<engine>/<category>/`` with backward-compatible legacy path fallback

--- a/changes/+filament-overrides.feature
+++ b/changes/+filament-overrides.feature
@@ -1,1 +1,0 @@
-Add ``[slicer.filament_overrides]`` to patch all filament profiles (e.g. ``required_nozzle_HRC``)

--- a/changes/+fix-broad-exceptions.bugfix
+++ b/changes/+fix-broad-exceptions.bugfix
@@ -1,1 +1,0 @@
-Narrow bare ``except Exception`` handlers to specific exception types for better debuggability.

--- a/changes/+fix-claude-review-oidc.misc
+++ b/changes/+fix-claude-review-oidc.misc
@@ -1,1 +1,0 @@
-Fix Claude PR review workflow: add missing id-token: write permission for OIDC authentication

--- a/changes/+fix-claude-review-turns.misc
+++ b/changes/+fix-claude-review-turns.misc
@@ -1,1 +1,0 @@
-Fix Claude PR review workflow: raise max-turns to 8 and add continue-on-error so turn limit never blocks a merge

--- a/changes/+fix-profile-push.bugfix
+++ b/changes/+fix-profile-push.bugfix
@@ -1,1 +1,0 @@
-Fix profile extraction push failure when branch already exists from earlier run

--- a/changes/+fix-release-checkout-ref.bugfix
+++ b/changes/+fix-release-checkout-ref.bugfix
@@ -1,1 +1,0 @@
-Fix release workflow checkout ref that prevented manual release dispatch

--- a/changes/+fix-release-skip-cascade.bugfix
+++ b/changes/+fix-release-skip-cascade.bugfix
@@ -1,1 +1,0 @@
-Fix release workflow job skip cascade on manual dispatch

--- a/changes/+fix-release-tag-check.bugfix
+++ b/changes/+fix-release-tag-check.bugfix
@@ -1,1 +1,0 @@
-Fix release workflow tag-check that used curl flags with ``gh api``

--- a/changes/+gcode-stats-accuracy.bugfix
+++ b/changes/+gcode-stats-accuracy.bugfix
@@ -1,1 +1,0 @@
-Fix filament weight reporting: correct multi-value regex, M83 relative extrusion support, newest-file selection, and layer count in output summary.

--- a/changes/+init-engine-choice.feature
+++ b/changes/+init-engine-choice.feature
@@ -1,1 +1,0 @@
-``estampo init`` wizard now prompts for slicer engine (OrcaSlicer or CuraEngine) and adapts version detection and profile discovery accordingly.

--- a/changes/+issue-infrastructure.misc
+++ b/changes/+issue-infrastructure.misc
@@ -1,1 +1,0 @@
-Add GitHub issue templates, labels, and milestones for structured backlog tracking

--- a/changes/+machine-overrides.feature
+++ b/changes/+machine-overrides.feature
@@ -1,1 +1,0 @@
-Add ``[slicer.machine_overrides]`` for overriding machine profile settings (e.g. ``nozzle_type = "hardened_steel"`` for carbon-fiber filaments).

--- a/changes/+material-centric-config.feature
+++ b/changes/+material-centric-config.feature
@@ -1,1 +1,0 @@
-Add ``EngineConfig`` base class, ``SlicerConfig.active`` property, top-level ``[filaments]`` table for material aliases, and ``PartConfig.material`` field; remove facade fields from ``SlicerConfig``

--- a/changes/+move-cura-profiles.misc
+++ b/changes/+move-cura-profiles.misc
@@ -1,1 +1,0 @@
-Move CuraEngine definition pinning and profile logic from ``profiles.py`` into ``cura.py`` engine module.

--- a/changes/+nozzle-scalar-broadcast.bugfix
+++ b/changes/+nozzle-scalar-broadcast.bugfix
@@ -1,1 +1,0 @@
-Broadcast scalar machine overrides to arrays when profile has per-extruder fields

--- a/changes/+orca-2.3.2.feature
+++ b/changes/+orca-2.3.2.feature
@@ -1,1 +1,0 @@
-Add OrcaSlicer 2.3.2 Docker image builds alongside 2.3.1

--- a/changes/+prepare-release-pat.misc
+++ b/changes/+prepare-release-pat.misc
@@ -1,1 +1,0 @@
-Use ``RELEASE_PAT`` in prepare-release workflow so CI triggers on release PRs automatically

--- a/changes/+printer-packaging.feature
+++ b/changes/+printer-packaging.feature
@@ -1,1 +1,0 @@
-Extract Bambu Connect 3MF fixup into a ``packaged_output`` pipeline stage so printer-specific packaging is explicit and only runs for Bambu printers

--- a/changes/+profiles-engine-aware.misc
+++ b/changes/+profiles-engine-aware.misc
@@ -1,1 +1,0 @@
-Profile system now handles CuraEngine gracefully — ``profiles list --engine cura`` explains that CuraEngine uses inline settings instead of showing empty results.

--- a/changes/+release-readiness-dispatch.misc
+++ b/changes/+release-readiness-dispatch.misc
@@ -1,1 +1,0 @@
-Fix release-readiness jobs skipping on manual dispatch and nightly schedule

--- a/changes/+remove-claude-review.misc
+++ b/changes/+remove-claude-review.misc
@@ -1,1 +1,0 @@
-Remove Claude PR review workflow — not working reliably

--- a/changes/+remove-legacy-config.misc
+++ b/changes/+remove-legacy-config.misc
@@ -1,1 +1,0 @@
-Remove legacy flat ``[slicer]`` config format, ``fabprint.toml`` alias, ``FABPRINT_*`` env vars, and ``~/.config/fabprint`` migration.

--- a/changes/+replace-eval.bugfix
+++ b/changes/+replace-eval.bugfix
@@ -1,1 +1,0 @@
-Replace unsafe ``eval()`` in CuraEngine G-code template substitution with AST-based safe evaluators.

--- a/changes/+revert-xvfb.bugfix
+++ b/changes/+revert-xvfb.bugfix
@@ -1,1 +1,0 @@
-Revert ``xvfb-run`` wrapping that caused OrcaSlicer 2.3.2 to segfault on GL init.

--- a/changes/+slicer-agnostic-messages.misc
+++ b/changes/+slicer-agnostic-messages.misc
@@ -1,1 +1,0 @@
-Replace hardcoded OrcaSlicer references with engine-agnostic text in CLI help, error messages, and 3MF metadata

--- a/changes/+slicer-engine-research.misc
+++ b/changes/+slicer-engine-research.misc
@@ -1,1 +1,0 @@
-Add slicer engine research doc: Bambu P1S multi-material support across CuraEngine, PrusaSlicer, and Kiri:Moto.

--- a/changes/+slicer-plugin-protocol.misc
+++ b/changes/+slicer-plugin-protocol.misc
@@ -1,1 +1,0 @@
-Add ADR-006 defining the slicer plugin protocol: each engine is a self-contained module; top-level files are pure dispatch layers; clear contract for adding new slicers

--- a/changes/+stale-profiles.bugfix
+++ b/changes/+stale-profiles.bugfix
@@ -1,1 +1,0 @@
-Error when pinned profiles don't match the target slicer version instead of silently crashing

--- a/changes/+status-spinners.feature
+++ b/changes/+status-spinners.feature
@@ -1,1 +1,0 @@
-Show animated status spinners during slow Docker operations (image pull, profile extraction)

--- a/changes/+testpypi-versioning.bugfix
+++ b/changes/+testpypi-versioning.bugfix
@@ -1,1 +1,0 @@
-Fix TestPyPI dev version collisions by using git commit count instead of workflow run number.

--- a/changes/+todo-slicer-complete.misc
+++ b/changes/+todo-slicer-complete.misc
@@ -1,1 +1,0 @@
-Mark all ``todo-slicer.md`` items as resolved — slicer-agnostic work is complete.

--- a/changes/+unused-filament-slots.bugfix
+++ b/changes/+unused-filament-slots.bugfix
@@ -1,1 +1,0 @@
-Pass ``--allow-mix-temp`` for multi-filament AMS configurations on OrcaSlicer 2.3.2

--- a/changes/+wayland-segfault.bugfix
+++ b/changes/+wayland-segfault.bugfix
@@ -1,1 +1,0 @@
-Fix OrcaSlicer 2.3.2 segfault in Docker on Colima by preventing Wayland GL init

--- a/changes/275.misc
+++ b/changes/275.misc
@@ -1,1 +1,0 @@
-Run e2e slice test from host to match real user flow (Docker-based slicing).

--- a/changes/282.feature
+++ b/changes/282.feature
@@ -1,1 +1,0 @@
-Add CuraEngine slicer backend (``engine = "cura"``) as alternative to OrcaSlicer

--- a/changes/283.bugfix
+++ b/changes/283.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine Docker image breaking Python by isolating bundled libssl/libcrypto

--- a/changes/286.bugfix
+++ b/changes/286.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine Docker image Python access for unprivileged estampo user

--- a/changes/288.bugfix
+++ b/changes/288.bugfix
@@ -1,1 +1,0 @@
-Show CuraEngine error output instead of suppressing stderr

--- a/changes/299.feature
+++ b/changes/299.feature
@@ -1,1 +1,0 @@
-Build CuraEngine from source instead of extracting from AppImage, eliminating placeholder G-code header issue

--- a/changes/300.bugfix
+++ b/changes/300.bugfix
@@ -1,1 +1,0 @@
-Show rich UI output (checkmarks, print summary) alongside debug logs in verbose mode

--- a/changes/301.feature
+++ b/changes/301.feature
@@ -1,1 +1,0 @@
-Add Bambu Lab P1S machine definition for CuraEngine with proper start/end G-code

--- a/changes/310.bugfix
+++ b/changes/310.bugfix
@@ -1,1 +1,0 @@
-Fix ``ValueError`` when CuraEngine override values include a ``%`` suffix (e.g. ``sparse_infill_density = "35%"``).

--- a/changes/331.misc
+++ b/changes/331.misc
@@ -1,1 +1,0 @@
-Fix lint errors in ``scripts/bambu_cloud_login.py`` and ``scripts/test_cloud_print.py``

--- a/changes/340.bugfix
+++ b/changes/340.bugfix
@@ -1,1 +1,0 @@
-Fix ``profiles pin`` failing for CuraEngine when printer name includes nozzle suffix or different casing

--- a/changes/345.bugfix
+++ b/changes/345.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine slice failing when no separate machine profile JSON exists for the printer

--- a/changes/347.bugfix
+++ b/changes/347.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine squashed definitions preserving ``inherits`` for unresolved base definitions like ``fdmprinter``

--- a/changes/354.misc
+++ b/changes/354.misc
@@ -1,1 +1,0 @@
-Populate bundled CuraEngine 5.12.0 printer definition manifest with full machine list extracted from Docker image

--- a/changes/363.bugfix
+++ b/changes/363.bugfix
@@ -1,1 +1,0 @@
-Fix profile extraction push failure when bot-managed branch already exists

--- a/changes/367.bugfix
+++ b/changes/367.bugfix
@@ -1,1 +1,0 @@
-Remove Bambu-specific AMS auto-detect from ``estampo init`` wizard

--- a/changes/380.bugfix
+++ b/changes/380.bugfix
@@ -1,1 +1,0 @@
-Skip printer setup and print stage for CuraEngine in ``estampo init``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estampo"
-version = "0.2.3"
+version = "0.3.0"
 description = "The build system for reproducible 3D prints. Define parts, slicer settings, and printer targets in code."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release v0.3.0


### Features

- Add CuraEngine slicer backend (``engine = "cura"``) as alternative to OrcaSlicer ([#282](https://github.com/estampo/estampo/pull/282))
- Build CuraEngine from source instead of extracting from AppImage, eliminating placeholder G-code header issue ([#299](https://github.com/estampo/estampo/pull/299))
- Add Bambu Lab P1S machine definition for CuraEngine with proper start/end G-code ([#301](https://github.com/estampo/estampo/pull/301))
- Add OrcaSlicer 2.3.2 Docker image builds alongside 2.3.1
- Add ``--engine cura`` support to profile extraction script and CI workflow for automated CuraEngine printer definition discovery
- Add ``EngineConfig`` base class, ``SlicerConfig.active`` property, top-level ``[filaments]`` table for material aliases, and ``PartConfig.material`` field; remove facade fields from ``SlicerConfig``
- Add ``[slicer.filament_overrides]`` to patch all filament profiles (e.g. ``required_nozzle_HRC``)
- Add ``[slicer.machine_overrides]`` for overriding machine profile settings (e.g. ``nozzle_type = "hardened_steel"`` for carbon-fiber filaments).
- Add ``bed_type`` config option to set plate type for filament compatibility
- CuraEngine machine definitions are now stored as JSON files (bundled ``Bambu Lab P1S 0.4 nozzle.json``); add custom printers via ``estampo profiles add``; ``profiles pin`` and ``profiles add`` no longer misroute Cura profiles; override values from config are now coerced to the correct type.
- CuraEngine printer definitions: discoverable selection during ``estampo init``, configurable via ``[slicer.cura] printer``, and dynamic definition resolution at slice time
- Engine-namespaced TOML config: ``[slicer.orca]`` and ``[slicer.cura]`` sections for per-engine settings with backward-compatible legacy format support
- Engine-namespaced profile directories: ``profiles/<engine>/<category>/`` with backward-compatible legacy path fallback
- Extract Bambu Connect 3MF fixup into a ``packaged_output`` pipeline stage so printer-specific packaging is explicit and only runs for Bambu printers
- Show animated status spinners during slow Docker operations (image pull, profile extraction)
- Support CuraEngine in local slicer discovery (``find_slicer``) for all platforms
- ``estampo init`` wizard now prompts for slicer engine (OrcaSlicer or CuraEngine) and adapts version detection and profile discovery accordingly.

### Bugfixes

- Fix CuraEngine Docker image breaking Python by isolating bundled libssl/libcrypto ([#283](https://github.com/estampo/estampo/pull/283))
- Fix CuraEngine Docker image Python access for unprivileged estampo user ([#286](https://github.com/estampo/estampo/pull/286))
- Show CuraEngine error output instead of suppressing stderr ([#288](https://github.com/estampo/estampo/pull/288))
- Show rich UI output (checkmarks, print summary) alongside debug logs in verbose mode ([#300](https://github.com/estampo/estampo/pull/300))
- Fix ``ValueError`` when CuraEngine override values include a ``%`` suffix (e.g. ``sparse_infill_density = "35%"``). ([#310](https://github.com/estampo/estampo/pull/310))
- Fix ``profiles pin`` failing for CuraEngine when printer name includes nozzle suffix or different casing ([#340](https://github.com/estampo/estampo/pull/340))
- Fix CuraEngine slice failing when no separate machine profile JSON exists for the printer ([#345](https://github.com/estampo/estampo/pull/345))
- Fix CuraEngine squashed definitions preserving ``inherits`` for unresolved base definitions like ``fdmprinter`` ([#347](https://github.com/estampo/estampo/pull/347))
- Fix profile extraction push failure when bot-managed branch already exists ([#363](https://github.com/estampo/estampo/pull/363))
- Remove Bambu-specific AMS auto-detect from ``estampo init`` wizard ([#367](https://github.com/estampo/estampo/pull/367))
- Skip printer setup and print stage for CuraEngine in ``estampo init`` ([#380](https://github.com/estampo/estampo/pull/380))
- Broadcast scalar machine overrides to arrays when profile has per-extruder fields
- Error when pinned profiles don't match the target slicer version instead of silently crashing
- Fix CuraEngine binary "not found" by patching ELF interpreter and replace missing ``bambu_3mf`` dependency with inline G-code generation
- Fix CuraEngine reporting zero filament usage — CuraEngine CLI writes placeholder G-code header values that are not updated after slicing; patch with real values from stderr and fall back to E-value analysis.
- Fix CuraEngine slicing by converting 3MF model data to STL before passing to the engine
- Fix CuraEngine slicing: place mesh on bed, resolve G-code template variables, fix header patching
- Fix CuraEngine: disable default brim, center mesh on build plate
- Fix OrcaSlicer 2.3.2 segfault in Docker on Colima by preventing Wayland GL init
- Fix TestPyPI dev version collisions by using git commit count instead of workflow run number.
- Fix filament weight reporting: correct multi-value regex, M83 relative extrusion support, newest-file selection, and layer count in output summary.
- Fix profile extraction push failure when branch already exists from earlier run
- Fix release workflow checkout ref that prevented manual release dispatch
- Fix release workflow job skip cascade on manual dispatch
- Fix release workflow tag-check that used curl flags with ``gh api``
- Narrow bare ``except Exception`` handlers to specific exception types for better debuggability.
- Pass ``--allow-mix-temp`` for multi-filament AMS configurations on OrcaSlicer 2.3.2
- Pass ``--allow-mix-temp`` unconditionally on OrcaSlicer 2.3.2+ to fix grouping errors; gate the flag off for older versions.
- Replace unsafe ``eval()`` in CuraEngine G-code template substitution with AST-based safe evaluators.
- Revert ``xvfb-run`` wrapping that caused OrcaSlicer 2.3.2 to segfault on GL init.
- Set ``infill_line_distance`` directly so CuraEngine respects infill density overrides
- Stage Docker slicer input inside output directory and preserve file extension to fix bind-mount issues

### Misc

- Run e2e slice test from host to match real user flow (Docker-based slicing). ([#275](https://github.com/estampo/estampo/pull/275))
- Fix lint errors in ``scripts/bambu_cloud_login.py`` and ``scripts/test_cloud_print.py`` ([#331](https://github.com/estampo/estampo/pull/331))
- Populate bundled CuraEngine 5.12.0 printer definition manifest with full machine list extracted from Docker image ([#354](https://github.com/estampo/estampo/pull/354))
- Add ADR-006 defining the slicer plugin protocol: each engine is a self-contained module; top-level files are pure dispatch layers; clear contract for adding new slicers
- Add Architecture Decision Records, ROADMAP.md, and module ownership table to CLAUDE.md for long-term architectural coherence
- Add GitHub issue templates, labels, and milestones for structured backlog tracking
- Add ``scripts/compare_engines.py`` utility to compare OrcaSlicer vs CuraEngine G-code output
- Add automatic Claude PR review workflow — checks ADR compliance, exception handling, eval() usage, and missing changelog fragments on every PR
- Add slicer engine research doc: Bambu P1S multi-material support across CuraEngine, PrusaSlicer, and Kiri:Moto.
- Consolidate ``bambu-3mf`` + ``bambu-cloud`` into single ``bambox`` package in docs and ADR-005
- Disable OrcaSlicer 2.3.2 builds (segfaults on slice); re-enable when upstream fixes it
- Extract OrcaSlicer-specific logic from ``slicer.py``, ``profiles.py``, and ``init.py`` into new ``orca.py`` engine module per ADR-006.
- Extract shared magic numbers into ``constants.py`` and migrate example configs to engine-namespaced ``[slicer.orca]``/``[slicer.cura]`` format
- Fix Claude PR review workflow: add missing id-token: write permission for OIDC authentication
- Fix Claude PR review workflow: raise max-turns to 8 and add continue-on-error so turn limit never blocks a merge
- Fix release-readiness jobs skipping on manual dispatch and nightly schedule
- Improve CuraEngine error reporting to include both stdout and stderr
- Mark all ``todo-slicer.md`` items as resolved — slicer-agnostic work is complete.
- Move CuraEngine definition pinning and profile logic from ``profiles.py`` into ``cura.py`` engine module.
- Profile system now handles CuraEngine gracefully — ``profiles list --engine cura`` explains that CuraEngine uses inline settings instead of showing empty results.
- Remove Claude PR review workflow — not working reliably
- Remove legacy flat ``[slicer]`` config format, ``fabprint.toml`` alias, ``FABPRINT_*`` env vars, and ``~/.config/fabprint`` migration.
- Replace hardcoded OrcaSlicer references with engine-agnostic text in CLI help, error messages, and 3MF metadata
- Speed up CI with uv dependency caching, concurrency groups, and conditional bridge builds
- Update docs and README to use engine-namespaced ``[slicer.orca]``/``[slicer.cura]`` config format and document ``[filaments]`` table
- Use ``RELEASE_PAT`` in prepare-release workflow so CI triggers on release PRs automatically

---
**Merge this PR to trigger the release pipeline.**
The release workflow will auto-tag `v0.3.0`, build all artifacts, validate on TestPyPI, then publish to PyPI + Docker Hub + GHCR.