### PR TITLE
Remove G-code template post-processing from CuraEngine backend

### DIFF
--- a/changes/485.feature
+++ b/changes/485.feature
@@ -1,0 +1,1 @@
+Remove G-code template post-processing from CuraEngine backend; write ``cura_settings.json`` for external resolvers via command stages

--- a/examples/cura-p1s/README.md
+++ b/examples/cura-p1s/README.md
@@ -1,25 +1,26 @@
 # CuraEngine + Bambu P1S
 
-CuraEngine slicing with a Bambu Lab P1S printer definition from bambox,
+CuraEngine slicing with a Bambu Lab P1S printer definition from cura-p1s,
 packed into a `.gcode.3mf` ready for the printer.
 
 ## Prerequisites
 
 - Docker running (CuraEngine image pulled automatically)
-- bambox installed (`pipx install bambox`)
+- cura-p1s installed (`pipx install cura-p1s`) — resolves G-code template variables
+- bambox installed (`pipx install bambox`) — packs G-code into `.gcode.3mf`
 
 ## Setup — importing the printer definition
 
-The Bambu P1S printer definition is provided by the bambox package. To set up
-a new project from scratch, import the definitions with `estampo profiles add`:
+The Bambu P1S printer definition is provided by the cura-p1s package. To set
+up a new project from scratch, import the definitions with `estampo profiles add`:
 
 ```sh
-# Find where bambox installed its definitions
-bambox cura-defs --path
+# Find where cura-p1s installed its definitions
+cura-p1s defs --path
 
 # Import the P1S definition and its extruder file
-estampo profiles add "$(bambox cura-defs --path)/bambox_p1s.def.json"
-estampo profiles add "$(bambox cura-defs --path)/bambox_p1s_extruder_0.def.json"
+estampo profiles add "$(cura-p1s defs --path)/bambox_p1s.def.json"
+estampo profiles add "$(cura-p1s defs --path)/bambox_p1s_extruder_0.def.json"
 ```
 
 This example has the definitions pre-committed in `profiles/cura/definitions/`
@@ -52,7 +53,7 @@ To automate this as a pipeline stage, add a `[print]` section to
 
 ```toml
 [pipeline]
-stages = ["load", "arrange", "plate", "slice", "pack", "print"]
+stages = ["load", "arrange", "plate", "slice", "resolve_templates", "pack", "print"]
 
 [print]
 command = "bambox print {output_dir}/plate.gcode.3mf"
@@ -60,9 +61,10 @@ command = "bambox print {output_dir}/plate.gcode.3mf"
 
 ## What it demonstrates
 
-- CuraEngine with a native Bambu P1S definition (from bambox)
+- CuraEngine with a native Bambu P1S definition (from cura-p1s)
 - Importing printer definitions via `estampo profiles add`
 - Single-filament PLA printing
 - `[slicer.cura.overrides]` — infill, walls, speed, layer height
+- `[resolve_templates]` command stage — `cura-p1s resolve` resolves G-code template variables
 - `[pack]` command stage — `bambox pack` converts CuraEngine G-code to Bambu `.gcode.3mf`
 - Pinned profiles committed to the repo for reproducibility

--- a/examples/cura-p1s/estampo.toml
+++ b/examples/cura-p1s/estampo.toml
@@ -1,14 +1,16 @@
 # CuraEngine slicing for Bambu Lab P1S, packed by bambox.
 #
-# The printer definition comes from bambox — see README.md for setup.
+# The printer definition comes from cura-p1s — see README.md for setup.
 #
 # Run:
 #   estampo run examples/cura-p1s/estampo.toml
 #
-# Requires: bambox (pipx install bambox)
+# Requires:
+#   - cura-p1s (pipx install cura-p1s) — resolves G-code template variables
+#   - bambox (pipx install bambox) — packs G-code into .gcode.3mf
 
 [pipeline]
-stages = ["load", "arrange", "plate", "slice", "pack"]
+stages = ["load", "arrange", "plate", "slice", "resolve_templates", "pack"]
 
 [plate]
 size = [256, 256]
@@ -37,6 +39,9 @@ filament = 1
 file = "cylinder_5x20mm.stl"
 orient = "upright"
 filament = 1
+
+[resolve_templates]
+command = "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"
 
 [pack]
 command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"

--- a/src/estampo/commands.py
+++ b/src/estampo/commands.py
@@ -39,6 +39,7 @@ COMMAND_VARIABLES: dict[str, str] = {
     "input_3mf": "Plate 3MF path (available after plate stage)",
     "sliced_3mf": "Packaged 3MF after slicing (available after slice stage)",
     "sliced_dir": "Slicer output directory (available after slice stage)",
+    "cura_settings": "CuraEngine settings JSON path (after slice, cura only)",
 }
 
 
@@ -67,7 +68,13 @@ def build_command_context(
         "input_3mf": str(stage_results.get("plate_3mf_path", "")),
         "sliced_3mf": str(stage_results.get("packaged_output", "")),
         "sliced_dir": str(stage_results.get("sliced_output_dir", "")),
+        "cura_settings": "",
     }
+    sliced_dir = stage_results.get("sliced_output_dir")
+    if sliced_dir and config.slicer.engine == "cura":
+        settings_path = Path(str(sliced_dir)) / "cura_settings.json"
+        if settings_path.exists():
+            ctx["cura_settings"] = str(settings_path)
     return ctx
 
 

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -667,8 +667,8 @@ class CuraProfile:
     per_extruder: list[dict[str, object]] = field(default_factory=list)
 
 
-def _settings_flags(profile: CuraProfile) -> list[str]:
-    """Build -s key=value flags from profile.
+def _settings_dict(profile: CuraProfile) -> dict[str, object]:
+    """Build the flat CuraEngine settings dict from a profile.
 
     Machine settings (bed size, heated bed, start/end gcode) are handled
     by the printer definition — only process/material settings here.
@@ -707,11 +707,18 @@ def _settings_flags(profile: CuraProfile) -> list[str]:
         # CuraEngine 5.12 requires these explicitly (not resolved from def)
         "roofing_layer_count": 0,
         "flooring_layer_count": 0,
+        "machine_nozzle_size": profile.nozzle_diameter,
+        "machine_buildplate_type": profile.bed_type.lower().replace(" ", "_"),
+        "material_type": profile.filament_type,
     }
     pairs.update(profile.overrides)
+    return pairs
 
+
+def _settings_flags(profile: CuraProfile) -> list[str]:
+    """Build -s key=value flags from profile."""
     flags: list[str] = []
-    for k, v in pairs.items():
+    for k, v in _settings_dict(profile).items():
         flags.extend(["-s", f"{k}={v}"])
     return flags
 
@@ -815,143 +822,16 @@ def _place_on_bed(
     return out
 
 
-def _safe_eval_arithmetic(expr: str) -> float:
-    """Safely evaluate a simple arithmetic expression (integers and +-*/).
+def _write_cura_settings(output_dir: Path, profile: CuraProfile) -> Path:
+    """Write CuraEngine settings to JSON for downstream command stages.
 
-    Uses ``ast`` to parse the expression and only allows numeric literals
-    and basic binary operators.  Raises ``ValueError`` for anything else.
+    External tools (e.g. ``cura-p1s resolve``) use this file to resolve
+    template variables in G-code produced by CuraEngine.
     """
-    import ast
-    import operator
-
-    _OPS: dict[type, object] = {
-        ast.Add: operator.add,
-        ast.Sub: operator.sub,
-        ast.Mult: operator.mul,
-        ast.Div: operator.truediv,
-    }
-
-    def _eval_node(node: ast.AST) -> float:
-        if isinstance(node, ast.Expression):
-            return _eval_node(node.body)
-        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
-            return float(node.value)
-        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
-            return -_eval_node(node.operand)
-        if isinstance(node, ast.BinOp) and type(node.op) in _OPS:
-            op = _OPS[type(node.op)]
-            return op(  # type: ignore[operator]
-                _eval_node(node.left), _eval_node(node.right)
-            )
-        raise ValueError(f"Unsupported expression node: {ast.dump(node)}")
-
-    tree = ast.parse(expr.strip(), mode="eval")
-    return _eval_node(tree)
-
-
-def _safe_eval_condition(expr: str) -> bool:
-    """Safely evaluate a simple comparison expression (string == string).
-
-    Uses ``ast`` to parse the expression and only allows string/numeric
-    literals and ``==`` / ``!=`` comparisons.  Raises ``ValueError`` for
-    anything else.
-    """
-    import ast
-
-    tree = ast.parse(expr.strip(), mode="eval")
-    node = tree.body
-
-    if not isinstance(node, ast.Compare):
-        raise ValueError(f"Expected comparison, got: {ast.dump(node)}")
-    if len(node.ops) != 1 or len(node.comparators) != 1:
-        raise ValueError(f"Only single comparisons supported: {ast.dump(node)}")
-
-    def _get_value(n: ast.AST) -> object:
-        if isinstance(n, ast.Constant):
-            return n.value
-        raise ValueError(f"Unsupported node in comparison: {ast.dump(n)}")
-
-    left = _get_value(node.left)
-    right = _get_value(node.comparators[0])
-    op = node.ops[0]
-
-    if isinstance(op, ast.Eq):
-        return left == right
-    if isinstance(op, ast.NotEq):
-        return left != right
-    raise ValueError(f"Unsupported comparison operator: {ast.dump(op)}")
-
-
-def _substitute_gcode_templates(gcode_path: Path, profile: CuraProfile) -> None:
-    """Replace OrcaSlicer-style ``{variable}`` placeholders in G-code.
-
-    CuraEngine emits start/end G-code verbatim from the machine
-    definition — it does not resolve ``{material_bed_temperature_layer_0}``
-    and similar template variables.  This function substitutes them with
-    values from the profile.
-    """
-    text = gcode_path.read_text()
-
-    replacements = {
-        "material_bed_temperature_layer_0": str(profile.material_bed_temperature),
-        "material_bed_temperature": str(profile.material_bed_temperature),
-        "material_print_temperature_layer_0": str(profile.material_print_temperature),
-        "material_print_temperature": str(profile.material_print_temperature),
-        "machine_nozzle_size": str(profile.nozzle_diameter),
-        "machine_buildplate_type": profile.bed_type.lower().replace(" ", "_"),
-        "material_type": profile.filament_type,
-    }
-
-    changed = False
-    for key, value in replacements.items():
-        # Simple {key} replacement
-        placeholder = "{" + key + "}"
-        if placeholder in text:
-            text = text.replace(placeholder, value)
-            changed = True
-
-    # Handle expressions like {material_print_temperature_layer_0 - 20}
-    def _eval_expr(m: re.Match[str]) -> str:
-        expr = m.group(1).strip()
-        for k, v in replacements.items():
-            expr = expr.replace(k, v)
-        try:
-            return str(int(_safe_eval_arithmetic(expr)))
-        except (ValueError, TypeError, SyntaxError):
-            return m.group(0)
-
-    text, n = re.subn(r"\{([^}]*\b(?:material_\w+|machine_\w+)\b[^}]*)\}", _eval_expr, text)
-    if n > 0:
-        changed = True
-
-    # Handle conditionals: {if condition}...{endif}
-    # Simple approach: evaluate the condition and keep/remove the block
-    def _eval_conditional(m: re.Match[str]) -> str:
-        condition = m.group(1).strip()
-        body = m.group(2)
-        # Replace known variables in condition
-        cond_eval = condition
-        cond_eval = cond_eval.replace(
-            "machine_buildplate_type",
-            repr(profile.bed_type.lower().replace(" ", "_")),
-        )
-        try:
-            if _safe_eval_condition(cond_eval):
-                return body
-        except (ValueError, TypeError, SyntaxError):
-            pass
-        return ""
-
-    text, n_cond = re.subn(
-        r"\{if\s+([^}]+)\}(.*?)\{endif\}",
-        _eval_conditional,
-        text,
-        flags=re.DOTALL,
-    )
-
-    if changed or n > 0 or n_cond > 0:
-        gcode_path.write_text(text)
-        log.info("Substituted template variables in G-code")
+    settings_path = output_dir / "cura_settings.json"
+    settings_path.write_text(json.dumps(_settings_dict(profile), indent=2) + "\n")
+    log.info("Wrote CuraEngine settings: %s", settings_path)
+    return settings_path
 
 
 def _prepare_cura_staging(
@@ -1047,7 +927,7 @@ def _run_docker_slice(
         raise EstampoError(f"CuraEngine produced no output:\n{combined[:500]}")
 
     _patch_gcode_header(output_gcode, result.stderr)
-    _substitute_gcode_templates(output_gcode, profile)
+    _write_cura_settings(output_dir, profile)
 
     log.info("CuraEngine output: %s (%d bytes)", output_gcode, output_gcode.stat().st_size)
     return output_dir
@@ -1091,7 +971,7 @@ def _run_local_slice(
         raise EstampoError(f"CuraEngine produced no output:\n{combined[:500]}")
 
     _patch_gcode_header(output_gcode, result.stderr)
-    _substitute_gcode_templates(output_gcode, profile)
+    _write_cura_settings(output_dir, profile)
 
     log.info("CuraEngine output: %s (%d bytes)", output_gcode, output_gcode.stat().st_size)
     return output_dir

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -140,6 +140,30 @@ class TestBuildCommandContext:
         ctx = build_command_context(cfg, tmp_path / "out", {})
         assert ctx["filament"] == "PLA"
 
+    def test_cura_settings_populated_when_file_exists(self, tmp_path):
+        sliced = tmp_path / "sliced"
+        sliced.mkdir()
+        settings = sliced / "cura_settings.json"
+        settings.write_text("{}")
+        cfg = _make_config(tmp_path, engine="cura")
+        results = {"sliced_output_dir": sliced}
+        ctx = build_command_context(cfg, tmp_path / "out", results)
+        assert ctx["cura_settings"] == str(settings)
+
+    def test_cura_settings_empty_for_orca_engine(self, tmp_path):
+        sliced = tmp_path / "sliced"
+        sliced.mkdir()
+        (sliced / "cura_settings.json").write_text("{}")
+        cfg = _make_config(tmp_path, engine="orca")
+        results = {"sliced_output_dir": sliced}
+        ctx = build_command_context(cfg, tmp_path / "out", results)
+        assert ctx["cura_settings"] == ""
+
+    def test_cura_settings_empty_when_no_file(self, tmp_path):
+        cfg = _make_config(tmp_path, engine="cura")
+        ctx = build_command_context(cfg, tmp_path / "out", {})
+        assert ctx["cura_settings"] == ""
+
 
 # ---------------------------------------------------------------------------
 # parse_command_stage

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -13,10 +13,9 @@ from estampo.cura import (
     _patch_gcode_header,
     _place_on_bed,
     _resolve_def_name,
-    _safe_eval_arithmetic,
-    _safe_eval_condition,
+    _settings_dict,
     _settings_flags,
-    _substitute_gcode_templates,
+    _write_cura_settings,
     cura_docker_image,
     cura_profile_from_config,
     slice_stl,
@@ -672,129 +671,55 @@ def test_place_on_bed_already_on_bed(tmp_path):
     assert placed.bounds[1][2] == pytest.approx(10.0)
 
 
-# --- _substitute_gcode_templates ---
+# --- _write_cura_settings / _settings_dict ---
 
 
-def test_substitute_simple_variables(tmp_path):
-    """Simple {variable} placeholders are replaced with profile values."""
-    gcode = tmp_path / "test.gcode"
-    gcode.write_text(
-        "M140 S{material_bed_temperature_layer_0}\n"
-        "M190 S{material_bed_temperature_layer_0}\n"
-        "M104 S{material_print_temperature_layer_0}\n"
-        "M109 S{material_print_temperature_layer_0}\n"
-        "G1 X0 Y0\n"
-    )
-    profile = CuraProfile(material_print_temperature=260, material_bed_temperature=70)
-    _substitute_gcode_templates(gcode, profile)
-    text = gcode.read_text()
-    assert "M140 S70" in text
-    assert "M190 S70" in text
-    assert "M104 S260" in text
-    assert "M109 S260" in text
-    assert "{material_" not in text
-
-
-def test_substitute_expression(tmp_path):
-    """Expressions like {temp - 20} are evaluated."""
-    gcode = tmp_path / "test.gcode"
-    gcode.write_text("M109 S{material_print_temperature_layer_0 - 20}\n")
-    profile = CuraProfile(material_print_temperature=260)
-    _substitute_gcode_templates(gcode, profile)
-    text = gcode.read_text()
-    assert "M109 S240" in text
-
-
-def test_substitute_conditional(tmp_path):
-    """Conditionals like {if condition}...{endif} are evaluated."""
-    gcode = tmp_path / "test.gcode"
-    gcode.write_text(
-        "G28\n"
-        "{if machine_buildplate_type=='textured_pei_plate'}"
-        "M1002 set_flag bed_type textured\n"
-        "{endif}"
-        "G29\n"
-    )
-    profile = CuraProfile(bed_type="Textured PEI Plate")
-    _substitute_gcode_templates(gcode, profile)
-    text = gcode.read_text()
-    assert "M1002 set_flag bed_type textured" in text
-    assert "{if" not in text
-    assert "{endif}" not in text
-
-
-def test_substitute_machine_and_material_type(tmp_path):
-    """Machine and material type placeholders are replaced."""
-    gcode = tmp_path / "test.gcode"
-    gcode.write_text(
-        "; BAMBOX_NOZZLE_DIAMETER={machine_nozzle_size}\n"
-        "; BAMBOX_BED_TYPE={machine_buildplate_type}\n"
-        "; BAMBOX_FILAMENT_TYPE={material_type}\n"
-    )
+def test_settings_dict_includes_machine_and_material(tmp_path):
+    """_settings_dict includes machine/material keys for template resolution."""
     profile = CuraProfile(
         nozzle_diameter=0.4,
         bed_type="Textured PEI Plate",
         filament_type="PLA",
+        material_print_temperature=260,
+        material_bed_temperature=70,
     )
-    _substitute_gcode_templates(gcode, profile)
-    text = gcode.read_text()
-    assert "; BAMBOX_NOZZLE_DIAMETER=0.4" in text
-    assert "; BAMBOX_BED_TYPE=textured_pei_plate" in text
-    assert "; BAMBOX_FILAMENT_TYPE=PLA" in text
-    assert "{machine_" not in text
-    assert "{material_type}" not in text
+    d = _settings_dict(profile)
+    assert d["machine_nozzle_size"] == 0.4
+    assert d["machine_buildplate_type"] == "textured_pei_plate"
+    assert d["material_type"] == "PLA"
+    assert d["material_print_temperature_layer_0"] == 260
+    assert d["material_bed_temperature_layer_0"] == 70
 
 
-def test_substitute_no_change(tmp_path):
-    """G-code without template variables is unchanged."""
-    gcode = tmp_path / "test.gcode"
-    original = "G28\nG1 X0 Y0 Z0.2\nG1 E5 F300\n"
-    gcode.write_text(original)
-    profile = CuraProfile()
-    _substitute_gcode_templates(gcode, profile)
-    assert gcode.read_text() == original
+def test_write_cura_settings(tmp_path):
+    """_write_cura_settings writes valid JSON with all profile settings."""
+    import json
+
+    profile = CuraProfile(
+        material_print_temperature=260,
+        material_bed_temperature=70,
+        filament_type="PETG",
+        bed_type="Textured PEI Plate",
+    )
+    path = _write_cura_settings(tmp_path, profile)
+    assert path == tmp_path / "cura_settings.json"
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["material_print_temperature_layer_0"] == 260
+    assert data["material_bed_temperature_layer_0"] == 70
+    assert data["material_type"] == "PETG"
+    assert data["machine_buildplate_type"] == "textured_pei_plate"
 
 
-# --- _safe_eval_arithmetic ---
+def test_write_cura_settings_includes_overrides(tmp_path):
+    """Profile overrides are included in the settings JSON."""
+    import json
 
-
-def test_safe_eval_arithmetic_basic():
-    assert _safe_eval_arithmetic("260 - 20") == 240.0
-    assert _safe_eval_arithmetic("100 + 50") == 150.0
-    assert _safe_eval_arithmetic("10 * 3") == 30.0
-    assert _safe_eval_arithmetic("100 / 4") == 25.0
-
-
-def test_safe_eval_arithmetic_negative():
-    assert _safe_eval_arithmetic("-5") == -5.0
-
-
-def test_safe_eval_arithmetic_rejects_function_calls():
-    with pytest.raises(ValueError, match="Unsupported"):
-        _safe_eval_arithmetic("__import__('os').system('rm -rf /')")
-
-
-def test_safe_eval_arithmetic_rejects_names():
-    with pytest.raises(ValueError, match="Unsupported"):
-        _safe_eval_arithmetic("x + 1")
-
-
-# --- _safe_eval_condition ---
-
-
-def test_safe_eval_condition_string_eq():
-    assert _safe_eval_condition("'foo' == 'foo'") is True
-    assert _safe_eval_condition("'foo' == 'bar'") is False
-
-
-def test_safe_eval_condition_string_neq():
-    assert _safe_eval_condition("'foo' != 'bar'") is True
-    assert _safe_eval_condition("'foo' != 'foo'") is False
-
-
-def test_safe_eval_condition_rejects_function_calls():
-    with pytest.raises(ValueError):
-        _safe_eval_condition("__import__('os').system('id') == ''")
+    profile = CuraProfile(overrides={"infill_pattern": "gyroid", "wall_line_count": "4"})
+    path = _write_cura_settings(tmp_path, profile)
+    data = json.loads(path.read_text())
+    assert data["infill_pattern"] == "gyroid"
+    assert data["wall_line_count"] == "4"
 
 
 # --- _fetch_printer_def (URL / file path) ---


### PR DESCRIPTION
## Summary

- Delete `_substitute_gcode_templates()`, `_safe_eval_arithmetic()`, `_safe_eval_condition()` from `cura.py` (~140 lines of buggy, printer-definition-specific code)
- After slicing, write `cura_settings.json` (flat dict of CuraEngine settings) alongside the G-code output
- Add `cura_settings` to `COMMAND_VARIABLES` so command stages can reference the settings file
- Update cura-p1s example to use a `[resolve_templates]` command stage invoking `cura-p1s resolve`
- Net -157 lines

## Why

Template resolution (`{material_bed_temperature_layer_0}`, `{if material_type == "PLA"}`, etc.) is a property of the **printer definition**, not of estampo or CuraEngine generically. Different definitions use different templates. The resolution logic belongs alongside the definition — in `cura-p1s` as a CLI tool, invoked via command stage (ADR-007).

The removed code was also buggy: no nested `{if}`, no `{elif}`/`{else}`, no `>` comparisons, limited variables — and it didn't match CuraEngine's actual `GcodeTemplateResolver` semantics.

## Architecture

```
estampo (slice) → cura_settings.json → cura-p1s resolve (command stage) → bambox pack (command stage)
```

When CuraEngine eventually ships with native template resolution (5.14+), users just remove the `[resolve_templates]` stage from TOML. Zero estampo code changes needed.

## Test plan

- [x] All 532 tests pass (9 skipped)
- [x] Lint, format, mypy all clean
- [x] New tests for `_settings_dict`, `_write_cura_settings`, `cura_settings` context variable
- [x] Old template substitution tests removed
- [ ] CI passes

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)