### PR TITLE
Include towncrier fragments in auto-generated profile PRs

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -187,6 +187,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
+          echo "Update bundled OrcaSlicer ${{ matrix.orca_version }} profiles" > changes/+update-orca-profiles.misc
+          git add changes/
           git commit -m "Update bundled OrcaSlicer profiles (${{ matrix.orca_version }})"
           git push --force origin "$BRANCH"
           gh pr create \
@@ -388,6 +390,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
+          echo "Update bundled CuraEngine ${{ matrix.cura_version }} definitions" > changes/+update-cura-definitions.misc
+          git add changes/
           git commit -m "Update bundled CuraEngine definitions (${{ matrix.cura_version }})"
           git push --force origin "$BRANCH"
           gh pr create \

--- a/changes/+profile-pr-changelog.bugfix
+++ b/changes/+profile-pr-changelog.bugfix
@@ -1,0 +1,1 @@
+Include towncrier changelog fragments in auto-generated profile update PRs


### PR DESCRIPTION
## Summary
- Add orphan towncrier fragments (`changes/+update-orca-profiles.misc`, `changes/+update-cura-definitions.misc`) to the auto-generated profile update commits in `release-readiness.yml`
- Fixes the CI `changelog` check failing on bot-created profile PRs like #432

Closes #437

## Test plan
- [ ] CI passes
- [ ] Next profile extraction run creates a PR with a changelog fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)