### PR TITLE
Pin slicer versions in all examples

### DIFF
--- a/examples/multi-filament/estampo.toml
+++ b/examples/multi-filament/estampo.toml
@@ -14,6 +14,7 @@ padding = 8.0
 
 [slicer]
 engine = "orca"
+version = "2.3.1"
 bed_type = "Textured PEI Plate"
 
 [slicer.orca]

--- a/examples/multi-part/estampo.toml
+++ b/examples/multi-part/estampo.toml
@@ -14,6 +14,7 @@ padding = 8.0
 
 [slicer]
 engine = "orca"
+version = "2.3.1"
 
 [slicer.orca]
 printer = "Bambu Lab P1S 0.4 nozzle"

--- a/examples/quickstart/estampo.toml
+++ b/examples/quickstart/estampo.toml
@@ -10,6 +10,7 @@ stages = ["load", "arrange", "plate", "slice", "pack"]
 
 [slicer]
 engine = "orca"
+version = "2.3.1"
 
 [slicer.orca]
 printer = "Bambu Lab P1S 0.4 nozzle"


### PR DESCRIPTION
## Summary

- Pin OrcaSlicer examples to `version = "2.3.1"`
- Cura example already pinned to `5.12.0`

Eliminates the version warning from `estampo validate`.

## Test plan

- [ ] CI `examples` job passes with no version warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)