### PR TITLE
Fix cylinder orientation in cura-p1s example

### DIFF
--- a/examples/cura-p1s/estampo.toml
+++ b/examples/cura-p1s/estampo.toml
@@ -35,6 +35,7 @@ filament = 1
 
 [[parts]]
 file = "cylinder_5x20mm.stl"
+orient = "upright"
 filament = 1
 
 [pack]


### PR DESCRIPTION
## Summary

Add `orient = "upright"` to the cylinder part in `examples/cura-p1s/` so it stands on a flat end instead of lying on its curved face.

The only cylinder without an explicit orient — multi-part already had `orient = "upright"`.

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)