### PR TITLE
Fix pin_cura_definitions() to copy extruder definitions

### DIFF
--- a/changes/455.bugfix
+++ b/changes/455.bugfix
@@ -1,0 +1,1 @@
+Fix ``pin_cura_definitions()`` to also copy extruder definitions referenced by the machine definition

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -515,13 +515,25 @@ def pin_cura_definitions(
             json.dump(squashed, fh, indent=4)
         log.info("Pinned CuraEngine definition %s → %s (squashed)", printer, dest)
 
+        # Pin extruder definitions referenced by the machine def
+        pinned = [dest]
+        trains = squashed.get("metadata", {}).get("machine_extruder_trains", {})
+        for extruder_id in trains.values():
+            ext_filename = f"{extruder_id}.def.json"
+            ext_src = defs_dir / ext_filename
+            ext_dest = dest_dir / ext_filename
+            if ext_src.exists() and not ext_dest.exists():
+                shutil.copy2(ext_src, ext_dest)
+                log.info("Pinned extruder definition → %s", ext_dest)
+                pinned.append(ext_dest)
+
         # Write version marker
         if docker_version:
             marker = project_dir / profiles_dir / "cura" / ".slicer-version"
             marker.parent.mkdir(parents=True, exist_ok=True)
             marker.write_text(docker_version + "\n")
 
-        return [dest]
+        return pinned
     finally:
         if cleanup_dir:
             shutil.rmtree(cleanup_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

- `pin_cura_definitions()` now copies extruder definition files referenced by `metadata.machine_extruder_trains` alongside the squashed machine definition
- Fixes CuraEngine failing with `Couldn't find definition file with ID: bambox_p1s_ams_extruder_0` when using pinned custom printer definitions

Closes #455

## Test plan

- [x] `ruff check` — zero errors
- [x] `mypy src/estampo` — zero errors
- [x] `pytest` — 538 passed, 9 skipped
- [ ] CI passes
- [ ] Manual test: slice with bambox_p1s_ams printer definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)