### PR TITLE
Fix profiles pin overwrite prompt on fresh projects

### DIFF
--- a/changes/457.bugfix
+++ b/changes/457.bugfix
@@ -1,0 +1,1 @@
+Fix ``profiles pin`` showing unnecessary overwrite prompt after ``profiles add`` on a fresh project

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -481,10 +481,14 @@ def profiles_pin(
         ui.info(f"Engine '{cfg.slicer.engine}' uses inline settings — no profiles to pin.")
         raise typer.Exit(0)
 
-    # If profiles directory already exists, ask what to do
+    # If pinned output already exists, ask what to do.
+    # Only check engine-specific subdirectories — user-added files in the
+    # top-level profiles dir (e.g. from 'profiles add') should not trigger
+    # the overwrite prompt.
     target = cfg.base_dir / profiles_dir
-    if target.exists() and any(target.iterdir()):
-        ui.warn(f"Profiles directory '{profiles_dir}/' already exists.")
+    engine_subdir = target / cfg.slicer.engine
+    if engine_subdir.exists() and any(engine_subdir.iterdir()):
+        ui.warn(f"Pinned profiles already exist in '{profiles_dir}/{cfg.slicer.engine}/'.")
         choice = input("  [o]verwrite, use [d]ifferent directory, or [c]ancel? ").strip().lower()
         if choice.startswith("d"):
             profiles_dir = input("  New directory name: ").strip()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -618,9 +618,9 @@ def test_profiles_pin_existing_dir_overwrite(mock_load, mock_pin, tmp_path, caps
     """profiles pin should allow overwriting an existing profiles directory."""
     config = tmp_path / "estampo.toml"
     config.write_text("[slicer]\n")
-    # Create existing profiles dir with content
-    (tmp_path / "profiles" / "machine").mkdir(parents=True)
-    (tmp_path / "profiles" / "machine" / "old.json").write_text("{}")
+    # Create existing engine-specific profiles dir with content
+    (tmp_path / "profiles" / "orca").mkdir(parents=True)
+    (tmp_path / "profiles" / "orca" / "old.json").write_text("{}")
     mock_load.return_value = _mock_pin_cfg(tmp_path)
 
     with patch("builtins.input", return_value="o"):
@@ -635,8 +635,8 @@ def test_profiles_pin_existing_dir_cancel(mock_load, mock_pin, tmp_path, capsys)
     """profiles pin should allow cancelling when dir exists."""
     config = tmp_path / "estampo.toml"
     config.write_text("[slicer]\n")
-    (tmp_path / "profiles" / "machine").mkdir(parents=True)
-    (tmp_path / "profiles" / "machine" / "old.json").write_text("{}")
+    (tmp_path / "profiles" / "orca").mkdir(parents=True)
+    (tmp_path / "profiles" / "orca" / "old.json").write_text("{}")
     mock_load.return_value = _mock_pin_cfg(tmp_path)
 
     with patch("builtins.input", return_value="c"):
@@ -651,8 +651,8 @@ def test_profiles_pin_existing_dir_different(mock_load, mock_pin, tmp_path, caps
     """profiles pin should allow choosing a different directory."""
     config = tmp_path / "estampo.toml"
     config.write_text('[slicer]\nengine = "orca"\n')
-    (tmp_path / "profiles" / "machine").mkdir(parents=True)
-    (tmp_path / "profiles" / "machine" / "old.json").write_text("{}")
+    (tmp_path / "profiles" / "orca").mkdir(parents=True)
+    (tmp_path / "profiles" / "orca" / "old.json").write_text("{}")
     mock_load.return_value = _mock_pin_cfg(tmp_path)
 
     with patch("builtins.input", side_effect=["d", "my-profiles"]):
@@ -712,8 +712,8 @@ def test_profiles_pin_empty_dir_name_cancels(mock_load, mock_pin, tmp_path, caps
     """profiles pin should cancel when user enters empty directory name."""
     config = tmp_path / "estampo.toml"
     config.write_text("[slicer]\n")
-    (tmp_path / "profiles" / "machine").mkdir(parents=True)
-    (tmp_path / "profiles" / "machine" / "old.json").write_text("{}")
+    (tmp_path / "profiles" / "orca").mkdir(parents=True)
+    (tmp_path / "profiles" / "orca" / "old.json").write_text("{}")
     mock_load.return_value = _mock_pin_cfg(tmp_path)
 
     with patch("builtins.input", side_effect=["d", ""]):


### PR DESCRIPTION
## Summary

- Check `profiles/{engine}/` instead of `profiles/` for the overwrite prompt, so files from `profiles add` don't falsely trigger it
- Updated 4 tests to create files in the engine-specific subdirectory

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)