### PR TITLE
Define SlicerEngine protocol (ADR-006)

### DIFF
--- a/changes/+slicer-engine-protocol.feature
+++ b/changes/+slicer-engine-protocol.feature
@@ -1,0 +1,1 @@
+Add ``SlicerEngine`` protocol in ``engine.py`` formalizing the contract every slicer module must implement

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -15,6 +15,7 @@ import logging
 import re
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -23,8 +24,43 @@ from estampo.constants import DEFAULT_PLATE_SIZE
 
 log = logging.getLogger(__name__)
 
+ENGINE_NAME = "CuraEngine"
+ENGINE_KEY = "cura"
+
 DOCKERHUB_REPO = "estampo/estampo"
 CURAENGINE_VERSION = "5.12.0"
+
+
+# ---------------------------------------------------------------------------
+# Binary discovery
+# ---------------------------------------------------------------------------
+
+
+def _default_binary_path() -> Path:
+    """Return the platform-specific default path for CuraEngine."""
+    if sys.platform == "darwin":
+        return Path("/Applications/UltiMaker Cura.app/Contents/MacOS/CuraEngine")
+    elif sys.platform == "win32":
+        return Path("C:/Program Files/UltiMaker Cura/CuraEngine.exe")
+    return Path("/usr/local/bin/CuraEngine")
+
+
+def find_binary() -> Path:
+    """Locate the CuraEngine executable on this system.
+
+    Raises ``FileNotFoundError`` if not found.
+    """
+    path = _default_binary_path()
+    if path.exists():
+        return path
+
+    for name in ("CuraEngine", "curaengine"):
+        found = shutil.which(name)
+        if found:
+            return Path(found)
+
+    raise FileNotFoundError(f"CuraEngine not found at {path} or on PATH. Is it installed?")
+
 
 # Definitions directory inside the Docker image (fdmprinter.def.json etc.)
 _DEFS_DIR = "/opt/cura/definitions"
@@ -305,6 +341,9 @@ def cura_docker_image(version: str | None = None) -> str:
     if version:
         return f"{DOCKERHUB_REPO}:cura-{version}"
     return f"{DOCKERHUB_REPO}:cura-{CURAENGINE_VERSION}"
+
+
+docker_image = cura_docker_image
 
 
 # ---------------------------------------------------------------------------

--- a/src/estampo/engine.py
+++ b/src/estampo/engine.py
@@ -1,0 +1,89 @@
+"""Slicer engine protocol — the contract every engine module must implement.
+
+See docs/decisions/006-slicer-plugin-protocol.md for the full specification.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SlicerEngine(Protocol):
+    """Protocol that every slicer engine module must satisfy.
+
+    Engine modules (``orca.py``, ``cura.py``, …) are plain Python modules,
+    not classes.  This Protocol exists so that:
+
+    1. Static type checkers can verify dispatch layers call the right signatures.
+    2. Tests can assert that an engine module conforms at import time.
+    3. New engine authors have a single source of truth for what to implement.
+
+    Functions not yet needed by an engine should raise ``NotImplementedError``.
+    """
+
+    ENGINE_NAME: str
+    ENGINE_KEY: str
+
+    @staticmethod
+    def find_binary() -> Path:
+        """Locate the slicer executable on this system.
+
+        Raises ``FileNotFoundError`` if not found.
+        """
+        ...
+
+    @staticmethod
+    def docker_image(version: str | None = None) -> str:
+        """Return the Docker image tag for this engine and version.
+
+        Must use the ``estampo/estampo:<key>-<version>`` format.
+        """
+        ...
+
+    @staticmethod
+    def discover_profiles(
+        project_dir: Path,
+        profiles_dir: str,
+    ) -> dict[str, list[str]]:
+        """Return available profile/definition names by category."""
+        ...
+
+    @staticmethod
+    def load_profile(
+        name: str,
+        category: str,
+        project_dir: Path,
+        profiles_dir: str,
+        version: str | None = None,
+    ) -> dict[str, Any]:
+        """Load a profile/definition by name and category."""
+        ...
+
+    @staticmethod
+    def pin_profiles(
+        project_dir: Path,
+        profiles_dir: str,
+        version: str | None = None,
+    ) -> list[Path]:
+        """Pin profiles/definitions for reproducible builds."""
+        ...
+
+    @staticmethod
+    def bundled_profile_names(version: str | None = None) -> dict[str, list[str]]:
+        """Return profile/definition names from bundled data files."""
+        ...
+
+    @staticmethod
+    def wizard_steps(
+        console: Any,
+        existing_config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Run engine-specific init wizard steps."""
+        ...
+
+    @staticmethod
+    def emit_toml(config_values: dict[str, Any]) -> list[str]:
+        """Emit the ``[slicer.<key>]`` TOML section lines for this engine."""
+        ...

--- a/src/estampo/orca.py
+++ b/src/estampo/orca.py
@@ -24,6 +24,38 @@ log = logging.getLogger(__name__)
 ENGINE_NAME = "OrcaSlicer"
 ENGINE_KEY = "orca"
 
+
+# ---------------------------------------------------------------------------
+# Binary discovery
+# ---------------------------------------------------------------------------
+
+
+def _default_binary_path() -> Path:
+    """Return the platform-specific default path for OrcaSlicer."""
+    if sys.platform == "darwin":
+        return Path("/Applications/OrcaSlicer.app/Contents/MacOS/OrcaSlicer")
+    elif sys.platform == "win32":
+        return Path("C:/Program Files/OrcaSlicer/orca-slicer.exe")
+    return Path("/usr/bin/orca-slicer")
+
+
+def find_binary() -> Path:
+    """Locate the OrcaSlicer executable on this system.
+
+    Raises ``FileNotFoundError`` if not found.
+    """
+    path = _default_binary_path()
+    if path.exists():
+        return path
+
+    for name in ("orca-slicer", "OrcaSlicer", "OrcaSlicer.AppImage"):
+        found = shutil.which(name)
+        if found:
+            return Path(found)
+
+    raise FileNotFoundError(f"OrcaSlicer not found at {path} or on PATH. Is it installed?")
+
+
 # ---------------------------------------------------------------------------
 # Docker image naming
 # ---------------------------------------------------------------------------
@@ -766,12 +798,9 @@ def _detect_orca_version() -> str | None:
     if skip_detect:
         return None
     try:
-        from estampo.slicer import SLICER_PATHS
-
-        slicer = SLICER_PATHS.get("orca")
-        if slicer and slicer.exists():
-            return _detect_slicer_version(slicer)
-    except (OSError, ImportError):
+        slicer = find_binary()
+        return _detect_slicer_version(slicer)
+    except (FileNotFoundError, OSError):
         log.debug("Failed to detect OrcaSlicer version", exc_info=True)
     return None
 

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import logging
-import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 from estampo.gcode import parse_gcode_metadata
@@ -29,53 +27,22 @@ log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _slicer_paths() -> dict[str, Path]:
-    """Return default slicer executable paths for the current platform."""
-    if sys.platform == "darwin":
-        return {
-            "orca": Path("/Applications/OrcaSlicer.app/Contents/MacOS/OrcaSlicer"),
-            "cura": Path("/Applications/UltiMaker Cura.app/Contents/MacOS/CuraEngine"),
-        }
-    elif sys.platform == "win32":
-        pf = Path("C:/Program Files")
-        return {
-            "orca": pf / "OrcaSlicer/orca-slicer.exe",
-            "cura": pf / "UltiMaker Cura/CuraEngine.exe",
-        }
-    else:  # Linux and other Unix
-        return {
-            "orca": Path("/usr/bin/orca-slicer"),
-            "cura": Path("/usr/local/bin/CuraEngine"),
-        }
+def _get_engine_module(engine: str):  # noqa: ANN202
+    """Return the engine module for the given engine key."""
+    from estampo import cura, orca
 
-
-SLICER_PATHS = _slicer_paths()
+    engines = {"orca": orca, "cura": cura}
+    if engine not in engines:
+        raise ValueError(f"Unknown slicer engine: '{engine}'. Supported: {list(engines)}")
+    return engines[engine]
 
 
 def find_slicer(engine: str) -> Path:
     """Find the slicer executable for the given engine.
 
-    Checks the platform-specific default path first, then falls back
-    to searching PATH (useful on Linux or custom installs).
+    Delegates to the engine module's ``find_binary()`` function.
     """
-    if engine not in SLICER_PATHS:
-        raise ValueError(f"Unknown slicer engine: '{engine}'. Supported: {list(SLICER_PATHS)}")
-
-    path = SLICER_PATHS[engine]
-    if path.exists():
-        return path
-
-    # Fall back to PATH lookup (handles AppImage, Flatpak, AUR, custom installs)
-    path_names = {
-        "orca": ("orca-slicer", "OrcaSlicer", "OrcaSlicer.AppImage"),
-        "cura": ("CuraEngine", "curaengine"),
-    }
-    for name in path_names.get(engine, ()):
-        found = shutil.which(name)
-        if found:
-            return Path(found)
-
-    raise FileNotFoundError(f"Slicer ({engine}) not found at {path} or on PATH. Is it installed?")
+    return _get_engine_module(engine).find_binary()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engine_protocol.py
+++ b/tests/test_engine_protocol.py
@@ -1,0 +1,44 @@
+"""Tests for the SlicerEngine protocol conformance."""
+
+from estampo import cura, orca
+
+
+def _check_protocol_attrs(module: object) -> list[str]:
+    """Return protocol attribute names missing from the module."""
+    required = [
+        "ENGINE_NAME",
+        "ENGINE_KEY",
+        "find_binary",
+        "docker_image",
+    ]
+    return [name for name in required if not hasattr(module, name)]
+
+
+def test_orca_has_constants():
+    assert orca.ENGINE_NAME == "OrcaSlicer"
+    assert orca.ENGINE_KEY == "orca"
+
+
+def test_cura_has_constants():
+    assert cura.ENGINE_NAME == "CuraEngine"
+    assert cura.ENGINE_KEY == "cura"
+
+
+def test_orca_has_protocol_attrs():
+    missing = _check_protocol_attrs(orca)
+    assert missing == [], f"orca.py missing: {missing}"
+
+
+def test_cura_has_protocol_attrs():
+    missing = _check_protocol_attrs(cura)
+    assert missing == [], f"cura.py missing: {missing}"
+
+
+def test_orca_docker_image():
+    assert orca.docker_image("2.3.1") == "estampo/estampo:orca-2.3.1"
+    assert orca.docker_image() == "estampo/estampo:latest"
+
+
+def test_cura_docker_image():
+    assert cura.cura_docker_image("5.12.0") == "estampo/estampo:cura-5.12.0"
+    assert "cura-" in cura.cura_docker_image()

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -7,7 +7,6 @@ import pytest
 
 from estampo import EstampoError
 from estampo.slicer import (
-    SLICER_PATHS,
     _apply_overrides,
     _ensure_docker_image,
     _has_docker_image,
@@ -23,9 +22,11 @@ from estampo.slicer import (
 
 
 def test_find_orca():
-    if not SLICER_PATHS["orca"].exists():
+    from estampo.orca import _default_binary_path
+
+    if not _default_binary_path().exists():
         pytest.skip("OrcaSlicer not installed")
-    assert find_slicer("orca") == SLICER_PATHS["orca"]
+    assert find_slicer("orca") == _default_binary_path()
 
 
 def test_find_unknown():
@@ -35,16 +36,16 @@ def test_find_unknown():
 
 def test_find_slicer_path_fallback():
     """Falls back to shutil.which when default path doesn't exist."""
-    with patch.dict("estampo.slicer.SLICER_PATHS", {"orca": Path("/nonexistent/orca")}):
-        with patch("estampo.slicer.shutil.which", return_value="/usr/local/bin/orca-slicer"):
+    with patch("estampo.orca._default_binary_path", return_value=Path("/nonexistent/orca")):
+        with patch("estampo.orca.shutil.which", return_value="/usr/local/bin/orca-slicer"):
             result = find_slicer("orca")
             assert result == Path("/usr/local/bin/orca-slicer")
 
 
 def test_find_slicer_not_found():
     """Raises FileNotFoundError when slicer not at default path or on PATH."""
-    with patch.dict("estampo.slicer.SLICER_PATHS", {"orca": Path("/nonexistent/orca")}):
-        with patch("estampo.slicer.shutil.which", return_value=None):
+    with patch("estampo.orca._default_binary_path", return_value=Path("/nonexistent/orca")):
+        with patch("estampo.orca.shutil.which", return_value=None):
             with pytest.raises(FileNotFoundError, match="not found"):
                 find_slicer("orca")
 


### PR DESCRIPTION
## Summary

- Adds `engine.py` with a `typing.Protocol` class (`SlicerEngine`) that formalizes the contract from ADR-006
- Adds `ENGINE_NAME` / `ENGINE_KEY` constants to `cura.py` (already existed in `orca.py`)
- Implements `find_binary()` in both `orca.py` and `cura.py`, replacing the monolithic `_slicer_paths()` / `SLICER_PATHS` dict in `slicer.py`
- Updates `slicer.py` dispatch to delegate `find_slicer()` to engine modules via `_get_engine_module()`
- Adds `docker_image` alias in `cura.py` (protocol-standard name alongside existing `cura_docker_image`)
- New `test_engine_protocol.py` with conformance tests for both engines

Closes #440

## Test plan

- [x] `ruff check` — zero errors
- [x] `ruff format --check` — all files formatted
- [x] `mypy src/estampo` — zero errors
- [x] `pytest` — 538 passed, 9 skipped
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)