### PR TITLE
Fix CuraEngine extruder defs not found at slice time

### DIFF
--- a/changes/459.bugfix
+++ b/changes/459.bugfix
@@ -1,0 +1,1 @@
+Extract CuraEngine extruder definitions from Docker image and copy them automatically on ``profiles add``

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -64,6 +64,8 @@ def find_binary() -> Path:
 
 # Definitions directory inside the Docker image (fdmprinter.def.json etc.)
 _DEFS_DIR = "/opt/cura/definitions"
+# Extruder definitions directory inside the Docker image
+_EXTRUDERS_DIR = "/opt/cura/extruders"
 
 # Bundled definition files shipped with estampo
 _DATA_PKG = "estampo.data"
@@ -394,20 +396,36 @@ def extract_cura_docker_defs(
 ) -> Path:
     """Extract CuraEngine definitions from a Docker image to a temp directory.
 
+    Extracts both machine definitions (``/opt/cura/definitions``) and extruder
+    definitions (``/opt/cura/extruders``) into a single flat directory.
+
     Returns a Path to a temporary directory containing ``*.def.json`` files.
     The caller is responsible for cleanup.
     """
-    from estampo.docker import extract_files
+    import tempfile
+
+    from estampo.docker import copy_from_container, ensure_image, stopped_container
 
     if not image:
         image = cura_docker_image(version)
 
-    return extract_files(
-        image,
-        _DEFS_DIR,
-        tmp_prefix="estampo_cura_defs_",
-        status_label="Extracting CuraEngine definitions from Docker image",
-    )
+    if not ensure_image(image):
+        raise EstampoError(f"Docker image {image} is not available and could not be pulled.")
+
+    from estampo import ui
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="estampo_cura_defs_"))
+
+    with ui.status("Extracting CuraEngine definitions from Docker image"):
+        with stopped_container(image) as container_id:
+            for container_path in (_DEFS_DIR, _EXTRUDERS_DIR):
+                cp = copy_from_container(container_id, f"{container_path}/.", tmp_dir, timeout=60)
+                if cp.returncode != 0:
+                    raise EstampoError(
+                        f"Failed to copy {container_path} from Docker: {cp.stderr.strip()}"
+                    )
+
+    return tmp_dir
 
 
 def _squash_cura_def(def_id: str, defs_dir: Path) -> dict:

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -596,6 +596,26 @@ def add_profile(
     with open(dest, "w") as fh:
         json.dump(data, fh, indent=4)
 
+    # For CuraEngine machine defs, copy referenced extruder definitions
+    # from the same source directory.
+    if (
+        engine == "cura"
+        and is_cura_definition(data)
+        and not source.startswith(("http://", "https://"))
+    ):
+        src_dir = Path(source).parent
+        trains = data.get("metadata", {}).get("machine_extruder_trains", {})
+        for extruder_id in trains.values():
+            ext_filename = f"{extruder_id}.def.json"
+            ext_src = src_dir / ext_filename
+            ext_dest = dest_dir / ext_filename
+            if ext_src.exists() and not ext_dest.exists():
+                with open(ext_src) as f:
+                    ext_data = json.load(f)
+                with open(ext_dest, "w") as fh:
+                    json.dump(ext_data, fh, indent=4)
+                log.info("Added extruder definition → %s", ext_dest)
+
     # Warn about unresolved inheritance
     if data.get("inherits"):
         parent = data["inherits"]


### PR DESCRIPTION
## Summary

- `extract_cura_docker_defs()` now extracts both `/opt/cura/definitions` and `/opt/cura/extruders` from a single stopped container, so `pin_cura_definitions()` can find extruder definition files
- `add_profile()` now auto-copies referenced extruder definitions from the same source directory when adding a CuraEngine machine def (e.g. `profiles add ~/bambox/data/cura/bambox_p1s_ams.def.json` also copies `bambox_p1s_ams_extruder_0.def.json` etc.)

Closes #459

## Test plan

- [ ] `estampo profiles add <machine_def>` copies extruder defs from same dir
- [ ] `estampo profiles pin` with Docker extracts extruder defs
- [ ] CuraEngine slice completes without "Couldn't find definition file" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)