### PR TITLE
Fix auto-generated profile/definition PRs so they can merge

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -183,7 +183,7 @@ jobs:
         run: |
           git add src/estampo/data/
           git diff --cached --quiet src/estampo/data/ && echo "No profile changes" && exit 0
-          BRANCH="update-orca-profiles-${{ matrix.orca_version }}-$(date +%Y%m%d)"
+          BRANCH="update-orca-profiles-${{ matrix.orca_version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -198,7 +198,7 @@ jobs:
             --head "$BRANCH" \
           || echo "::warning::Could not create PR automatically. Branch '$BRANCH' pushed — create the PR manually."
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
 
   slice-test:
     needs: [resolve-versions, build-estampo-image]
@@ -386,7 +386,7 @@ jobs:
         run: |
           git add src/estampo/data/
           git diff --cached --quiet src/estampo/data/ && echo "No definition changes" && exit 0
-          BRANCH="update-cura-definitions-${{ matrix.cura_version }}-$(date +%Y%m%d)"
+          BRANCH="update-cura-definitions-${{ matrix.cura_version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -401,7 +401,7 @@ jobs:
             --head "$BRANCH" \
           || echo "::warning::Could not create PR automatically. Branch '$BRANCH' pushed — create the PR manually."
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
 
   cura-slice-test:
     needs: build-cura-image

--- a/changes/+fix-auto-pr-token.bugfix
+++ b/changes/+fix-auto-pr-token.bugfix
@@ -1,0 +1,1 @@
+Auto-generated profile and definition update PRs now trigger CI and reuse a stable branch name, so they can actually merge.


### PR DESCRIPTION
## Summary
- Swap \`GITHUB_TOKEN\` → \`RELEASE_PAT\` for the two \`gh pr create\` steps in \`release-readiness.yml\` so CI actually runs on the PRs they open (PRs created with \`GITHUB_TOKEN\` don't trigger downstream workflows, so required checks \`lint\` / \`test (ubuntu-latest, 3.12)\` never reported and the ruleset kept the PRs \`BLOCKED\`).
- Drop the \`-\$(date +%Y%m%d)\` suffix from the auto-PR branch names so the daily force-push updates the existing PR instead of opening a new one every day (which is how #438 and #454 both ended up stranded).

\`prepare-release.yml\` already uses \`RELEASE_PAT\` for exactly this reason.

Closes #462

## Test plan
- [ ] Next scheduled \`release-readiness\` run opens (or refreshes) a single PR with the stable branch name
- [ ] That PR shows \`lint\` and \`test (ubuntu-latest, 3.12)\` checks running/passing
- [ ] PR becomes mergeable instead of \`BLOCKED\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)