### PR TITLE
Add {filament} and {filaments} command stage variables

### DIFF
--- a/changes/+filament-command-variable.feature
+++ b/changes/+filament-command-variable.feature
@@ -1,0 +1,1 @@
+Add ``{filament}`` and ``{filaments}`` template variables for command stages

--- a/src/estampo/commands.py
+++ b/src/estampo/commands.py
@@ -34,6 +34,8 @@ COMMAND_VARIABLES: dict[str, str] = {
     "output_dir": "Output directory path",
     "machine": "Active printer/machine name (empty string if unset)",
     "engine": "Active slicer engine name (orca or cura)",
+    "filament": "First filament profile name (empty string if unset)",
+    "filaments": "All filament profiles, comma-separated (empty string if unset)",
     "input_3mf": "Plate 3MF path (available after plate stage)",
     "sliced_3mf": "Packaged 3MF after slicing (available after slice stage)",
     "sliced_dir": "Slicer output directory (available after slice stage)",
@@ -53,11 +55,15 @@ def build_command_context(
 
     The returned dict always has exactly the keys in ``COMMAND_VARIABLES``.
     """
+    engine_cfg = config.slicer.orca if config.slicer.engine == "orca" else config.slicer.cura
+    fils = engine_cfg.filaments
     ctx: dict[str, str] = {
         "name": config.name or "",
         "output_dir": str(output_dir),
         "machine": config.slicer.active.printer or "",
         "engine": config.slicer.engine,
+        "filament": fils[0] if fils else "",
+        "filaments": ",".join(fils) if fils else "",
         "input_3mf": str(stage_results.get("plate_3mf_path", "")),
         "sliced_3mf": str(stage_results.get("packaged_output", "")),
         "sliced_dir": str(stage_results.get("sliced_output_dir", "")),

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -117,6 +117,29 @@ class TestBuildCommandContext:
         assert ctx["sliced_3mf"] == ""
         assert ctx["sliced_dir"] == ""
 
+    def test_filament_single(self, tmp_path):
+        cfg = _make_config(tmp_path, filaments=["Generic PLA @base"])
+        ctx = build_command_context(cfg, tmp_path / "out", {})
+        assert ctx["filament"] == "Generic PLA @base"
+        assert ctx["filaments"] == "Generic PLA @base"
+
+    def test_filament_multiple(self, tmp_path):
+        cfg = _make_config(tmp_path, filaments=["Generic PLA @base", "Generic PETG @base"])
+        ctx = build_command_context(cfg, tmp_path / "out", {})
+        assert ctx["filament"] == "Generic PLA @base"
+        assert ctx["filaments"] == "Generic PLA @base,Generic PETG @base"
+
+    def test_filament_empty_when_unset(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        ctx = build_command_context(cfg, tmp_path / "out", {})
+        assert ctx["filament"] == ""
+        assert ctx["filaments"] == ""
+
+    def test_filament_from_cura_engine(self, tmp_path):
+        cfg = _make_config(tmp_path, engine="cura", filaments=["PLA"])
+        ctx = build_command_context(cfg, tmp_path / "out", {})
+        assert ctx["filament"] == "PLA"
+
 
 # ---------------------------------------------------------------------------
 # parse_command_stage
@@ -357,6 +380,8 @@ def _make_config(
     tmp_path: Path,
     name: str | None = None,
     printer: str | None = None,
+    filaments: list[str] | None = None,
+    engine: str = "orca",
 ) -> EstampoConfig:
     """Create a minimal EstampoConfig for testing."""
     stl = tmp_path / "cube.stl"
@@ -365,8 +390,9 @@ def _make_config(
     return EstampoConfig(
         plate=PlateConfig(),
         slicer=SlicerConfig(
-            orca=OrcaSlicerConfig(printer=printer),
-            cura=CuraSlicerConfig(),
+            engine=engine,
+            orca=OrcaSlicerConfig(printer=printer, filaments=filaments or []),
+            cura=CuraSlicerConfig(filaments=filaments or []),
         ),
         parts=[PartConfig(file=stl)],
         base_dir=tmp_path,


### PR DESCRIPTION
## Summary
- Add `{filament}` variable: first filament profile name from slicer config
- Add `{filaments}` variable: all filament profiles, comma-separated
- Sourced from the active engine's filaments list (works for both orca and cura)

Example usage:
```toml
[pack]
command = "bambox pack {sliced_dir}/plate.gcode -f {filament} -o {output_dir}/{name}.gcode.3mf"
```

Closes #398

## Test plan
- [x] `test_filament_single` — single filament populates both variables
- [x] `test_filament_multiple` — multi-filament comma-separates in `{filaments}`
- [x] `test_filament_empty_when_unset` — empty string when no filaments configured
- [x] `test_filament_from_cura_engine` — works with cura engine config
- [x] Full suite: 532 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)