### PR TITLE
Fix release-readiness workflow: stale example paths

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -209,10 +209,10 @@ jobs:
       matrix:
         orca_version: ${{ fromJson(needs.resolve-versions.outputs.versions) }}
         example:
-          - name: generic
-            workdir: examples
-          - name: decoy-case
-            workdir: examples/decoy-case
+          - name: quickstart
+            workdir: examples/quickstart
+          - name: multi-part
+            workdir: examples/multi-part
     steps:
       - uses: actions/checkout@v6
 
@@ -243,9 +243,8 @@ jobs:
       # which falls back to local slicer and can behave differently.
       - name: Run slice (${{ matrix.example.name }} on orca-${{ matrix.orca_version }})
         run: |
-          SHORT=$(echo "${{ matrix.orca_version }}" | tr -d '.')
           cd ${{ matrix.example.workdir }}
-          uv run estampo run "estampo-${SHORT}.toml" -v
+          uv run estampo run estampo.toml --until slice -v
 
       - name: Verify output
         run: |
@@ -436,17 +435,17 @@ jobs:
 
       - name: Run slice (CuraEngine ${{ matrix.cura_version }})
         run: |
-          cd examples
-          uv run estampo run estampo-cura.toml -v
+          cd examples/cura
+          uv run estampo run estampo.toml -v
 
       - name: Verify output
         run: |
           echo "Checking for slice output..."
-          ls -la examples/estampo_output/
+          ls -la examples/cura/estampo_output/
           echo "Slice test OK — CuraEngine ${{ matrix.cura_version }}"
 
       - uses: actions/upload-artifact@v7
         with:
           name: slice-output-cura-${{ matrix.cura_version }}
-          path: examples/estampo_output/
+          path: examples/cura/estampo_output/
           retention-days: 5

--- a/changes/491.bugfix
+++ b/changes/491.bugfix
@@ -1,0 +1,1 @@
+Fix release-readiness workflow to use restructured example directories


### PR DESCRIPTION
## Summary

- Update OrcaSlicer slice-test matrix to use `examples/quickstart` and `examples/multi-part` (replaces removed `examples/` flat layout and `examples/decoy-case`)
- Update CuraEngine slice-test to use `examples/cura/estampo.toml` (replaces `examples/estampo-cura.toml`)
- Add `--until slice` to OrcaSlicer tests to stop before bambox `pack` stages that aren't available in CI

Closes #491

## Test plan

- [ ] Verify release-readiness nightly run passes after merge
- [ ] Check that both `quickstart` and `multi-part` OrcaSlicer examples slice successfully
- [ ] Check that `cura` example slices successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)