### PR TITLE
Align docs with printer-agnostic north star

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,24 +57,30 @@ Each module has a defined scope. Do not add logic to the wrong module — even i
 | `config.py` | TOML parsing, config dataclasses | Business logic, file I/O beyond TOML |
 | `cli.py` | Typer commands, user-facing flags, Hamilton driver construction | Pipeline logic, slicer invocation |
 | `adapters.py` | Hamilton lifecycle hooks (progress, timing) | Pipeline logic, direct node invocation |
-| `printer.py` | Printer dispatch (LAN/Cloud/Bambu Connect) | Slicing, G-code generation |
-| `credentials.py` | `~/.config/estampo/credentials.toml` loading | Any other file I/O |
+| `commands.py` | Command stage execution (generic subprocess runner) | Printer-specific logic, slicer logic |
+| `printer.py` | **DEPRECATED — deleting in v0.4.0** (Bambu dispatch) | New code — use command stages instead |
+| `credentials.py` | **DEPRECATED — deleting in v0.4.0** (Bambu credentials) | New code — credentials belong in bambox |
 
 ## Architecture: Key Decisions
 
-Four architecture decisions are documented in `docs/decisions/`. Read them before changing any of the following:
+Seven architecture decisions are documented in `docs/decisions/`. Read them before changing any of the following:
 
 1. **`docs/decisions/001-hamilton-dag-pipeline.md`** — Why Hamilton; DAG invariants; what must not go in pipeline nodes
 2. **`docs/decisions/002-docker-local-fallback.md`** — Docker-first + local fallback; `docker_image()` as single source of truth
 3. **`docs/decisions/003-multi-engine-facade.md`** — OrcaSlicer + CuraEngine coexistence; facade pattern on SlicerConfig; engine-specific code stays in slicer.py / cura.py
 4. **`docs/decisions/004-bundled-profiles.md`** — Profiles extracted from Docker, committed to repo, bundled in pip package
+5. **`docs/decisions/005-vendor-agnostic-split.md`** — estampo is printer-agnostic; Bambu code is deleted (not moved); bambox is CLI-only (never imported)
+6. **`docs/decisions/006-slicer-plugin-protocol.md`** — Slicer engine modules as first-class peers; dispatch layers stay pure
+7. **`docs/decisions/007-command-stages.md`** — External CLI tools as pipeline stages; `str.format_map()` variable substitution
 
 **Before adding a new slicer engine:** read ADR-006 (the complete protocol a new engine module must implement).  
 **Before adding engine `if/elif` to profiles.py, init.py, or slicer.py:** read ADR-006 — it goes in the engine module instead.  
 **Before touching Docker image tag construction:** read ADR-002.  
 **Before adding logic to pipeline.py:** read ADR-001.  
 **Before changing profile loading:** read ADR-004.  
-**Before adding Bambu-specific code anywhere:** read ADR-005.
+**Before adding Bambu-specific code anywhere:** read ADR-005 — **do not add it. estampo is printer-agnostic.**  
+**Before adding printer/packaging logic:** read ADR-005 + ADR-007 — it belongs in a command stage, not in estampo.  
+**Before importing bambox:** read ADR-005 + ADR-007 — **do not import it. CLI integration only.**
 
 ## What estampo is NOT
 
@@ -82,10 +88,10 @@ To prevent scope creep and re-invention:
 
 - **Not a slicer.** estampo wraps slicers (OrcaSlicer, CuraEngine). Do not reimplement slicing algorithms in Python.
 - **Not a profile editor.** estampo pins and references profiles. Do not build profile editing UI or deep profile merging logic.
-- **Not a printer firmware.** estampo sends files to printers via existing APIs (Bambu LAN, Bambu Cloud). Do not implement printer protocols from scratch.
+- **Not a printer tool.** estampo does not send files to printers, package G-code for specific printer vendors, or handle printer authentication. Printing and packaging are handled by external tools (e.g. `bambox` for Bambu Lab) configured as command stages in TOML. See ADR-005.
 - **Not a CAD tool.** estampo loads meshes. The `build123d` integration is for code-CAD users who want to go straight from model to print — it is not a CAD kernel.
 - **Not a standalone G-code generator.** G-code comes from the slicer. estampo parses G-code metadata (print time, filament weight) but does not generate toolpaths.
-- **Not a Bambu-only tool.** Bambu Lab printer support is being extracted to the separate `bambox` package (packaging, printing, auth). Do not add new Bambu-specific logic to estampo core modules (pipeline.py, slicer.py, cura.py, gcode.py). See ADR-005.
+- **Not a Bambu tool (or any vendor's tool).** estampo is printer-agnostic. All Bambu-specific code is being deleted (v0.4.0) — not moved, not wrapped. The `bambox` package is a separate CLI tool for Bambu Lab printers. estampo never imports bambox; integration is via command stages (ADR-005, ADR-007). Do not add printer-vendor logic to any estampo module.
 
 ## Architecture: Slicer Execution
 

--- a/changes/428.misc
+++ b/changes/428.misc
@@ -1,0 +1,1 @@
+Align docs and CLAUDE.md with printer-agnostic north star and CLI-only bambox integration

--- a/docs/architecture-roadmap.md
+++ b/docs/architecture-roadmap.md
@@ -1,114 +1,99 @@
-# Architecture Roadmap: Slicer-Agnostic Printing
+# Architecture Roadmap: Slicer-Agnostic, Printer-Agnostic Pipeline
 
 This document captures the long-term vision for estampo's architecture,
 motivated by ongoing instability in OrcaSlicer's CLI mode (undocumented
 behavior changes, settings ignored from `--load-settings`, segfaults in
 headless mode, broken validation checks in 2.3.2+).
 
-## Current State
+## North Star
 
-Estampo is tightly coupled to OrcaSlicer:
+**estampo is a printer-agnostic, slicer-agnostic pipeline orchestrator.**
+It loads parts, arranges them onto a plate, invokes a slicer, and
+extracts G-code metadata. It has no knowledge of printer vendors,
+packaging formats, or print protocols.
 
-```
-estampo (pipeline) → OrcaSlicer CLI (slicing + 3MF packaging) → Bambu Connect → Printer
-```
+Printer-vendor concerns (packaging, printing, auth) live in separate
+external tools invoked via **command stages** — CLI commands declared in
+the user's TOML config (see ADR-007).
 
-OrcaSlicer handles three distinct responsibilities:
-1. **Slicing** — toolpath generation from 3D models
-2. **BBL G-code** — printer-specific start/end/toolchange macros
-3. **Packaging** — `.gcode.3mf` archive format for BBL printers
+## Current State (April 2026, v0.3.0)
 
-This coupling means every OrcaSlicer CLI bug blocks the entire pipeline.
-
-## Target Architecture
-
-Two projects, each owning one concern:
+estampo supports two slicer backends (OrcaSlicer and CuraEngine) and
+has a working command stages framework. However, legacy Bambu-specific
+code remains in several modules, pending extraction (v0.4.0).
 
 ```
 estampo (pipeline + slicer backends)
-    ↓ G-code
-bambox (packaging + G-code templates + printer communication)
+    ├── OrcaSlicer (via Docker)
+    ├── CuraEngine (via Docker)
+    ↓ plain G-code
+    ↓ command stages (user-configured CLI calls)
+bambox pack / bambox print              ← external CLI tool
     ↓ .gcode.3mf → MQTT/FTP
 Bambu printer
 ```
 
-### estampo — Pipeline Orchestrator
+Legacy code still in estampo (to be deleted in v0.4.0):
+- `printer.py` — Bambu LAN/Cloud dispatch, `.gcode.3mf` packaging
+- `auth.py`, `credentials.py`, `cloud/` — Bambu auth and bridge
+- AMS flags and Bambu stage IDs in `cli.py`
+- Bambu-specific defaults in `init.py` and `cura.py`
 
-What it does today, minus the OrcaSlicer lock-in:
-- Plate arrangement, profile management, build automation
-- Slicer-agnostic: pluggable backends (OrcaSlicer, CuraEngine, others)
-- Delegates all BBL-specific concerns to `bambox`
-- Could target non-BBL printers (Prusa, Voron, etc.) in the future
+## Target Architecture (v0.4.0)
 
-### bambox — BBL Packaging, Templates & Printing
+```
+estampo (pipeline + slicer backends)
+    ├── OrcaSlicer (via Docker)
+    ├── CuraEngine (via Docker)
+    ├── [future: PrusaSlicer, others]
+    ↓ plain G-code + metadata
+    ↓ command stages (TOML-configured CLI calls)
+Any printer tool                        ← user's choice
+```
 
-Three responsibilities:
+estampo's modules after v0.4.0:
 
-**1. `.gcode.3mf` packager** — takes plain G-code and produces a
-printer-ready BBL archive:
-- ZIP structure with required metadata files
-- MD5 checksums (validated by firmware)
-- `model_settings.config`, `slice_info.config`, `project_settings.config`
-- Thumbnail placeholders
-- Pure Python, no dependencies beyond stdlib (`zipfile`, `hashlib`)
-- ~200-300 lines for the core packager
+| Module | Responsibility |
+|--------|---------------|
+| `pipeline.py` | Hamilton DAG orchestration |
+| `slicer.py` | Slicer dispatch (routes to engine modules) |
+| `orca.py` | OrcaSlicer-specific logic |
+| `cura.py` | CuraEngine-specific logic |
+| `gcode.py` | G-code metadata parsing |
+| `commands.py` | Command stage execution |
+| `arrange.py`, `plate.py`, `loader.py`, `orient.py` | Geometry pipeline |
+| `config.py`, `cli.py`, `profiles.py`, `adapters.py` | Config, CLI, profiles |
 
-See [gcode-3mf-format.md](gcode-3mf-format.md) for the full format
-specification we've already documented.
+**Deleted:** `printer.py`, `auth.py`, `credentials.py`, `cloud/`,
+`thumbnails.py` (BBL-specific). No Bambu Python dependencies remain.
 
-**2. BBL G-code template library** — Jinja2-based rendering of
-printer-specific G-code macros:
-- Start G-code (bed leveling, nozzle wipe, AMS init, vibration cal)
-- End G-code (cooldown, retract, park)
-- Tool change G-code (AMS filament swap, purge, wipe)
-- Layer change G-code (timelapse support)
-- Per-printer-model templates (P1S, X1C, A1, etc.)
+## bambox — Standalone Bambu Lab Tool
 
-Source material for templates:
-- **KiriMoto** (`Bambu.P1S.json`, `Bambu.A1.json`) — MIT licensed,
-  complete start/end/toolchange with AMS support, JSON format
-- **BambuStudio** (`resources/profiles/BBL/machine/`) — Apache-2.0,
-  canonical templates with OrcaSlicer variable syntax
-- **OpenBambuAPI** (`gcode.md`) — reverse-engineered M-code reference
-  for proprietary commands (M620/M621, M975, M1002, etc.)
+bambox is a separate project (`estampo/bambox`) that handles all
+Bambu Lab concerns. estampo integrates with it exclusively via CLI
+command stages — never as a Python import.
 
-Template engine: **Jinja2** — proven for G-code templating by both Klipper
-and OctoPrint. OrcaSlicer's custom template syntax maps almost 1:1:
+**bambox provides:**
 
-| OrcaSlicer | Jinja2 |
-|---|---|
-| `{bed_temperature}` | `{{ bed_temperature }}` |
-| `{filament_type[0]}` | `{{ filament_type[0] }}` |
-| `{if cond}...{endif}` | `{% if cond %}...{% endif %}` |
+1. **`.gcode.3mf` packager** — takes plain G-code and produces a
+   printer-ready BBL archive (ZIP structure, MD5 checksums, metadata)
+2. **BBL G-code templates** — Jinja2-based start/end/toolchange macros
+   with BAMBOX header contract for auto-configuration
+3. **CuraEngine printer definitions** — `bambox_p1s_ams.def.json` and
+   related extruder definitions for Bambu printers
+4. **Printer communication** — cloud/LAN printing, status monitoring,
+   AMS mapping, Bambu Cloud authentication
+5. **Bridge** — Docker-based BNL bridge binary for cloud printing
 
-A thin translator (~50 lines of regex) can convert existing OrcaSlicer
-templates to Jinja2 format.
+**Integration point:**
+```toml
+[pack]
+command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
+output = "{output_dir}/plate.gcode.3mf"
 
-**3. Printer communication** — wraps the Docker-based Bambu Network
-Library (BNL) bridge:
-- Estampo already uses Docker for slicing; same pattern for printing
-- BNL `.so` is preserved in the Docker image (insurance against Bambu
-  pulling it)
-- Handles LAN and cloud printing workflows
-- Printer discovery, status monitoring, job management
-- AMS filament slot mapping
-- Bambu Cloud authentication
-
-**Why not replace BNL?** Repeated attempts to reverse-engineer the Bambu
-cloud protocol have failed. The BNL `.so` is the only reliable path for
-cloud printing. LAN printing via raw MQTT/FTP is possible (and KiriMoto
-demonstrates it) but cloud printing requires BNL.
-
-## What This Unlocks
-
-**For estampo users:**
-- Slicer choice: CuraEngine for stability, OrcaSlicer for BBL profiles
-- No more fighting OrcaSlicer CLI bugs for non-slicing concerns
-- Faster iteration — slicer upgrades don't break packaging/printing
-
-**For the broader community:**
-- `bambox` is useful standalone (anyone using CuraEngine + BBL printer, Home Assistant, custom dashboards)
-- Each project is small, focused, and independently testable
+[print]
+command = "bambox print {output_dir}/plate.gcode.3mf --serial YOUR_SERIAL"
+```
 
 ## Slicer Comparison
 
@@ -125,30 +110,26 @@ as potential OrcaSlicer alternatives:
 | License | AGPL-3.0 | AGPL-3.0 | AGPL-3.0 | MIT |
 | Active dev | Yes | Yes (UltiMaker) | Yes (Prusa) | Solo maintainer |
 
-**CuraEngine** is the strongest candidate for a second backend:
-- Purpose-built headless CLI, stable, actively maintained
-- JSON-based settings with ~1200 parameters
-- The missing pieces (BBL profiles, 3MF packaging) are exactly what
-  `bambox` would provide
+**CuraEngine** is the strongest second backend — purpose-built headless
+CLI, stable, actively maintained. The missing pieces (BBL profiles, 3MF
+packaging) are handled by `bambox`.
 
-**PrusaSlicer** is not viable — cannot produce `.gcode.3mf` and has no
-BBL profile ecosystem.
+## Migration Phases
 
-**KiriMoto** is interesting for reference (MIT-licensed BBL templates,
-Bambu MQTT integration) but the slicer itself lacks features and the CLI
-is not production-grade.
+### Phase 1: Multi-engine support (DONE — v0.3.0)
+- CuraEngine added as second slicer backend
+- Slicer plugin protocol (ADR-006) established
+- Command stages framework (ADR-007) implemented
+- bambox extracted as standalone package
 
-## Migration Path
+### Phase 2: Vendor-agnostic estampo (IN PROGRESS — v0.4.0)
+- Delete all Bambu-specific code from estampo (see ADR-005)
+- Remove Bambu Python dependencies
+- Printing/packaging becomes command stages only
+- Tracked by issues #370, #373, #374, #375, #377, #378, #387
 
-This is not a rewrite — it's a gradual decoupling:
-
-1. **Now**: Keep OrcaSlicer as the only backend. Pin stable versions,
-   work around CLI bugs with overrides and retries.
-2. **Phase 1**: Extract `bambox` as a library. Estampo already
-   post-processes OrcaSlicer's 3MF output — formalize packaging,
-   printing, and auth into a standalone package.
-3. **Phase 2**: Add CuraEngine as a second slicer backend. Use
-   `bambox` for packaging and G-code template injection.
-
-Each phase is independently useful and shippable. No big bang migration
-required.
+### Phase 3: Ecosystem expansion (FUTURE)
+- PrusaSlicer as third engine (#351)
+- BambuStudio headless spike (#352)
+- Additional printer vendor tools (community-driven)
+- Each new printer vendor = a new external CLI tool, not estampo code

--- a/docs/decisions/005-vendor-agnostic-split.md
+++ b/docs/decisions/005-vendor-agnostic-split.md
@@ -1,7 +1,7 @@
 # ADR-005: Vendor-Agnostic estampo via bambox Extraction
 
 **Status:** Accepted — migration in progress  
-**Date:** 2026-04  
+**Date:** 2026-04 (revised 2026-04-11)  
 
 ## Context
 
@@ -16,75 +16,105 @@ The slicer comparison research (in `docs/architecture-roadmap.md`) confirmed tha
 
 ## Decision
 
-Extract all Bambu-specific concerns into a single standalone package:
+**estampo is printer-agnostic.** It has no knowledge of printer vendors, protocols, or packaging formats. Its job ends at G-code output.
+
+All printer-vendor concerns live in separate, external tools:
 
 - **`bambox`** — Bambu Lab packaging, G-code templates, cloud/LAN printing, AMS mapping, and authentication
 
-estampo becomes a **printer-vendor-agnostic pipeline orchestrator**. It produces plain G-code and delegates packaging and dispatch to pluggable backends.
+estampo integrates with bambox (and any other printer tool) exclusively through **command stages** (ADR-007) — external CLI commands declared in the user's TOML config. estampo never imports bambox as a Python library.
 
 ```
 estampo (pipeline + slicer backends)
     ↓ plain G-code
-bambox (packaging + printing + auth)       ← optional, Bambu-specific
+    ↓ command stages (TOML-configured CLI calls)
+bambox pack / bambox print            ← external CLI, user-configured
     ↓ .gcode.3mf → MQTT/FTP
 Bambu printer
 ```
 
-For non-Bambu printers, estampo sends plain G-code directly — no BBL packaging needed.
+Example user TOML:
+```toml
+[pack]
+command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
+output = "{output_dir}/plate.gcode.3mf"
+
+[print]
+command = "bambox print {output_dir}/plate.gcode.3mf --serial YOUR_SERIAL"
+```
+
+For non-Bambu printers, users configure different command stages (or none — just take the G-code).
 
 ## Rationale
 
-**Decoupling slicer from packaging:** OrcaSlicer currently handles slicing, BBL G-code injection, and `.gcode.3mf` packaging in one binary. Any CLI bug in OrcaSlicer blocks all three. If estampo owns packaging independently, it can swap slicers (OrcaSlicer → CuraEngine) without losing BBL printer support.
+**Decoupling slicer from packaging:** OrcaSlicer currently handles slicing, BBL G-code injection, and `.gcode.3mf` packaging in one binary. Any CLI bug in OrcaSlicer blocks all three. With bambox as a separate CLI, estampo can swap slicers (OrcaSlicer → CuraEngine) without losing BBL printer support.
 
-**Community value:** `bambox` is useful to anyone with a Bambu printer, regardless of which slicer or pipeline they use. Splitting it out makes it independently installable and testable.
+**CLI-only integration:** bambox is a Rust+Python tool with its own release cadence, FFI dependencies (BNL bridge), and build toolchain. A Python import would couple estampo's version constraints to bambox's internals. CLI integration via command stages (ADR-007) keeps both projects independently versioned and deployable.
 
-**Scope clarity for estampo:** Once the split is done, estampo's job is clear and finite: load parts, arrange, plate, invoke slicer, hand off G-code. It has no knowledge of printer vendors.
+**Community value:** `bambox` is useful to anyone with a Bambu printer, regardless of which slicer or pipeline they use. It is independently installable (`pip install bambox` / `pipx install bambox`).
 
-## What moves where
+**Scope clarity for estampo:** estampo's job is clear and finite: load parts, arrange, plate, invoke slicer, extract G-code metadata. It has no knowledge of printer vendors, packaging formats, or print protocols.
 
-### Stays in estampo
+## What stays in estampo
 
 - `pipeline.py` — DAG orchestration
-- `slicer.py` — OrcaSlicer invocation
-- `cura.py` — CuraEngine invocation
+- `slicer.py` — slicer dispatch (OrcaSlicer / CuraEngine)
+- `orca.py` — OrcaSlicer-specific logic (including OrcaSlicer 3MF painting metadata)
+- `cura.py` — CuraEngine-specific logic (printer-agnostic)
 - `gcode.py` — G-code metadata parsing (print time, filament weight — engine-agnostic)
+- `commands.py` — command stage execution (generic, not printer-aware)
 - `arrange.py`, `plate.py`, `loader.py`, `orient.py` — geometry pipeline
 - `config.py`, `cli.py`, `profiles.py`, `adapters.py`
 
-### Moves to `bambox`
+## What gets deleted from estampo
 
-- `.gcode.3mf` packaging (`printer.py` → `wrap_gcode_3mf()`)
-- BBL G-code template library (start/end/toolchange/layer-change macros)
-- The format specification at `docs/gcode-3mf-format.md`
-- Thumbnail generation (`thumbnails.py`) — BBL-specific metadata
-- Bambu LAN printing (`bambulabs-api`)
-- Bambu Cloud printing (`bambu-lab-cloud-api`)
-- Bambu Connect bridge (`cloud/bridge.py`)
-- AMS filament slot mapping (`cloud/ams.py`)
-- Bambu Cloud authentication (`auth.py`)
-- Bambu printer credentials (`credentials.py`)
-- Bambu Connect 3MF fixup (`orca.py` → `bambu_connect_fixup()`)
+These modules and functions are **deleted entirely** — not moved, not wrapped, not shimmed. bambox already provides all replacements as CLI commands.
+
+| Delete from estampo | bambox replacement | Tracking issue |
+|---|---|---|
+| `printer.py` (entire module) | `bambox pack`, `bambox print` | #370 |
+| `auth.py` (entire module) | `bambox` handles its own auth | #370 |
+| `credentials.py` (entire module) | `bambox` handles its own credentials | #370 |
+| `cloud/` directory (bridge, ams) | `bambox bridge`, `bambox print` | #370 |
+| `cli.py`: `_PRINT_STAGES`, AMS flags, printer status rendering | `bambox status`, `bambox print` | #375 |
+| `cli.py`: `--no-ams-mapping`, bambu-cloud serial discovery | `bambox print` flags | #375 |
+| `cura.py`: `_substitute_gcode_templates()`, `_patch_gcode_header()` | `bambox pack` (auto-configures from BAMBOX headers) | #387 |
+| `cura.py`: bundled `bambulab_p1s.def.json`, `bambulab_base.def.json` | bambox ships its own CuraEngine definitions | #387 |
+| `cura.py`: default to `"bambulab_p1s"` when no printer specified | Error if no printer specified | #374 |
+| `init.py`: Bambu P1S defaults in prompts and template | Generic prompts, profile picker | #373 |
+| `plate.py`: `BambuStudio:MmPaintingVersion`, `_encode_paint_color()` | Moves to `orca.py` (OrcaSlicer-specific, not printer-specific) | #378 |
+| `constants.py`: Bambu-specific comments | Generic wording | #377 |
+| `pyproject.toml`: `bambulabs-api`, `bambu-lab-cloud-api` dependencies | Not needed — bambox is a CLI tool, not a Python dependency | #370 |
 
 ## Migration path
 
 Gradual decoupling — no big bang rewrite. Each phase is independently shippable.
 
-**v0.4.0:** Extract `bambox` as a standalone library. estampo depends on it. No user-visible change, but all Bambu-specific code is out of estampo core.
+**Phase 1 — Quick wins (no bambox changes needed):**
+- #377: Reword Bambu-specific comments in `constants.py`
+- #373: Remove Bambu defaults from `init.py` prompts
+- #374: Remove Bambu defaults from `cura.py`, error on missing printer
 
-**Future:** estampo has zero Bambu-specific imports. `bambox` is an optional extra: `pip install estampo[bambu]`.
+**Phase 2 — Delete Bambu code from estampo:**
+- #378: Move BambuStudio 3MF painting metadata from `plate.py` to `orca.py`
+- #387: Delete bundled Bambu CuraEngine definitions and post-processing functions
+- #375: Delete AMS CLI flags, Bambu stage IDs, printer status rendering from `cli.py`
+- #370: Delete `printer.py`, `auth.py`, `credentials.py`, `cloud/` — remove Bambu dependencies from `pyproject.toml`
+
+**v0.4.0 gate:** After all phases complete, estampo has zero Bambu-specific code, zero Bambu Python dependencies, and zero knowledge of printer vendors. Users configure packaging and printing via command stages in TOML.
 
 ## Consequences
 
-- `printer.py` will shrink to a thin dispatch layer, then eventually move to `bambox`
-- `thumbnails.py` will move to `bambox`
-- `cloud/` directory will move to `bambox`
-- `auth.py` and `credentials.py` will move to `bambox`
-- The `packaged_output` pipeline node will call `bambox` APIs instead of local functions
-- Adding Prusa/Voron/etc. printer support becomes a matter of adding a new dispatch plugin, not forking estampo
+- `printer.py`, `auth.py`, `credentials.py`, `cloud/` are deleted
+- `bambulabs-api` and `bambu-lab-cloud-api` are removed from dependencies
+- estampo's `print` and `status` CLI subcommands are removed (users use `bambox print` / `bambox status`)
+- `plate.py` becomes a pure geometry assembler; OrcaSlicer-specific 3MF metadata moves to `orca.py`
+- Adding support for a new printer vendor requires zero changes to estampo — users just configure a different command stage
 
 ## Anti-patterns to avoid
 
-- Do not add new Bambu-specific logic to `pipeline.py`, `gcode.py`, or `arrange.py`
-- Do not add new Bambu-specific logic to `slicer.py` or `cura.py` — the slicers produce generic G-code; packaging is `bambox`'s job
-- Do not add OrcaSlicer-specific packaging logic assuming it will always be the slicer — CuraEngine output must go through the same packaging path
-- Do not create a `prusa.py` or `voron.py` in estampo — printer-vendor code belongs in vendor-specific packages, not estampo core
+- **Do not import bambox** as a Python library. Integration is CLI-only via command stages (ADR-007).
+- Do not add new Bambu-specific logic to any estampo module.
+- Do not create "thin dispatch shims" or "wrapper functions" for bambox — that's still coupling.
+- Do not add printer-vendor modules (`prusa.py`, `voron.py`) to estampo — printer-vendor code belongs in vendor-specific packages.
+- Do not add OrcaSlicer-specific packaging logic assuming it will always be the slicer — CuraEngine output must go through the same packaging path (command stages).

--- a/docs/printers.md
+++ b/docs/printers.md
@@ -1,8 +1,24 @@
 # Printer support
 
-estampo supports three printer connection types. All are configured via `estampo setup` and stored in `~/.config/estampo/credentials.toml`.
+> **Note (v0.4.0 migration):** Printer communication is moving out of estampo.
+> estampo is becoming printer-agnostic — it produces G-code and delegates
+> packaging/printing to external tools via command stages (see ADR-005, ADR-007).
+>
+> For Bambu Lab printers, use [bambox](https://github.com/estampo/bambox):
+> ```toml
+> [pack]
+> command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
+>
+> [print]
+> command = "bambox print {output_dir}/plate.gcode.3mf --serial YOUR_SERIAL"
+> ```
+>
+> The built-in `bambu-lan`, `bambu-cloud`, and `moonraker` printer types
+> described below are **deprecated** and will be removed in v0.4.0.
 
-## bambu-lan (experimental)
+---
+
+## bambu-lan (deprecated — use bambox)
 
 Direct LAN connection to Bambu Lab printers using the `bambulabs_api` library.
 
@@ -17,9 +33,9 @@ Direct LAN connection to Bambu Lab printers using the `bambulabs_api` library.
 
 **Dependencies:** `bambulabs_api` (optional install)
 
-**Tested against:** Not yet tested against real hardware.
+**Migration:** Use `bambox print --lan` instead. See [bambox docs](https://github.com/estampo/bambox).
 
-## bambu-cloud
+## bambu-cloud (deprecated — use bambox)
 
 Cloud connection to Bambu Lab printers via the Bambu Connect bridge binary (`bambu_cloud_bridge`).
 
@@ -34,9 +50,9 @@ Cloud connection to Bambu Lab printers via the Bambu Connect bridge binary (`bam
 
 **Dependencies:** `bambu_cloud_bridge` binary, cloud auth token
 
-**Tested against:** Bambu Lab P1S via Bambu Cloud.
+**Migration:** Use `bambox print` and `bambox bridge` instead. See [bambox docs](https://github.com/estampo/bambox).
 
-## moonraker
+## moonraker (deprecated — use command stages)
 
 REST API connection to Klipper/Moonraker printers. Works with any printer running Klipper + Moonraker (Voron, Ender with Klipper, etc.).
 
@@ -50,6 +66,13 @@ REST API connection to Klipper/Moonraker printers. Works with any printer runnin
 **Credentials:** `url` (required), `api_key` (optional, for authenticated instances)
 
 **Dependencies:** `requests` (optional install)
+
+**Migration:** In v0.4.0, Moonraker support will be available as a command stage.
+A simple `curl`-based command stage can replace the built-in integration:
+```toml
+[print]
+command = "curl -F file=@{sliced_dir}/plate.gcode http://YOUR_PRINTER:7125/server/files/upload"
+```
 
 ### API endpoints used
 


### PR DESCRIPTION
## Summary

- Rewrite ADR-005 to establish "delete, don't move" as the migration strategy with CLI-only bambox integration via command stages
- Restructure architecture roadmap with north star statement, current vs target state, and phased milestones (Phase 1 DONE, Phase 2 IN PROGRESS)
- Mark all built-in printer types as deprecated in printers.md with migration paths to command stages
- Update CLAUDE.md module ownership table (deprecated modules, `commands.py` added), expand ADR list to 7 with guard rules

Also updated comments on issues #370, #373, #374, #375, #377, #378, #387 with corrected "delete, not move" framing and retitled 4 issues.

Closes #428

## Test plan

- [ ] Docs-only change — verify rendered markdown reads correctly
- [ ] Confirm ADR-005 migration table references all 7 extraction issues
- [ ] Confirm CLAUDE.md guard rules match ADR numbering

🤖 Generated with [Claude Code](https://claude.com/claude-code)