### PR TITLE
Extract shared Docker logic into docker.py

### DIFF
--- a/changes/+shared-docker-logic.misc
+++ b/changes/+shared-docker-logic.misc
@@ -1,0 +1,1 @@
+Extract shared Docker utilities into ``docker.py`` module, removing duplication from engine modules

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -414,56 +414,17 @@ def extract_cura_docker_defs(
     Returns a Path to a temporary directory containing ``*.def.json`` files.
     The caller is responsible for cleanup.
     """
-    import tempfile
+    from estampo.docker import extract_files
 
     if not image:
         image = cura_docker_image(version)
 
-    from estampo.slicer import _ensure_docker_image
-
-    if not _ensure_docker_image(image):
-        raise EstampoError(f"Docker image {image} is not available and could not be pulled.")
-
-    from estampo import ui
-
-    tmp_dir = Path(tempfile.mkdtemp(prefix="estampo_cura_defs_"))
-    container_id = None
-    try:
-        with ui.status("Extracting CuraEngine definitions from Docker image"):
-            result = subprocess.run(
-                ["docker", "create", "--platform", "linux/amd64", image, "true"],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if result.returncode != 0:
-                raise EstampoError(f"docker create failed: {result.stderr.strip()}")
-            container_id = result.stdout.strip()
-
-            cp_result = subprocess.run(
-                [
-                    "docker",
-                    "cp",
-                    f"{container_id}:{_DEFS_DIR}/.",
-                    str(tmp_dir),
-                ],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-            if cp_result.returncode != 0:
-                raise EstampoError(
-                    f"Failed to copy definitions from Docker: {cp_result.stderr.strip()}"
-                )
-    finally:
-        if container_id:
-            subprocess.run(
-                ["docker", "rm", "-f", container_id],
-                capture_output=True,
-                timeout=15,
-            )
-
-    return tmp_dir
+    return extract_files(
+        image,
+        _DEFS_DIR,
+        tmp_prefix="estampo_cura_defs_",
+        status_label="Extracting CuraEngine definitions from Docker image",
+    )
 
 
 def _squash_cura_def(def_id: str, defs_dir: Path) -> dict:

--- a/src/estampo/docker.py
+++ b/src/estampo/docker.py
@@ -1,0 +1,141 @@
+"""Shared Docker utilities for slicer engine modules."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from estampo import EstampoError
+
+log = logging.getLogger(__name__)
+
+
+def has_image(image: str) -> bool:
+    """Check if the given Docker image exists locally."""
+    try:
+        r = subprocess.run(
+            ["docker", "image", "inspect", image],
+            capture_output=True,
+            timeout=10,
+        )
+        return r.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def pull_image(image: str, *, cached: bool) -> bool:
+    """Pull a Docker image from the registry. Returns True on success."""
+    from estampo import ui
+
+    label = "Checking for updated image" if cached else "Pulling Docker image"
+    log.info("Pulling Docker image %s ...", image)
+    try:
+        with ui.status(f"{label} [bold]{image}[/bold]"):
+            r = subprocess.run(
+                ["docker", "pull", image],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        if r.returncode == 0:
+            return True
+        log.debug("docker pull failed: %s", r.stderr.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return False
+
+
+def ensure_image(image: str) -> bool:
+    """Ensure an up-to-date Docker image is available locally.
+
+    Always attempts a pull so that image updates are picked up
+    automatically.  If the pull fails (no network, registry down)
+    the locally cached image is used instead.  Returns False only
+    when no usable image is available at all.
+    """
+    cached = has_image(image)
+    if pull_image(image, cached=cached):
+        return True
+    if cached:
+        log.warning("Could not pull %s — using locally cached image", image)
+        return True
+    return False
+
+
+@contextmanager
+def stopped_container(image: str) -> Iterator[str]:
+    """Create a stopped Docker container and yield its ID.
+
+    The container is removed when the context exits (even on error).
+    """
+    result = subprocess.run(
+        ["docker", "create", "--platform", "linux/amd64", image, "true"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise EstampoError(f"docker create failed: {result.stderr.strip()}")
+    container_id = result.stdout.strip()
+    try:
+        yield container_id
+    finally:
+        subprocess.run(
+            ["docker", "rm", "-f", container_id],
+            capture_output=True,
+            timeout=15,
+        )
+
+
+def copy_from_container(
+    container_id: str,
+    src: str,
+    dest: Path,
+    *,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``docker cp`` from a container path to a local directory."""
+    return subprocess.run(
+        ["docker", "cp", f"{container_id}:{src}", str(dest)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def extract_files(
+    image: str,
+    container_path: str,
+    *,
+    tmp_prefix: str = "estampo_",
+    status_label: str = "Extracting files from Docker image",
+) -> Path:
+    """Extract files from a Docker image to a temp directory.
+
+    Uses ``docker create`` + ``docker cp`` + ``docker rm`` — the
+    container is never started.  Returns a temp directory whose
+    cleanup is the caller's responsibility.
+    """
+    if not ensure_image(image):
+        raise EstampoError(f"Docker image {image} is not available and could not be pulled.")
+
+    from estampo import ui
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix=tmp_prefix))
+
+    with ui.status(status_label):
+        with stopped_container(image) as container_id:
+            cp = copy_from_container(
+                container_id,
+                f"{container_path}/.",
+                tmp_dir,
+                timeout=60,
+            )
+            if cp.returncode != 0:
+                raise EstampoError(f"Failed to copy files from Docker: {cp.stderr.strip()}")
+
+    return tmp_dir

--- a/src/estampo/orca.py
+++ b/src/estampo/orca.py
@@ -380,8 +380,9 @@ def orca_slice_plate(
 
     Returns the output directory containing the sliced gcode.
     """
+    from estampo.docker import ensure_image as _ensure_docker_image
     from estampo.profiles import pinned_profiles_version
-    from estampo.slicer import _ensure_docker_image, find_slicer
+    from estampo.slicer import find_slicer
 
     # If config specifies a version and no explicit docker_version was given,
     # use it as the docker_version for Docker-based slicing.
@@ -620,53 +621,31 @@ def extract_docker_profiles(
     ``<tmpdir>/{machine,process,filament}/*.json``.
     The caller is responsible for cleanup.
     """
+    from estampo import docker, ui
+
     if not image:
         image = docker_image(version)
 
-    from estampo.slicer import _ensure_docker_image
-
-    if not _ensure_docker_image(image):
+    if not docker.ensure_image(image):
         raise EstampoError(
             f"Docker image {image} is not available and could not be pulled. "
             "Check your Docker setup or install the slicer locally."
         )
 
-    from estampo import ui
-
     tmp_dir = Path(tempfile.mkdtemp(prefix="estampo_profiles_"))
-    container_id = None
-    try:
-        with ui.status("Extracting profiles from Docker image"):
-            # Create a stopped container (does not start it)
-            result = subprocess.run(
-                ["docker", "create", "--platform", "linux/amd64", image, "true"],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if result.returncode != 0:
-                raise EstampoError(f"docker create failed: {result.stderr.strip()}")
-            container_id = result.stdout.strip()
 
-            # Copy the entire BBL profile tree (includes root-level base profiles
-            # that category profiles may inherit from).
-            # docker cp copies directory contents into the destination, so
-            # the result is bbl_dest/{machine,process,filament,...}
+    with ui.status("Extracting profiles from Docker image"):
+        with docker.stopped_container(image) as container_id:
             bbl_dest = tmp_dir / "_bbl"
-            cp_result = subprocess.run(
-                ["docker", "cp", f"{container_id}:{_DOCKER_PROFILE_ROOT}/.", str(bbl_dest)],
-                capture_output=True,
-                text=True,
-                timeout=30,
+            cp_result = docker.copy_from_container(
+                container_id, f"{_DOCKER_PROFILE_ROOT}/.", bbl_dest
             )
             if cp_result.returncode == 0 and bbl_dest.is_dir():
-                # Move category dirs up to tmp_dir for backwards compatibility
                 for category in CATEGORIES:
                     src_cat = bbl_dest / category
                     dest_cat = tmp_dir / category
                     if src_cat.is_dir():
                         src_cat.rename(dest_cat)
-                # Move any remaining files/dirs (root-level base profiles, common/, etc.)
                 for item in list(bbl_dest.iterdir()):
                     item.rename(tmp_dir / item.name)
                 if not any(bbl_dest.iterdir()):
@@ -677,25 +656,17 @@ def extract_docker_profiles(
                     cp_result.stderr.strip(),
                 )
                 for category in CATEGORIES:
-                    src = f"{container_id}:{_DOCKER_PROFILE_ROOT}/{category}"
-                    dest = tmp_dir / category
-                    cat_result = subprocess.run(
-                        ["docker", "cp", src, str(dest)],
-                        capture_output=True,
-                        text=True,
-                        timeout=30,
+                    cat_result = docker.copy_from_container(
+                        container_id,
+                        f"{_DOCKER_PROFILE_ROOT}/{category}",
+                        tmp_dir / category,
                     )
                     if cat_result.returncode != 0:
-                        log.debug("docker cp %s failed: %s", category, cat_result.stderr.strip())
-
-    finally:
-        # Clean up the container
-        if container_id:
-            subprocess.run(
-                ["docker", "rm", container_id],
-                capture_output=True,
-                timeout=10,
-            )
+                        log.debug(
+                            "docker cp %s failed: %s",
+                            category,
+                            cat_result.stderr.strip(),
+                        )
 
     return tmp_dir
 

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import subprocess
 from pathlib import Path
 
 from estampo.gcode import parse_gcode_metadata
@@ -43,64 +42,6 @@ def find_slicer(engine: str) -> Path:
     Delegates to the engine module's ``find_binary()`` function.
     """
     return _get_engine_module(engine).find_binary()
-
-
-# ---------------------------------------------------------------------------
-# Shared Docker utilities (used by both orca and cura engines)
-# ---------------------------------------------------------------------------
-
-
-def _has_docker_image(image: str) -> bool:
-    """Check if the given Docker image exists locally."""
-    try:
-        r = subprocess.run(
-            ["docker", "image", "inspect", image],
-            capture_output=True,
-            timeout=10,
-        )
-        return r.returncode == 0
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return False
-
-
-def _pull_docker_image(image: str, *, cached: bool) -> bool:
-    """Pull a Docker image from the registry. Returns True on success."""
-    from estampo import ui
-
-    label = "Checking for updated image" if cached else "Pulling Docker image"
-    log.info("Pulling Docker image %s ...", image)
-    try:
-        with ui.status(f"{label} [bold]{image}[/bold]"):
-            r = subprocess.run(
-                ["docker", "pull", image],
-                capture_output=True,
-                text=True,
-                timeout=300,
-            )
-        if r.returncode == 0:
-            return True
-        log.debug("docker pull failed: %s", r.stderr.strip())
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
-    return False
-
-
-def _ensure_docker_image(image: str) -> bool:
-    """Ensure an up-to-date Docker image is available locally.
-
-    Always attempts a pull so that image updates are picked up
-    automatically.  If the pull fails (no network, registry down)
-    the locally cached image is used instead.  Returns False only
-    when no usable image is available at all.
-    """
-    cached = _has_docker_image(image)
-    if _pull_docker_image(image, cached=cached):
-        return True
-    # Pull failed — fall back to local cache if available
-    if cached:
-        log.warning("Could not pull %s — using locally cached image", image)
-        return True
-    return False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -6,10 +6,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from estampo import EstampoError
+from estampo.docker import ensure_image, has_image
 from estampo.slicer import (
     _apply_overrides,
-    _ensure_docker_image,
-    _has_docker_image,
     _resolve_profiles,
     _slice_via_docker,
     docker_image,
@@ -244,8 +243,8 @@ def test_docker_image_tag_consistency():
 
 def test_has_docker_image_true():
     mock_result = MagicMock(returncode=0)
-    with patch("estampo.slicer.subprocess.run", return_value=mock_result) as mock_run:
-        assert _has_docker_image("estampo:orca-2.3.1") is True
+    with patch("estampo.docker.subprocess.run", return_value=mock_result) as mock_run:
+        assert has_image("estampo:orca-2.3.1") is True
         mock_run.assert_called_once_with(
             ["docker", "image", "inspect", "estampo:orca-2.3.1"],
             capture_output=True,
@@ -255,13 +254,13 @@ def test_has_docker_image_true():
 
 def test_has_docker_image_false_no_image():
     mock_result = MagicMock(returncode=1)
-    with patch("estampo.slicer.subprocess.run", return_value=mock_result):
-        assert _has_docker_image("estampo:orca-2.3.1") is False
+    with patch("estampo.docker.subprocess.run", return_value=mock_result):
+        assert has_image("estampo:orca-2.3.1") is False
 
 
 def test_has_docker_image_false_no_docker():
-    with patch("estampo.slicer.subprocess.run", side_effect=FileNotFoundError):
-        assert _has_docker_image("estampo:orca-2.3.1") is False
+    with patch("estampo.docker.subprocess.run", side_effect=FileNotFoundError):
+        assert has_image("estampo:orca-2.3.1") is False
 
 
 # --- _ensure_docker_image ---
@@ -270,29 +269,29 @@ def test_has_docker_image_false_no_docker():
 def test_ensure_docker_image_pulls_even_when_cached():
     """Always pulls to pick up updates, even when image is cached locally."""
     with (
-        patch("estampo.slicer._has_docker_image", return_value=True),
-        patch("estampo.slicer._pull_docker_image", return_value=True) as mock_pull,
+        patch("estampo.docker.has_image", return_value=True),
+        patch("estampo.docker.pull_image", return_value=True) as mock_pull,
     ):
-        assert _ensure_docker_image("estampo:orca-2.3.1") is True
+        assert ensure_image("estampo:orca-2.3.1") is True
     mock_pull.assert_called_once_with("estampo:orca-2.3.1", cached=True)
 
 
 def test_ensure_docker_image_falls_back_to_cache_on_pull_failure():
     """Uses cached image when pull fails (offline, registry down)."""
     with (
-        patch("estampo.slicer._has_docker_image", return_value=True),
-        patch("estampo.slicer._pull_docker_image", return_value=False),
+        patch("estampo.docker.has_image", return_value=True),
+        patch("estampo.docker.pull_image", return_value=False),
     ):
-        assert _ensure_docker_image("estampo:orca-2.3.1") is True
+        assert ensure_image("estampo:orca-2.3.1") is True
 
 
 def test_ensure_docker_image_fails_when_no_cache_and_pull_fails():
     """Returns False when no cached image and pull fails."""
     with (
-        patch("estampo.slicer._has_docker_image", return_value=False),
-        patch("estampo.slicer._pull_docker_image", return_value=False),
+        patch("estampo.docker.has_image", return_value=False),
+        patch("estampo.docker.pull_image", return_value=False),
     ):
-        assert _ensure_docker_image("estampo:orca-2.3.1") is False
+        assert ensure_image("estampo:orca-2.3.1") is False
 
 
 # --- _slice_via_docker ---
@@ -500,7 +499,7 @@ def test_slice_plate_local_fallback(tmp_path):
     slicer_path = Path("/usr/bin/orca-slicer")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=False),
+        patch("estampo.docker.ensure_image", return_value=False),
         patch("estampo.slicer.find_slicer", return_value=slicer_path),
         patch("estampo.profiles.resolve_profile_data", side_effect=_mock_resolve),
         patch("estampo.orca.subprocess.run", return_value=mock_result) as mock_run,
@@ -525,7 +524,7 @@ def test_slice_plate_docker_default(tmp_path):
     mock_result = MagicMock(returncode=0, stdout="", stderr="")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=True),
+        patch("estampo.docker.ensure_image", return_value=True),
         patch("estampo.profiles.resolve_profile_data", side_effect=_mock_resolve),
         patch("estampo.orca.subprocess.run", return_value=mock_result) as mock_run,
     ):
@@ -550,7 +549,7 @@ def test_slice_plate_docker_version(tmp_path):
     mock_result = MagicMock(returncode=0, stdout="", stderr="")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=True),
+        patch("estampo.docker.ensure_image", return_value=True),
         patch("estampo.profiles.resolve_profile_data", side_effect=_mock_resolve),
         patch("estampo.orca.subprocess.run", return_value=mock_result) as mock_run,
     ):
@@ -573,7 +572,7 @@ def test_slice_plate_docker_image_missing_no_local(tmp_path):
     input_3mf.write_text("fake")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=False),
+        patch("estampo.docker.ensure_image", return_value=False),
         patch("estampo.slicer.find_slicer", side_effect=FileNotFoundError("not found")),
     ):
         with pytest.raises(FileNotFoundError, match="Docker image.*not found"):
@@ -594,7 +593,7 @@ def test_slice_plate_docker_fallback_to_local(tmp_path):
     slicer_path = Path("/usr/bin/orca-slicer")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=False),
+        patch("estampo.docker.ensure_image", return_value=False),
         patch("estampo.slicer.find_slicer", return_value=slicer_path),
         patch("estampo.profiles.resolve_profile_data", side_effect=_mock_resolve),
         patch("estampo.orca.subprocess.run", return_value=mock_result) as mock_run,
@@ -623,7 +622,7 @@ def test_slice_plate_allow_mix_temp_on_232(tmp_path):
     mock_result = MagicMock(returncode=0, stdout="", stderr="")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=True),
+        patch("estampo.docker.ensure_image", return_value=True),
         patch("estampo.profiles.resolve_profile_data", side_effect=_mock_resolve),
         patch("estampo.orca.subprocess.run", return_value=mock_result) as mock_run,
     ):
@@ -649,7 +648,7 @@ def test_slice_plate_no_allow_mix_temp_on_231(tmp_path):
     mock_result = MagicMock(returncode=0, stdout="", stderr="")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=True),
+        patch("estampo.docker.ensure_image", return_value=True),
         patch("estampo.profiles.resolve_profile_data", side_effect=_mock_resolve),
         patch("estampo.orca.subprocess.run", return_value=mock_result) as mock_run,
     ):
@@ -675,7 +674,7 @@ def test_slice_plate_allow_mix_temp_single_filament_232(tmp_path):
     mock_result = MagicMock(returncode=0, stdout="", stderr="")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=True),
+        patch("estampo.docker.ensure_image", return_value=True),
         patch("estampo.profiles.resolve_profile_data", side_effect=_mock_resolve),
         patch("estampo.orca.subprocess.run", return_value=mock_result) as mock_run,
     ):
@@ -706,7 +705,7 @@ def test_slice_plate_errors_on_stale_pinned_profiles_no_marker(tmp_path):
     (profiles / "Printer.json").write_text('{"name": "Printer"}')
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=True),
+        patch("estampo.docker.ensure_image", return_value=True),
         pytest.raises(EstampoError, match="no version marker"),
     ):
         slice_plate(
@@ -730,7 +729,7 @@ def test_slice_plate_errors_on_version_mismatch(tmp_path):
     (tmp_path / "profiles" / "orca" / ".slicer-version").write_text("2.3.1\n")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=True),
+        patch("estampo.docker.ensure_image", return_value=True),
         pytest.raises(EstampoError, match="created for slicer 2.3.1"),
     ):
         slice_plate(
@@ -755,7 +754,7 @@ def test_slice_plate_ok_with_matching_version(tmp_path):
     (tmp_path / "profiles" / "orca" / ".slicer-version").write_text("2.3.2\n")
 
     with (
-        patch("estampo.slicer._ensure_docker_image", return_value=True),
+        patch("estampo.docker.ensure_image", return_value=True),
         patch("estampo.orca._slice_via_docker", return_value=output_dir) as mock_docker,
         patch("estampo.orca.extract_docker_profiles", return_value=tmp_path / "docker"),
     ):


### PR DESCRIPTION
## Summary

- New `src/estampo/docker.py` module with shared Docker primitives:
  - `has_image()`, `pull_image()`, `ensure_image()` — moved from `slicer.py`
  - `stopped_container()` — context manager for create+rm lifecycle
  - `copy_from_container()` — thin wrapper around `docker cp`
  - `extract_files()` — convenience for the common create+cp+rm pattern
- `cura.extract_cura_docker_defs()` now uses `docker.extract_files()` (was ~30 lines of boilerplate, now 5)
- `orca.extract_docker_profiles()` uses `docker.stopped_container()` + `docker.copy_from_container()` (keeps its fallback per-category copy logic)
- `slicer.py` no longer contains Docker utilities — closer to pure dispatch per ADR-006
- Tests updated to patch `estampo.docker` instead of `estampo.slicer`

Closes #441

## Test plan

- [x] `ruff check` — zero errors
- [x] `ruff format --check` — all files formatted
- [x] `mypy src/estampo` — zero errors
- [x] `pytest` — 538 passed, 9 skipped
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)