### PR TITLE
Bundle bambox/cura-p1s in Docker images, add docker flag for command stages

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -121,7 +121,9 @@ jobs:
           tags: |
             estampo/estampo:orca-${{ matrix.orca-version }}
             ghcr.io/${{ github.repository }}:orca-${{ matrix.orca-version }}
-          build-args: ORCA_VERSION=${{ matrix.orca-version }}
+          build-args: |
+            ORCA_VERSION=${{ matrix.orca-version }}
+            BNL_TOKEN=${{ secrets.BNL_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -194,6 +196,8 @@ jobs:
           tags: |
             estampo/estampo:cura-${{ matrix.cura-version }}
             ghcr.io/${{ github.repository }}:cura-${{ matrix.cura-version }}
-          build-args: CURA_VERSION=${{ matrix.cura-version }}
+          build-args: |
+            CURA_VERSION=${{ matrix.cura-version }}
+            BNL_TOKEN=${{ secrets.BNL_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           docker build --platform linux/amd64 \
             --build-arg ORCA_VERSION=${{ matrix.orca_version }} \
+            --build-arg BNL_TOKEN=${{ secrets.BNL_TOKEN }} \
             -t estampo/estampo:orca-${{ matrix.orca_version }}-test .
 
       - name: Save image as artifact
@@ -289,6 +290,7 @@ jobs:
           docker build --platform linux/amd64 \
             -f Dockerfile.cura \
             --build-arg CURA_VERSION=${{ matrix.cura_version }} \
+            --build-arg BNL_TOKEN=${{ secrets.BNL_TOKEN }} \
             -t estampo/estampo:cura-${{ matrix.cura_version }}-test .
 
       - name: Save image as artifact

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -209,10 +209,10 @@ jobs:
       matrix:
         orca_version: ${{ fromJson(needs.resolve-versions.outputs.versions) }}
         example:
-          - name: generic
-            workdir: examples
-          - name: decoy-case
-            workdir: examples/decoy-case
+          - name: quickstart
+            workdir: examples/quickstart
+          - name: multi-part
+            workdir: examples/multi-part
     steps:
       - uses: actions/checkout@v6
 
@@ -243,9 +243,8 @@ jobs:
       # which falls back to local slicer and can behave differently.
       - name: Run slice (${{ matrix.example.name }} on orca-${{ matrix.orca_version }})
         run: |
-          SHORT=$(echo "${{ matrix.orca_version }}" | tr -d '.')
           cd ${{ matrix.example.workdir }}
-          uv run estampo run "estampo-${SHORT}.toml" -v
+          uv run estampo run estampo.toml --until slice -v
 
       - name: Verify output
         run: |
@@ -436,17 +435,17 @@ jobs:
 
       - name: Run slice (CuraEngine ${{ matrix.cura_version }})
         run: |
-          cd examples
-          uv run estampo run estampo-cura.toml -v
+          cd examples/cura
+          uv run estampo run estampo.toml -v
 
       - name: Verify output
         run: |
           echo "Checking for slice output..."
-          ls -la examples/estampo_output/
+          ls -la examples/cura/estampo_output/
           echo "Slice test OK — CuraEngine ${{ matrix.cura_version }}"
 
       - uses: actions/upload-artifact@v7
         with:
           name: slice-output-cura-${{ matrix.cura_version }}
-          path: examples/estampo_output/
+          path: examples/cura/estampo_output/
           retention-days: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,9 @@ jobs:
           push: false
           load: true
           tags: estampo/estampo:orca-${{ matrix.orca-version }}
-          build-args: ORCA_VERSION=${{ matrix.orca-version }}
+          build-args: |
+            ORCA_VERSION=${{ matrix.orca-version }}
+            BNL_TOKEN=${{ secrets.BNL_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -226,7 +228,9 @@ jobs:
           push: false
           load: true
           tags: estampo/estampo:cura-${{ matrix.cura-version }}
-          build-args: CURA_VERSION=${{ matrix.cura-version }}
+          build-args: |
+            CURA_VERSION=${{ matrix.cura-version }}
+            BNL_TOKEN=${{ secrets.BNL_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           docker build \
             --build-arg ORCA_VERSION=${{ inputs.version }} \
+            --build-arg BNL_TOKEN=${{ secrets.BNL_TOKEN }} \
             -t estampo/estampo:orca-${{ inputs.version }} .
 
       - name: Generate plate and slice
@@ -79,6 +80,7 @@ jobs:
           docker build --platform linux/amd64 \
             -f Dockerfile.cura \
             --build-arg CURA_VERSION=${{ inputs.version }} \
+            --build-arg BNL_TOKEN=${{ secrets.BNL_TOKEN }} \
             -t estampo/estampo:cura-${{ inputs.version }} .
 
       - name: Generate plate and slice

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -81,18 +81,12 @@ jobs:
             --build-arg CURA_VERSION=${{ inputs.version }} \
             -t estampo/estampo:cura-${{ inputs.version }} .
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install estampo
-        run: |
-          pip install uv
-          uv sync --frozen --no-dev
-
       - name: Generate plate and slice
-        run: uv run estampo run "${{ inputs.config }}" -v
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/project" \
+            estampo/estampo:cura-${{ inputs.version }} \
+            run "${{ inputs.config }}" --local -v
 
       - name: Upload gcode
         uses: actions/upload-artifact@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,62 @@
 #   docker run --rm -v "$PWD:/project" estampo/estampo:orca-2.3.1 run estampo.toml
 
 ARG ORCA_VERSION=2.3.1
+
+# ---------------------------------------------------------------------------
+# Fetch stage: bambox-bridge binary + libbambu_networking.so + TLS cert
+# ---------------------------------------------------------------------------
+FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
+
+ARG BAMBOX_VERSION=0.4.2
+ARG BAMBU_SLICER_VERSION=02.05.00.00
+ARG BNL_TOKEN=""
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl python3 unzip ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download pre-built bambox-bridge binary from GitHub release
+RUN curl -fSL -o /usr/local/bin/bambox-bridge \
+        "https://github.com/estampo/bambox/releases/download/v${BAMBOX_VERSION}/bambox-bridge-linux-x86_64" \
+    && chmod +x /usr/local/bin/bambox-bridge
+
+# Fetch libbambu_networking.so (Bambu API → private cache fallback)
+RUN mkdir -p /out/lib /out/cert \
+    && (PLUGIN_URL=$(curl -fsSL \
+        -H "User-Agent: BambuStudio/${BAMBU_SLICER_VERSION}" \
+        -H "X-BBL-OS-Type: linux" \
+        "https://api.bambulab.com/v1/iot-service/api/slicer/resource?slicer/plugins/cloud=${BAMBU_SLICER_VERSION}" \
+        | python3 -c "import sys,json; r=json.load(sys.stdin)['resources']; print([x for x in r if 'plugins' in x['type']][0]['url'])") \
+    && curl -fsSL -o /tmp/plugins.zip "$PLUGIN_URL" \
+    && unzip -j /tmp/plugins.zip libbambu_networking.so -d /out/lib/ \
+    && echo "Fetched libbambu_networking.so from Bambu API") \
+    || (echo "Bambu API failed, falling back to private cache..." \
+    && curl -fsSL \
+        -H "Authorization: token ${BNL_TOKEN}" \
+        -H "Accept: application/octet-stream" \
+        -o /out/lib/libbambu_networking.so \
+        "https://api.github.com/repos/estampo/bnl/releases/assets/$(curl -fsSL \
+            -H "Authorization: token ${BNL_TOKEN}" \
+            "https://api.github.com/repos/estampo/bnl/releases/tags/v${BAMBU_SLICER_VERSION}" \
+            | python3 -c "import sys,json; print([a for a in json.load(sys.stdin)['assets'] if a['name']=='libbambu_networking.so'][0]['id'])")" \
+    && echo "Fetched libbambu_networking.so from private cache")
+
+# TLS certificate for Bambu Cloud MQTT
+RUN curl -fSL -o /out/cert/slicer_base64.cer \
+       "https://raw.githubusercontent.com/bambulab/BambuStudio/master/resources/cert/slicer_base64.cer"
+
+# ---------------------------------------------------------------------------
+# Main image
+# ---------------------------------------------------------------------------
 FROM estampo/orca-base:${ORCA_VERSION}
 
 LABEL org.opencontainers.image.description="estampo with OrcaSlicer ${ORCA_VERSION}"
+
+# bambox-bridge + libbambu_networking.so + TLS cert
+COPY --from=bridge-fetcher /usr/local/bin/bambox-bridge /usr/local/bin/bambox-bridge
+COPY --from=bridge-fetcher /out/lib/libbambu_networking.so /usr/lib/libbambu_networking.so
+COPY --from=bridge-fetcher /out/cert/slicer_base64.cer /tmp/bambu_agent/cert/slicer_base64.cer
+ENV BAMBU_LIB_PATH=/usr/lib/libbambu_networking.so
 
 # Install uv (fast Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ COPY src/ ./src/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable --python 3.12
 
+# Install bambox (CLI-only tool for Bambu Lab printers — not an estampo
+# dependency, but bundled so command stages like `bambox repack` work
+# inside the container without requiring host-side installation).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install bambox --python /opt/estampo/.venv/bin/python
+
 ENV PATH="/opt/estampo/.venv/bin:$PATH"
 
 USER estampo

--- a/Dockerfile.cura
+++ b/Dockerfile.cura
@@ -10,11 +10,64 @@
 #   docker run --rm -v "$PWD:/project" estampo/estampo:cura-5.12.0 run estampo.toml
 
 ARG CURA_VERSION=5.12.0
+
+# ---------------------------------------------------------------------------
+# Fetch stage: bambox-bridge binary + libbambu_networking.so + TLS cert
+# ---------------------------------------------------------------------------
+FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
+
+ARG BAMBOX_VERSION=0.4.2
+ARG BAMBU_SLICER_VERSION=02.05.00.00
+ARG BNL_TOKEN=""
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl python3 unzip ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download pre-built bambox-bridge binary from GitHub release
+RUN curl -fSL -o /usr/local/bin/bambox-bridge \
+        "https://github.com/estampo/bambox/releases/download/v${BAMBOX_VERSION}/bambox-bridge-linux-x86_64" \
+    && chmod +x /usr/local/bin/bambox-bridge
+
+# Fetch libbambu_networking.so (Bambu API → private cache fallback)
+RUN mkdir -p /out/lib /out/cert \
+    && (PLUGIN_URL=$(curl -fsSL \
+        -H "User-Agent: BambuStudio/${BAMBU_SLICER_VERSION}" \
+        -H "X-BBL-OS-Type: linux" \
+        "https://api.bambulab.com/v1/iot-service/api/slicer/resource?slicer/plugins/cloud=${BAMBU_SLICER_VERSION}" \
+        | python3 -c "import sys,json; r=json.load(sys.stdin)['resources']; print([x for x in r if 'plugins' in x['type']][0]['url'])") \
+    && curl -fsSL -o /tmp/plugins.zip "$PLUGIN_URL" \
+    && unzip -j /tmp/plugins.zip libbambu_networking.so -d /out/lib/ \
+    && echo "Fetched libbambu_networking.so from Bambu API") \
+    || (echo "Bambu API failed, falling back to private cache..." \
+    && curl -fsSL \
+        -H "Authorization: token ${BNL_TOKEN}" \
+        -H "Accept: application/octet-stream" \
+        -o /out/lib/libbambu_networking.so \
+        "https://api.github.com/repos/estampo/bnl/releases/assets/$(curl -fsSL \
+            -H "Authorization: token ${BNL_TOKEN}" \
+            "https://api.github.com/repos/estampo/bnl/releases/tags/v${BAMBU_SLICER_VERSION}" \
+            | python3 -c "import sys,json; print([a for a in json.load(sys.stdin)['assets'] if a['name']=='libbambu_networking.so'][0]['id'])")" \
+    && echo "Fetched libbambu_networking.so from private cache")
+
+# TLS certificate for Bambu Cloud MQTT
+RUN curl -fSL -o /out/cert/slicer_base64.cer \
+       "https://raw.githubusercontent.com/bambulab/BambuStudio/master/resources/cert/slicer_base64.cer"
+
+# ---------------------------------------------------------------------------
+# Main image
+# ---------------------------------------------------------------------------
 FROM estampo/cura-base:${CURA_VERSION}
 
 USER root
 
 LABEL org.opencontainers.image.description="estampo with CuraEngine ${CURA_VERSION}"
+
+# bambox-bridge + libbambu_networking.so + TLS cert
+COPY --from=bridge-fetcher /usr/local/bin/bambox-bridge /usr/local/bin/bambox-bridge
+COPY --from=bridge-fetcher /out/lib/libbambu_networking.so /usr/lib/libbambu_networking.so
+COPY --from=bridge-fetcher /out/cert/slicer_base64.cer /tmp/bambu_agent/cert/slicer_base64.cer
+ENV BAMBU_LIB_PATH=/usr/lib/libbambu_networking.so
 
 # Install uv (fast Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/Dockerfile.cura
+++ b/Dockerfile.cura
@@ -38,6 +38,20 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN chmod a+rx /root /root/.local /root/.local/share /root/.local/share/uv \
     /root/.local/share/uv/python
 
+# Install bambox (CLI-only tool for Bambu Lab printers — not an estampo
+# dependency, but bundled so command stages like `bambox repack` work
+# inside the container without requiring host-side installation).
+# Install cura-p1s (Bambu Lab P1S printer definition + G-code template
+# resolver for CuraEngine) and copy definitions into the search path.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install bambox \
+        "cura-p1s @ git+https://github.com/estampo/cura-p1s.git" \
+        --python /opt/estampo/.venv/bin/python \
+    && cp /opt/estampo/.venv/lib/python3.12/site-packages/cura_p1s/data/bambox_p1s.def.json \
+          /opt/cura/definitions/ \
+    && cp /opt/estampo/.venv/lib/python3.12/site-packages/cura_p1s/data/bambox_p1s_extruder_0.def.json \
+          /opt/cura/extruders/
+
 ENV PATH="/opt/estampo/.venv/bin:$PATH"
 
 USER estampo

--- a/action/action.yml
+++ b/action/action.yml
@@ -54,7 +54,7 @@ runs:
       env:
         ORCA_VERSION: ${{ inputs.orca-version }}
       run: |
-        IMAGE="ghcr.io/${{ github.repository }}:orca-${ORCA_VERSION}"
+        IMAGE="ghcr.io/estampo/estampo:orca-${ORCA_VERSION}"
         echo "::group::Pulling ${IMAGE}"
         docker pull "${IMAGE}"
         echo "::endgroup::"
@@ -71,7 +71,7 @@ runs:
         docker run --rm \
           -v "${WORKSPACE}:/project" \
           --workdir /project \
-          "ghcr.io/${{ github.repository }}:orca-${ORCA_VERSION}" \
+          "ghcr.io/estampo/estampo:orca-${ORCA_VERSION}" \
           run "${CONFIG}" \
           --until "${UNTIL}" \
           --output-dir "/project/${OUTPUT_DIR}" \

--- a/changes/+docker-bundle-fixes.feature
+++ b/changes/+docker-bundle-fixes.feature
@@ -1,0 +1,1 @@
+Bundle bambox and cura-p1s into Docker images; add ``docker`` flag for command stages; fix action image reference and stale workflow paths

--- a/changes/+docker-bundle-fixes.feature
+++ b/changes/+docker-bundle-fixes.feature
@@ -1,1 +1,1 @@
-Bundle bambox and cura-p1s into Docker images; add ``docker`` flag for command stages; fix action image reference and stale workflow paths
+Bundle bambox, bambox-bridge, and cura-p1s into Docker images; add ``docker`` flag for command stages; fix action image reference and stale workflow paths

--- a/src/estampo/commands.py
+++ b/src/estampo/commands.py
@@ -40,6 +40,7 @@ COMMAND_VARIABLES: dict[str, str] = {
     "sliced_3mf": "Packaged 3MF after slicing (available after slice stage)",
     "sliced_dir": "Slicer output directory (available after slice stage)",
     "cura_settings": "CuraEngine settings JSON path (after slice, cura only)",
+    "slicer_image": "Docker image tag for the active slicer engine",
 }
 
 
@@ -58,6 +59,18 @@ def build_command_context(
     """
     engine_cfg = config.slicer.orca if config.slicer.engine == "orca" else config.slicer.cura
     fils = engine_cfg.filaments
+
+    # Resolve slicer Docker image tag
+    slicer_image = ""
+    if config.slicer.engine == "orca":
+        from estampo.orca import docker_image as orca_docker_image
+
+        slicer_image = orca_docker_image(config.slicer.version)
+    elif config.slicer.engine == "cura":
+        from estampo.cura import cura_docker_image
+
+        slicer_image = cura_docker_image(config.slicer.version)
+
     ctx: dict[str, str] = {
         "name": config.name or "",
         "output_dir": str(output_dir),
@@ -69,6 +82,7 @@ def build_command_context(
         "sliced_3mf": str(stage_results.get("packaged_output", "")),
         "sliced_dir": str(stage_results.get("sliced_output_dir", "")),
         "cura_settings": "",
+        "slicer_image": slicer_image,
     }
     sliced_dir = stage_results.get("sliced_output_dir")
     if sliced_dir and config.slicer.engine == "cura":
@@ -90,6 +104,8 @@ class CommandStageConfig:
     name: str
     command: str
     output: str | None = None
+    docker: bool = False
+    image: str | None = None
 
 
 def parse_command_stage(name: str, raw: dict) -> CommandStageConfig:
@@ -107,12 +123,65 @@ def parse_command_stage(name: str, raw: dict) -> CommandStageConfig:
     if output is not None:
         if not isinstance(output, str) or not output.strip():
             raise EstampoError(f"[{name}].output must be a non-empty string")
-    return CommandStageConfig(name=name, command=command.strip(), output=output)
+    docker = raw.get("docker", False)
+    if not isinstance(docker, bool):
+        raise EstampoError(f"[{name}].docker must be true or false")
+    image = raw.get("image")
+    if image is not None:
+        if not isinstance(image, str) or not image.strip():
+            raise EstampoError(f"[{name}].image must be a non-empty string")
+    return CommandStageConfig(
+        name=name, command=command.strip(), output=output, docker=docker, image=image
+    )
 
 
 # ---------------------------------------------------------------------------
 # Execution
 # ---------------------------------------------------------------------------
+
+
+def _wrap_docker_command(
+    cmd: list[str],
+    image: str,
+    output_dir: str,
+) -> list[str]:
+    """Wrap a command in ``docker run`` with volume mounts.
+
+    Mounts the output directory at ``/work/output`` and rewrites any
+    arguments that reference the host output_dir to use the container path.
+    """
+    import os
+
+    abs_output = str(Path(output_dir).resolve())
+    container_output = "/work/output"
+
+    # Rewrite host paths to container paths in arguments
+    rewritten = []
+    for arg in cmd:
+        rewritten.append(arg.replace(abs_output, container_output))
+
+    docker_cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "--platform",
+        "linux/amd64",
+        "-v",
+        f"{abs_output}:{container_output}",
+        "--workdir",
+        container_output,
+    ]
+    # Match host user so output files are owned correctly (skip on Windows)
+    if os.name != "nt":
+        docker_cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+    docker_cmd.extend(["--entrypoint", rewritten[0], image])
+    docker_cmd.extend(rewritten[1:])
+    return docker_cmd
+
+
+def _is_inside_container() -> bool:
+    """Detect if we are already running inside a Docker container."""
+    return Path("/.dockerenv").exists()
 
 
 def run_command_stage(
@@ -148,7 +217,21 @@ def run_command_stage(
         output_path = Path(rendered_output)
 
     cmd = shlex.split(rendered_command)
-    log.info("Running command stage '%s': %s", stage.name, rendered_command)
+
+    # When docker=true and we're not already inside a container,
+    # wrap the command in docker run with volume mounts.
+    use_docker = stage.docker and not _is_inside_container()
+    if use_docker:
+        image = stage.image or context.get("slicer_image", "")
+        if not image:
+            raise EstampoError(
+                f"[{stage.name}]: docker=true but no image specified and "
+                f"no slicer image available. "
+                f"Set [{stage.name}].image or configure a slicer engine."
+            )
+        cmd = _wrap_docker_command(cmd, image, context.get("output_dir", ""))
+
+    log.info("Running command stage '%s': %s", stage.name, shlex.join(cmd))
 
     from estampo import ui
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,6 +9,7 @@ from estampo import EstampoError
 from estampo.commands import (
     COMMAND_VARIABLES,
     CommandStageConfig,
+    _wrap_docker_command,
     build_command_context,
     parse_command_stage,
     run_command_stage,
@@ -164,6 +165,18 @@ class TestBuildCommandContext:
         ctx = build_command_context(cfg, tmp_path / "out", {})
         assert ctx["cura_settings"] == ""
 
+    def test_slicer_image_orca(self, tmp_path):
+        cfg = _make_config(tmp_path, engine="orca")
+        cfg.slicer.version = "2.3.1"
+        ctx = build_command_context(cfg, tmp_path / "out", {})
+        assert ctx["slicer_image"] == "estampo/estampo:orca-2.3.1"
+
+    def test_slicer_image_cura(self, tmp_path):
+        cfg = _make_config(tmp_path, engine="cura")
+        cfg.slicer.version = "5.12.0"
+        ctx = build_command_context(cfg, tmp_path / "out", {})
+        assert ctx["slicer_image"] == "estampo/estampo:cura-5.12.0"
+
 
 # ---------------------------------------------------------------------------
 # parse_command_stage
@@ -195,6 +208,37 @@ class TestParseCommandStage:
     def test_empty_output_raises(self):
         with pytest.raises(EstampoError, match="non-empty string"):
             parse_command_stage("bad", {"command": "echo", "output": ""})
+
+    def test_docker_flag_defaults_false(self):
+        raw = {"command": "echo hello"}
+        stage = parse_command_stage("test", raw)
+        assert stage.docker is False
+        assert stage.image is None
+
+    def test_docker_flag_true(self):
+        raw = {"command": "cura-p1s resolve {sliced_dir}", "docker": True}
+        stage = parse_command_stage("resolve", raw)
+        assert stage.docker is True
+
+    def test_docker_with_image_override(self):
+        raw = {
+            "command": "cura-p1s resolve {sliced_dir}",
+            "docker": True,
+            "image": "estampo/estampo:cura-5.12.0",
+        }
+        stage = parse_command_stage("resolve", raw)
+        assert stage.docker is True
+        assert stage.image == "estampo/estampo:cura-5.12.0"
+
+    def test_docker_invalid_type_raises(self):
+        raw = {"command": "echo", "docker": "yes"}
+        with pytest.raises(EstampoError, match="docker must be true or false"):
+            parse_command_stage("bad", raw)
+
+    def test_docker_empty_image_raises(self):
+        raw = {"command": "echo", "docker": True, "image": ""}
+        with pytest.raises(EstampoError, match="image must be a non-empty string"):
+            parse_command_stage("bad", raw)
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +302,68 @@ class TestRunCommandStage:
         ctx = {}
         with pytest.raises(subprocess.TimeoutExpired):
             run_command_stage(stage, ctx, timeout=1)
+
+    def test_docker_true_no_image_raises(self, monkeypatch):
+        monkeypatch.setattr("estampo.commands._is_inside_container", lambda: False)
+        stage = CommandStageConfig(name="test", command="echo hello", docker=True)
+        ctx = {"slicer_image": "", "output_dir": "/tmp"}
+        with pytest.raises(EstampoError, match="no image specified"):
+            run_command_stage(stage, ctx)
+
+    def test_docker_uses_explicit_image(self, tmp_path, monkeypatch):
+        """When docker=true with explicit image, the command is wrapped in docker run."""
+        monkeypatch.setattr("estampo.commands._is_inside_container", lambda: False)
+        stage = CommandStageConfig(
+            name="test",
+            command="echo hello",
+            docker=True,
+            image="myimage:latest",
+        )
+        out = tmp_path / "output"
+        out.mkdir()
+        ctx = {"output_dir": str(out)}
+        # echo hello through docker will fail (no docker), but we can test the
+        # error message contains "docker"
+        with pytest.raises(EstampoError, match="failed"):
+            run_command_stage(stage, ctx)
+
+
+# ---------------------------------------------------------------------------
+# _wrap_docker_command
+# ---------------------------------------------------------------------------
+
+
+class TestWrapDockerCommand:
+    def test_basic_wrapping(self, tmp_path):
+        out = tmp_path / "output"
+        out.mkdir()
+        cmd = ["bambox", "repack", str(out / "plate.3mf")]
+        wrapped = _wrap_docker_command(cmd, "estampo/estampo:orca-2.3.1", str(out))
+        assert wrapped[0] == "docker"
+        assert "run" in wrapped
+        assert "--rm" in wrapped
+        assert "estampo/estampo:orca-2.3.1" in wrapped
+        # The output path should be rewritten to container path
+        assert "/work/output/plate.3mf" in wrapped
+
+    def test_volume_mount(self, tmp_path):
+        out = tmp_path / "output"
+        out.mkdir()
+        cmd = ["echo", "hello"]
+        wrapped = _wrap_docker_command(cmd, "img:latest", str(out))
+        # Find the -v argument
+        v_idx = wrapped.index("-v")
+        mount = wrapped[v_idx + 1]
+        assert mount.endswith(":/work/output")
+        assert str(out.resolve()) in mount
+
+    def test_entrypoint_is_first_cmd_element(self, tmp_path):
+        out = tmp_path / "output"
+        out.mkdir()
+        cmd = ["bambox", "repack", "file.3mf"]
+        wrapped = _wrap_docker_command(cmd, "img:latest", str(out))
+        ep_idx = wrapped.index("--entrypoint")
+        assert wrapped[ep_idx + 1] == "bambox"
 
 
 # ---------------------------------------------------------------------------
@@ -333,6 +439,33 @@ file = "{_posix(stl)}"
         cfg = load_config(toml)
         assert cfg.pipeline.command_stages == {}
         assert cfg.pipeline.stages == ["load", "arrange", "plate"]
+
+    def test_docker_flag_parsed_from_toml(self, tmp_path):
+        toml = tmp_path / "estampo.toml"
+        stl = tmp_path / "cube.stl"
+        stl.touch()
+        toml.write_text(f"""
+[pipeline]
+stages = ["load", "arrange", "plate", "slice", "resolve"]
+
+[plate]
+size = [256, 256]
+
+[slicer]
+engine = "cura"
+
+[resolve]
+command = "cura-p1s resolve {{sliced_dir}}"
+docker = true
+image = "estampo/estampo:cura-5.12.0"
+
+[[parts]]
+file = "{_posix(stl)}"
+""")
+        cfg = load_config(toml)
+        resolve = cfg.pipeline.command_stages["resolve"]
+        assert resolve.docker is True
+        assert resolve.image == "estampo/estampo:cura-5.12.0"
 
     def test_mixed_builtin_and_command_stages(self, tmp_path):
         toml = tmp_path / "estampo.toml"


### PR DESCRIPTION
## Summary

- **#483**: Fix `action/action.yml` to use hardcoded `ghcr.io/estampo/estampo` instead of `ghcr.io/${{ github.repository }}` which breaks for consuming repos
- **#486**: Bundle bambox in both `Dockerfile` and `Dockerfile.cura` so `bambox pack`/`bambox repack` command stages work inside the container without host-side installation
- **#488**: Add `docker` and `image` fields to `CommandStageConfig` — when `docker = true`, the command is wrapped in `docker run` with volume mounts using the slicer's Docker image. If already inside a container, runs locally. Also adds `slicer_image` to `COMMAND_VARIABLES`
- **#490**: Bundle `cura-p1s` in `Dockerfile.cura` and copy P1S printer definitions into CuraEngine's search path (`/opt/cura/definitions/` and `/opt/cura/extruders/`)
- **#491**: Fix release-readiness workflow stale example paths (subsumes PR #492)
- **#486**: Fix `slice.yml` CuraEngine job to run in-container (matching the OrcaSlicer pattern) instead of docker-in-docker

Closes #483, closes #486, closes #488, closes #490, closes #491
Partially addresses #436

## Test plan

- [x] `ruff check` — zero errors
- [x] `ruff format --check` — all formatted
- [x] `mypy src/estampo` — zero errors
- [x] `pytest` — 545 passed, 9 skipped
- [ ] After merge: trigger `publish-docker.yml` rebuild to publish images with bambox/cura-p1s bundled
- [ ] Verify release-readiness nightly passes with new example paths
- [ ] Test `docker = true` command stage from host against rebuilt image

🤖 Generated with [Claude Code](https://claude.com/claude-code)