### PR TITLE
Fix example pack commands and CuraEngine local defs path

### DIFF
--- a/changes/+fix-pack-commands.bugfix
+++ b/changes/+fix-pack-commands.bugfix
@@ -1,0 +1,1 @@
+Fix example pack commands and CuraEngine local definition search path

--- a/examples/multi-filament/estampo.toml
+++ b/examples/multi-filament/estampo.toml
@@ -40,5 +40,5 @@ file = "box_20x20x10.step"
 filament = 2
 
 [pack]
-command = "bambox repack {sliced_3mf} -o {output_dir}/plate.gcode.3mf"
-output = "{output_dir}/plate.gcode.3mf"
+command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
+output = "{output_dir}/plate_sliced.gcode.3mf"

--- a/examples/multi-part/estampo.toml
+++ b/examples/multi-part/estampo.toml
@@ -44,5 +44,5 @@ orient = "upright"
 rotate = [0, 0, 45]
 
 [pack]
-command = "bambox repack {sliced_3mf} -o {output_dir}/plate.gcode.3mf"
-output = "{output_dir}/plate.gcode.3mf"
+command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
+output = "{output_dir}/plate_sliced.gcode.3mf"

--- a/examples/quickstart/estampo.toml
+++ b/examples/quickstart/estampo.toml
@@ -20,5 +20,5 @@ process = "0.20mm Standard @BBL X1C"
 file = "cube_10mm.stl"
 
 [pack]
-command = "bambox repack {sliced_3mf} -o {output_dir}/plate.gcode.3mf"
-output = "{output_dir}/plate.gcode.3mf"
+command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
+output = "{output_dir}/plate_sliced.gcode.3mf"

--- a/src/estampo/commands.py
+++ b/src/estampo/commands.py
@@ -236,12 +236,18 @@ def run_command_stage(
     from estampo import ui
 
     with ui.status(f"Running {stage.name}"):
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except FileNotFoundError:
+            raise EstampoError(
+                f"Command stage '{stage.name}' failed: "
+                f"'{cmd[0]}' not found. Is it installed and on PATH?"
+            ) from None
 
     if result.returncode != 0:
         log.error("Command stage '%s' stderr:\n%s", stage.name, result.stderr)

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import importlib.resources
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -73,6 +74,19 @@ _DATA_DIR = Path(__file__).parent / "data"
 
 # Bundled machine profile JSONs (nozzle/material overrides per printer)
 _BUNDLED_MACHINE_DIR = _DATA_DIR / "cura" / "machine"
+
+
+def _local_defs_path(staging: Path) -> str:
+    """Build the ``-d`` search path for local CuraEngine invocation.
+
+    Includes the staging directory, bundled estampo data, and any system
+    paths from ``CURA_ENGINE_SEARCH_PATH`` (set in Docker images).
+    """
+    parts = [str(staging), str(_DATA_DIR)]
+    env_path = os.environ.get("CURA_ENGINE_SEARCH_PATH", "")
+    if env_path:
+        parts.extend(env_path.split(":"))
+    return ":".join(parts)
 
 
 def _bundled_def_path(name: str) -> Path:
@@ -1025,7 +1039,7 @@ def slice_stl(
     settings = _settings_flags(profile)
 
     if local:
-        defs_path = f"{staging}:{_DATA_DIR}"
+        defs_path = _local_defs_path(staging)
         cura_args = [
             "-d",
             defs_path,
@@ -1108,10 +1122,9 @@ def slice_stl_multi(
             shutil.copy2(stl_path, dest)
 
     if local:
-        defs_path = f"{staging}:{_DATA_DIR}"
         cura_args: list[str] = [
             "-d",
-            defs_path,
+            _local_defs_path(staging),
             "-j",
             str(staging / machine_def),
             "-o",


### PR DESCRIPTION
## Summary

Two bugs preventing E2E pack in release-readiness:

1. **OrcaSlicer examples**: `bambox repack` doesn't have `-o` flag — it modifies in-place. Fixed all three examples (quickstart, multi-part, multi-filament) to use correct syntax and output filename (`plate_sliced.gcode.3mf`)

2. **CuraEngine local mode**: When running `--local` inside the Docker container, CuraEngine couldn't find `fdmprinter.def.json` because the `-d` search path only included the staging dir and estampo's bundled data, not the system definitions at `/opt/cura/definitions`. Added `_local_defs_path()` that includes `CURA_ENGINE_SEARCH_PATH` env var (set in the Docker image).

## Test plan

- [x] All local checks pass
- [ ] Release-readiness OrcaSlicer: quickstart produces `.gcode.3mf`
- [ ] Release-readiness CuraEngine: cura-p1s produces `.gcode.3mf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)