### PR TITLE
Fix Docker command wrapping backslash paths on Windows

### DIFF
--- a/changes/497.bugfix
+++ b/changes/497.bugfix
@@ -1,0 +1,1 @@
+Fix Docker command wrapping producing backslash paths on Windows

--- a/src/estampo/commands.py
+++ b/src/estampo/commands.py
@@ -155,10 +155,11 @@ def _wrap_docker_command(
     abs_output = str(Path(output_dir).resolve())
     container_output = "/work/output"
 
-    # Rewrite host paths to container paths in arguments
+    # Rewrite host paths to container paths in arguments.
+    # Normalise backslashes — the target is always a Linux container.
     rewritten = []
     for arg in cmd:
-        rewritten.append(arg.replace(abs_output, container_output))
+        rewritten.append(arg.replace(abs_output, container_output).replace("\\", "/"))
 
     docker_cmd = [
         "docker",


### PR DESCRIPTION
## Summary
- Normalise backslashes to forward slashes in `_wrap_docker_command` after rewriting host paths to container paths — the target is always a Linux container

Closes #497

## Test plan
- [x] Existing `TestWrapDockerCommand` tests pass on Linux
- [ ] Windows CI matrix passes (was failing on `test_basic_wrapping`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)