### PR TITLE
Add third-party license attribution for CuraEngine components

### DIFF
--- a/Dockerfile.cura-base
+++ b/Dockerfile.cura-base
@@ -115,6 +115,10 @@ LABEL org.opencontainers.image.description="CuraEngine ${CURA_VERSION} base imag
 LABEL org.opencontainers.image.source="https://github.com/estampo/estampo"
 LABEL org.opencontainers.image.licenses="AGPL-3.0"
 LABEL estampo.cura-version="${CURA_VERSION}"
+LABEL estampo.curaengine.source="https://github.com/Ultimaker/CuraEngine/tree/${CURA_VERSION}"
+LABEL estampo.curaengine.license="AGPL-3.0"
+LABEL estampo.cura-definitions.source="https://github.com/Ultimaker/Cura/tree/${CURA_VERSION}"
+LABEL estampo.cura-definitions.license="LGPL-3.0"
 
 # Runtime deps (libgomp for OpenMP)
 RUN --mount=type=cache,id=apt-cura-rt,target=/var/cache/apt \

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1,0 +1,54 @@
+Third-Party Software Notices
+============================
+
+This file lists third-party components used by estampo and the licenses
+that apply to them. Estampo itself is licensed under the Apache License 2.0
+(see LICENSE).
+
+
+CuraEngine
+----------
+Copyright (C) UltiMaker
+License: AGPL-3.0 (GNU Affero General Public License v3.0)
+Source:  https://github.com/Ultimaker/CuraEngine
+
+Estampo invokes CuraEngine as a separate subprocess (not linked). The
+Docker images distributed as estampo/estampo:cura-* and estampo/cura-base:*
+contain the CuraEngine binary compiled from source. Complete corresponding
+source code is available at the URL above, tagged by version (e.g. 5.12.0).
+
+Full license text: https://www.gnu.org/licenses/agpl-3.0.html
+
+
+Cura Printer Definitions
+-------------------------
+Copyright (C) UltiMaker
+License: LGPL-3.0 (GNU Lesser General Public License v3.0)
+Source:  https://github.com/Ultimaker/Cura
+
+The following files in src/estampo/data/ are derived from printer
+definitions distributed with UltiMaker Cura under the LGPL-3.0:
+
+  - bambulab_base.def.json   (from Cura's resources/definitions/)
+  - bambulab_p1s.def.json    (adapted from Cura + OrcaSlicer profiles)
+
+The Docker images also bundle the full set of Cura printer definitions
+extracted from the Cura AppImage release.
+
+Modifications made by estampo are noted in each file's "author" metadata
+field. Per LGPL-3.0, modified files remain under LGPL-3.0.
+
+Full license text: https://www.gnu.org/licenses/lgpl-3.0.html
+
+
+OrcaSlicer
+----------
+Copyright (C) SoftFever and contributors
+License: AGPL-3.0 (GNU Affero General Public License v3.0)
+Source:  https://github.com/SoftFever/OrcaSlicer
+
+Estampo invokes OrcaSlicer as a separate subprocess (not linked). The
+Docker images distributed as estampo/estampo:orca-* contain the OrcaSlicer
+binary. Complete corresponding source code is available at the URL above.
+
+Full license text: https://www.gnu.org/licenses/agpl-3.0.html

--- a/changes/426.misc
+++ b/changes/426.misc
@@ -1,0 +1,1 @@
+Add ``THIRD-PARTY-NOTICES`` file and Docker image labels for CuraEngine (AGPL-3.0) and Cura definition (LGPL-3.0) license attribution

--- a/src/estampo/data/LICENSING.md
+++ b/src/estampo/data/LICENSING.md
@@ -1,0 +1,21 @@
+# License Information for Bundled Data Files
+
+## CuraEngine Printer Definitions (`.def.json`)
+
+The files `bambulab_base.def.json` and `bambulab_p1s.def.json` are derived
+from printer definitions distributed with [UltiMaker Cura](https://github.com/Ultimaker/Cura)
+under the **LGPL-3.0** (GNU Lesser General Public License v3.0).
+
+Copyright (C) UltiMaker. Modifications by estampo are noted in each file's
+`"author"` metadata field.
+
+## OrcaSlicer Profiles (`profiles.orca.*.json`)
+
+Profile manifests extracted from OrcaSlicer ([AGPL-3.0](https://github.com/SoftFever/OrcaSlicer)).
+These are index/metadata files listing available printer names and IDs.
+
+## CuraEngine Profile Manifests (`profiles.cura.*.json`)
+
+Profile manifests listing available CuraEngine printer definitions.
+
+See the top-level `THIRD-PARTY-NOTICES` file for full attribution details.


### PR DESCRIPTION
## Summary

- Add `THIRD-PARTY-NOTICES` file covering CuraEngine (AGPL-3.0), Cura printer definitions (LGPL-3.0), and OrcaSlicer (AGPL-3.0) with source URLs and copyright holders
- Add `src/estampo/data/LICENSING.md` documenting the license status of bundled definition and profile files
- Add Docker image OCI labels (`estampo.curaengine.source`, `estampo.cura-definitions.source`, etc.) for AGPL source-offer compliance

Closes #426

## Test plan
- [x] `ruff check` — pass
- [x] `ruff format --check` — pass
- [x] `mypy` — pass
- [x] `pytest` — 697 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)