### PR TITLE
Add pack/resolve command stages to estampo init

### DIFF
--- a/changes/+init-command-stages.feature
+++ b/changes/+init-command-stages.feature
@@ -1,0 +1,1 @@
+``estampo init`` offers pack/repack command stages for Bambu Lab printers

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -994,6 +994,37 @@ def run_wizard(output: Path | None = None) -> str:
     overrides = _prompt_overrides()
     ui.console.print()
 
+    # --- Step 11: Command stages (pack/resolve) ---
+    command_stages: dict[str, dict[str, str | bool]] = {}
+    is_bambu = _is_bambu_printer(printer_profile or "")
+    if is_bambu:
+        ui.heading("Packaging")
+        ui.info("This printer needs bambox to produce printable .gcode.3mf files.")
+        if ui.prompt_yn("Add a pack stage? (requires: pipx install bambox)", default=True):
+            if engine == "cura":
+                # CuraEngine needs resolve_templates before pack
+                stages.append("resolve_templates")
+                command_stages["resolve_templates"] = {
+                    "command": (
+                        "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"
+                    ),
+                }
+                stages.append("pack")
+                command_stages["pack"] = {
+                    "command": (
+                        "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
+                    ),
+                    "output": "{output_dir}/plate.gcode.3mf",
+                }
+            else:
+                # OrcaSlicer — repack the existing .3mf
+                stages.append("pack")
+                command_stages["pack"] = {
+                    "command": "bambox repack {output_dir}/plate_sliced.gcode.3mf",
+                    "output": "{output_dir}/plate_sliced.gcode.3mf",
+                }
+        ui.console.print()
+
     # --- Build TOML ---
     toml = _build_toml(
         project_name=project_name,
@@ -1008,6 +1039,7 @@ def run_wizard(output: Path | None = None) -> str:
         bed_type=bed_type,
         overrides=overrides,
         machine_overrides=machine_overrides or None,
+        command_stages=command_stages,
     )
 
     # --- Preview and confirm ---
@@ -1036,6 +1068,12 @@ def run_wizard(output: Path | None = None) -> str:
         return run_wizard(output=output)
 
 
+def _is_bambu_printer(printer: str) -> bool:
+    """Check if a printer profile name refers to a Bambu Lab printer."""
+    lower = printer.lower()
+    return any(kw in lower for kw in ("bambu", "bbl", "bambox"))
+
+
 def _build_toml(
     *,
     project_name: str | None = None,
@@ -1050,6 +1088,7 @@ def _build_toml(
     bed_type: str | None = None,
     overrides: dict[str, str] | None = None,
     machine_overrides: dict[str, str] | None = None,
+    command_stages: dict[str, dict[str, str | bool]] | None = None,
 ) -> str:
     """Build a TOML string from wizard answers."""
     lines: list[str] = []
@@ -1137,6 +1176,17 @@ def _build_toml(
         if p.get("filament", 1) != 1:
             lines.append(f"filament = {p['filament']}")
         lines.append("")
+
+    # Command stages
+    if command_stages:
+        for stage_name, stage_cfg in command_stages.items():
+            lines.append(f"[{stage_name}]")
+            for key, val in stage_cfg.items():
+                if isinstance(val, bool):
+                    lines.append(f"{key} = {str(val).lower()}")
+                else:
+                    lines.append(f'{key} = "{val}"')
+            lines.append("")
 
     return "\n".join(lines)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,6 +9,7 @@ from estampo.init import (
     ValidationResult,
     _build_toml,
     _closest_match,
+    _is_bambu_printer,
     _validate_override,
     dump_template,
     validate_config,
@@ -614,10 +615,103 @@ class TestBuildToml:
         assert "orient" not in toml
         assert "filament" not in toml.split("[[parts]]")[1]
 
+    def test_orca_pack_command_stage(self):
+        toml = _build_toml(
+            engine="orca",
+            printer_profile="Bambu Lab P1S 0.4 nozzle",
+            process_profile="0.20mm Standard @BBL X1C",
+            filament_names=["Generic PLA @base"],
+            parts=[{"file": "cube.stl", "copies": 1, "orient": "flat", "filament": 1}],
+            plate_size=(256, 256),
+            slicer_version="2.3.1",
+            stages=["load", "arrange", "plate", "slice", "pack"],
+            command_stages={
+                "pack": {
+                    "command": "bambox repack {output_dir}/plate_sliced.gcode.3mf",
+                    "output": "{output_dir}/plate_sliced.gcode.3mf",
+                },
+            },
+        )
+        assert '"pack"' in toml
+        assert "[pack]" in toml
+        assert "bambox repack" in toml
+        assert 'output = "{output_dir}/plate_sliced.gcode.3mf"' in toml
+
+    def test_cura_resolve_and_pack_stages(self):
+        toml = _build_toml(
+            engine="cura",
+            printer_profile="bambox_p1s",
+            process_profile=None,
+            filament_names=["PLA"],
+            parts=[{"file": "cube.stl", "copies": 1, "orient": "flat", "filament": 1}],
+            plate_size=(256, 256),
+            slicer_version="5.12.0",
+            stages=["load", "arrange", "plate", "slice", "resolve_templates", "pack"],
+            command_stages={
+                "resolve_templates": {
+                    "command": (
+                        "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"
+                    ),
+                },
+                "pack": {
+                    "command": (
+                        "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
+                    ),
+                    "output": "{output_dir}/plate.gcode.3mf",
+                },
+            },
+        )
+        assert '"resolve_templates"' in toml
+        assert '"pack"' in toml
+        assert "[resolve_templates]" in toml
+        assert "cura-p1s resolve" in toml
+        assert "[pack]" in toml
+        assert "bambox pack" in toml
+
+    def test_no_command_stages_when_none(self):
+        toml = _build_toml(
+            engine="orca",
+            printer_profile=None,
+            process_profile=None,
+            filament_names=[],
+            parts=[{"file": "a.stl", "copies": 1, "orient": "flat", "filament": 1}],
+            plate_size=(256, 256),
+            slicer_version=None,
+            stages=["load", "arrange", "plate", "slice"],
+        )
+        assert "[pack]" not in toml
+        assert "[resolve_templates]" not in toml
+
+
+# ---------------------------------------------------------------------------
+# _is_bambu_printer
+# ---------------------------------------------------------------------------
+
+
+class TestIsBambuPrinter:
+    def test_bambu_lab_detected(self):
+        assert _is_bambu_printer("Bambu Lab P1S 0.4 nozzle") is True
+
+    def test_bbl_detected(self):
+        assert _is_bambu_printer("0.20mm Standard @BBL X1C") is True
+
+    def test_bambox_detected(self):
+        assert _is_bambu_printer("bambox_p1s") is True
+
+    def test_other_printer_not_detected(self):
+        assert _is_bambu_printer("Ultimaker 2") is False
+
+    def test_empty_string(self):
+        assert _is_bambu_printer("") is False
+
 
 # ---------------------------------------------------------------------------
 # Wizard (non-interactive, mocked input)
 # ---------------------------------------------------------------------------
+
+
+def _empty_profiles(*args, **kwargs):
+    return {"machine": [], "process": [], "filament": []}, "none"
 
 
 class TestWizard:
@@ -651,11 +745,8 @@ class TestWizard:
             ],
         )
 
-        # Mock discover_profiles to return empty (no slicer installed in CI)
-        monkeypatch.setattr(
-            "estampo.profiles.discover_profiles",
-            lambda engine: {"machine": {}, "process": {}, "filament": {}},
-        )
+        # Mock profile discovery to return empty (no slicer installed in CI)
+        monkeypatch.setattr("estampo.profiles.discover_profile_names", _empty_profiles)
         # Mock slicer version discovery so we don't hit DockerHub
         monkeypatch.setattr("estampo.orca._fetch_available_versions", lambda: [])
         monkeypatch.setattr("estampo.orca._detect_orca_version", lambda: None)
@@ -690,10 +781,7 @@ class TestWizard:
                 "q",  # Write / Go back / Quit
             ],
         )
-        monkeypatch.setattr(
-            "estampo.profiles.discover_profiles",
-            lambda engine: {"machine": {}, "process": {}, "filament": {}},
-        )
+        monkeypatch.setattr("estampo.profiles.discover_profile_names", _empty_profiles)
         # Mock slicer version discovery so we don't hit DockerHub
         monkeypatch.setattr("estampo.orca._fetch_available_versions", lambda: [])
         monkeypatch.setattr("estampo.orca._detect_orca_version", lambda: None)


### PR DESCRIPTION
## Summary
- When the selected printer is a Bambu Lab printer, `estampo init` now offers to add command stages for packaging
- OrcaSlicer: adds `bambox repack` pack stage
- CuraEngine: adds `cura-p1s resolve` + `bambox pack` stages
- Fixes wizard tests to mock `discover_profile_names` instead of the unused `discover_profiles`

Closes #481
Closes #489

## Test plan
- [x] `_is_bambu_printer` detects Bambu/BBL/bambox printer names
- [x] `_build_toml` renders command stage sections correctly
- [x] Wizard tests pass with mocked empty profiles (non-Bambu path)
- [x] Full test suite passes (553 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)