### PR TITLE
Add AI/headless CLI: info, --json, --yes, non-interactive init

### DIFF
--- a/changes/+ai-cli-500.feature
+++ b/changes/+ai-cli-500.feature
@@ -1,0 +1,1 @@
+Add ``estampo info --json``, ``profiles list --json``, ``profiles pin --yes``, and non-interactive ``estampo init --engine --printer --filament --part``

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -1,5 +1,6 @@
 """CLI entry point for estampo."""
 
+import json
 import logging
 import sys
 from pathlib import Path
@@ -346,6 +347,41 @@ def _run_pipeline(
 
 
 @app.command()
+def info(
+    json_flag: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+) -> None:
+    """Show valid config values: stages, engines, orient, bed types, extensions, variables."""
+    from estampo.commands import COMMAND_VARIABLES
+    from estampo.config import SUPPORTED_EXTENSIONS, VALID_ENGINES, VALID_ORIENTS
+    from estampo.init import BED_TYPES
+    from estampo.pipeline import STAGE_OUTPUTS
+
+    data = {
+        "stages": sorted(STAGE_OUTPUTS.keys()),
+        "engines": list(VALID_ENGINES),
+        "orient_values": sorted(VALID_ORIENTS),
+        "bed_types": BED_TYPES,
+        "file_extensions": sorted(SUPPORTED_EXTENSIONS),
+        "command_variables": COMMAND_VARIABLES,
+    }
+
+    if json_flag:
+        print(json.dumps(data, indent=2))
+    else:
+        from estampo import ui
+
+        for key, val in data.items():
+            ui.heading(key.replace("_", " ").title())
+            if isinstance(val, dict):
+                for k, v in val.items():
+                    ui.console.print(f"  {{{k}}}  — {v}")
+            elif isinstance(val, list):
+                for item in val:
+                    ui.console.print(f"  {item}")
+            ui.console.print()
+
+
+@app.command()
 def init(
     template: Annotated[
         bool, typer.Option("--template", help="Dump a commented template to stdout (no wizard)")
@@ -358,40 +394,86 @@ def init(
         Path | None,
         typer.Option("-o", "--output", help="Output file path (default: ./estampo.toml)"),
     ] = None,
+    engine: Annotated[
+        str | None,
+        typer.Option("--engine", help="Slicer engine: orca or cura (non-interactive)"),
+    ] = None,
+    printer: Annotated[
+        str | None,
+        typer.Option("--printer", help="Printer profile name (non-interactive)"),
+    ] = None,
+    process: Annotated[
+        str | None,
+        typer.Option("--process", help="Process/quality profile name (non-interactive)"),
+    ] = None,
+    filament: Annotated[
+        list[str] | None,
+        typer.Option("--filament", help="Filament profile (repeatable, non-interactive)"),
+    ] = None,
+    part: Annotated[
+        list[str] | None,
+        typer.Option("--part", help="Part file path (repeatable, non-interactive)"),
+    ] = None,
     verbose: Annotated[bool, typer.Option("-v", "--verbose", help="Enable debug logging")] = False,
 ) -> None:
     """Create a new estampo.toml config file.
 
-    The interactive wizard requires a Unix terminal (Linux, macOS, or WSL).
+    Non-interactive mode: pass --engine, --printer, --filament, and --part
+    to generate a config without the wizard. Use --process for OrcaSlicer.
+
+    Interactive wizard: requires a Unix terminal (Linux, macOS, or WSL).
     On Windows, use --template to generate a config file manually.
     Use --from-3mf to extract settings from an OrcaSlicer project.
     """
     _setup_logging(verbose)
 
-    if from_3mf:
+    # Non-interactive mode: all required params provided
+    if engine and filament and part:
+        from estampo.init import build_config_toml
+
+        toml = build_config_toml(
+            engine=engine,
+            printer=printer,
+            process=process,
+            filaments=filament,
+            parts=part,
+        )
+        _write_or_print(toml, output)
+    elif from_3mf:
         from estampo.init import extract_from_3mf
 
         toml = extract_from_3mf(from_3mf)
-        dest = output or Path("estampo.toml")
-        if dest.exists():
-            from estampo import ui
-
-            ui.warn(f"{dest} already exists — printing to stdout")
-            print(toml, end="")
-        else:
-            from estampo import ui
-
-            dest.write_text(toml)
-            ui.success(f"Wrote {dest}")
-            ui.info("Review the file and add your [[parts]] entries.")
+        _write_or_print(toml, output)
     elif template:
         from estampo.init import dump_template
 
         print(dump_template(), end="")
     else:
+        if engine or filament or part:
+            from estampo import ui
+
+            ui.warn(
+                "Non-interactive init requires --engine, --filament, and --part. "
+                "Falling back to wizard."
+            )
         from estampo.init import run_wizard
 
         run_wizard(output=output)
+
+
+def _write_or_print(toml: str, output: Path | None) -> None:
+    """Write TOML to file or stdout."""
+    dest = output or Path("estampo.toml")
+    if dest.exists():
+        from estampo import ui
+
+        ui.warn(f"{dest} already exists — printing to stdout")
+        print(toml, end="")
+    else:
+        from estampo import ui
+
+        dest.write_text(toml)
+        ui.success(f"Wrote {dest}")
 
 
 @app.command()
@@ -430,6 +512,7 @@ def profiles_list(
     category: Annotated[
         str | None, typer.Option(help="Filter by category (machine, process, filament)")
     ] = None,
+    json_flag: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
     verbose: Annotated[bool, typer.Option("-v", "--verbose", help="Enable debug logging")] = False,
 ) -> None:
     """List available profiles."""
@@ -437,13 +520,24 @@ def profiles_list(
     from estampo.profiles import (
         _INLINE_ENGINES,
         CATEGORIES,
+        discover_profile_names,
         discover_profiles,
     )
 
     if engine in _INLINE_ENGINES:
-        from estampo import ui
+        if json_flag:
+            print(json.dumps({"profiles": {}, "source": "inline", "engine": engine}, indent=2))
+        else:
+            from estampo import ui
 
-        ui.info(f"Engine '{engine}' uses inline settings — no extractable profiles.")
+            ui.info(f"Engine '{engine}' uses inline settings — no extractable profiles.")
+        raise typer.Exit(0)
+
+    if json_flag:
+        names, source = discover_profile_names(engine)
+        if category:
+            names = {category: names.get(category, [])}
+        print(json.dumps({"profiles": names, "source": source, "engine": engine}, indent=2))
         raise typer.Exit(0)
 
     from estampo import ui
@@ -451,15 +545,19 @@ def profiles_list(
     profiles = discover_profiles(engine)
     categories = [category] if category else list(CATEGORIES)
     for cat in categories:
-        names = profiles.get(cat, {})
-        ui.console.print(f"\n{cat} ({len(names)} profiles):")
-        for name in names:
-            ui.console.print(f"  {name}")
+        cat_profiles = profiles.get(cat, {})
+        ui.console.print(f"\n{cat} ({len(cat_profiles)} profiles):")
+        for profile_name in cat_profiles:
+            ui.console.print(f"  {profile_name}")
 
 
 @profiles_app.command("pin")
 def profiles_pin(
     config: Annotated[Path | None, typer.Argument(help="Path to config file")] = None,
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", "--force", help="Skip confirmation prompts (auto-overwrite)"),
+    ] = False,
     verbose: Annotated[bool, typer.Option("-v", "--verbose", help="Enable debug logging")] = False,
 ) -> None:
     """Pin profiles from config into local profiles/ dir.
@@ -488,17 +586,22 @@ def profiles_pin(
     target = cfg.base_dir / profiles_dir
     engine_subdir = target / cfg.slicer.engine
     if engine_subdir.exists() and any(engine_subdir.iterdir()):
-        ui.warn(f"Pinned profiles already exist in '{profiles_dir}/{cfg.slicer.engine}/'.")
-        choice = input("  [o]verwrite, use [d]ifferent directory, or [c]ancel? ").strip().lower()
-        if choice.startswith("d"):
-            profiles_dir = input("  New directory name: ").strip()
-            if not profiles_dir:
+        if yes:
+            ui.info(f"Overwriting pinned profiles in '{profiles_dir}/{cfg.slicer.engine}/'.")
+        else:
+            ui.warn(f"Pinned profiles already exist in '{profiles_dir}/{cfg.slicer.engine}/'.")
+            choice = (
+                input("  [o]verwrite, use [d]ifferent directory, or [c]ancel? ").strip().lower()
+            )
+            if choice.startswith("d"):
+                profiles_dir = input("  New directory name: ").strip()
+                if not profiles_dir:
+                    ui.info("Cancelled.")
+                    raise typer.Exit(1)
+            elif choice.startswith("c"):
                 ui.info("Cancelled.")
-                raise typer.Exit(1)
-        elif choice.startswith("c"):
-            ui.info("Cancelled.")
-            raise typer.Exit(0)
-        # else: overwrite
+                raise typer.Exit(0)
+            # else: overwrite
 
     active = cfg.slicer.active
     orca = cfg.slicer.orca if cfg.slicer.engine == "orca" else None
@@ -523,16 +626,20 @@ def profiles_pin(
     if existing_dir == profiles_dir:
         pass  # already correct
     elif existing_dir is not None and existing_dir != profiles_dir:
-        # Different value exists — ask
-        update = (
-            input(
-                f'\n  estampo.toml has profiles_dir = "{existing_dir}". '
-                f'Update to "{profiles_dir}"? [y/n] '
+        # Different value exists — ask (or auto-accept with --yes)
+        if yes:
+            do_update = True
+        else:
+            update = (
+                input(
+                    f'\n  estampo.toml has profiles_dir = "{existing_dir}". '
+                    f'Update to "{profiles_dir}"? [y/n] '
+                )
+                .strip()
+                .lower()
             )
-            .strip()
-            .lower()
-        )
-        if update.startswith("y"):
+            do_update = update.startswith("y")
+        if do_update:
             toml_text = toml_text.replace(
                 f'profiles_dir = "{existing_dir}"',
                 f'profiles_dir = "{profiles_dir}"',

--- a/src/estampo/config.py
+++ b/src/estampo/config.py
@@ -14,6 +14,8 @@ from estampo.constants import DEFAULT_PLATE_SIZE
 log = logging.getLogger(__name__)
 
 VALID_ORIENTS = {"flat", "upright", "side", "upside-down"}
+VALID_ENGINES = ("orca", "cura")
+SUPPORTED_EXTENSIONS = {".stl", ".3mf", ".step", ".stp", ".obj"}
 
 
 @dataclass
@@ -280,7 +282,7 @@ def load_config(path: Path) -> EstampoConfig:
     # Slicer config
     slicer_raw = raw.get("slicer", {})
     engine = slicer_raw.get("engine", "orca")
-    if engine not in ("orca", "cura"):
+    if engine not in VALID_ENGINES:
         raise EstampoError(f"slicer.engine must be 'orca' or 'cura', got '{engine}'")
 
     # Engine-namespaced sections: [slicer.orca] and/or [slicer.cura]

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -7,9 +7,11 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from estampo.config import DEFAULT_STAGES
+from estampo.config import DEFAULT_STAGES, SUPPORTED_EXTENSIONS
 
 log = logging.getLogger(__name__)
+
+BED_TYPES = ["Cool Plate", "Engineering Plate", "High Temp Plate", "Textured PEI Plate"]
 
 # ---------------------------------------------------------------------------
 # Template
@@ -309,7 +311,6 @@ def validate_config(path: Path) -> ValidationResult:
 
     # Check part files: readability, extension, duplicates
     # (existence and orient are already hard errors in load_config)
-    _SUPPORTED_EXTENSIONS = {".stl", ".3mf", ".step", ".stp", ".obj"}
     seen_files: set[str] = set()
     parts_ok = True
     for i, part in enumerate(cfg.parts):
@@ -322,10 +323,10 @@ def validate_config(path: Path) -> ValidationResult:
 
         # Check file extension
         ext = part_path.suffix.lower()
-        if ext and ext not in _SUPPORTED_EXTENSIONS:
+        if ext and ext not in SUPPORTED_EXTENSIONS:
             warnings.append(
                 f"parts[{i}].file has unsupported extension '{ext}' "
-                f"— expected one of {sorted(_SUPPORTED_EXTENSIONS)}"
+                f"— expected one of {sorted(SUPPORTED_EXTENSIONS)}"
             )
             parts_ok = False
 
@@ -948,7 +949,6 @@ def run_wizard(output: Path | None = None) -> str:
 
     # --- Step 8: Bed type ---
     ui.heading("Bed Type")
-    BED_TYPES = ["Cool Plate", "Engineering Plate", "High Temp Plate", "Textured PEI Plate"]
     ui.info("Select bed/plate type (affects filament compatibility):")
     existing_bed = existing.bed_type if existing else None
     bed_default = ""
@@ -1189,6 +1189,35 @@ def _build_toml(
             lines.append("")
 
     return "\n".join(lines)
+
+
+def build_config_toml(
+    *,
+    engine: str,
+    printer: str | None,
+    process: str | None = None,
+    filaments: list[str],
+    parts: list[str],
+    plate_size: tuple[int, int] = (256, 256),
+    slicer_version: str | None = None,
+    stages: list[str] | None = None,
+    bed_type: str | None = None,
+    name: str | None = None,
+) -> str:
+    """Build estampo.toml content from explicit parameters (non-interactive)."""
+    part_dicts = [{"file": p, "copies": 1, "orient": "flat", "filament": 1} for p in parts]
+    return _build_toml(
+        project_name=name,
+        engine=engine,
+        printer_profile=printer,
+        process_profile=process,
+        filament_names=filaments,
+        parts=part_dicts,
+        plate_size=plate_size,
+        slicer_version=slicer_version,
+        stages=stages or list(DEFAULT_STAGES),
+        bed_type=bed_type,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -763,6 +763,151 @@ def test_init_template(capsys):
 # --- validate ---
 
 
+def test_init_non_interactive(tmp_path, capsys):
+    """init with --engine, --filament, --part should generate TOML without wizard."""
+    dest = tmp_path / "estampo.toml"
+    main(
+        [
+            "init",
+            "--engine",
+            "orca",
+            "--printer",
+            "Bambu Lab P1S 0.4 nozzle",
+            "--process",
+            "0.20mm Standard @BBL X1C",
+            "--filament",
+            "Generic PLA @base",
+            "--part",
+            "cube.stl",
+            "--part",
+            "bracket.stl",
+            "-o",
+            str(dest),
+        ]
+    )
+    toml = dest.read_text()
+    assert 'engine = "orca"' in toml
+    assert 'printer = "Bambu Lab P1S 0.4 nozzle"' in toml
+    assert 'process = "0.20mm Standard @BBL X1C"' in toml
+    assert "Generic PLA @base" in toml
+    assert 'file = "cube.stl"' in toml
+    assert 'file = "bracket.stl"' in toml
+
+
+def test_init_non_interactive_partial_falls_back_to_wizard_warning(capsys):
+    """init with only some non-interactive params should warn about fallback."""
+    # This will fall back to wizard which will fail without a terminal,
+    # but we should see the warning first
+    with pytest.raises((SystemExit, Exception)):
+        main(["init", "--engine", "orca", "--part", "cube.stl"])
+    out = capsys.readouterr().out
+    assert "Non-interactive init requires" in out
+
+
+# --- info ---
+
+
+def test_info_json(capsys):
+    """info --json should output valid JSON with expected keys."""
+    import json as json_mod
+
+    main(["info", "--json"])
+    out = capsys.readouterr().out
+    data = json_mod.loads(out)
+    assert "stages" in data
+    assert "engines" in data
+    assert "orient_values" in data
+    assert "bed_types" in data
+    assert "file_extensions" in data
+    assert "command_variables" in data
+    assert "orca" in data["engines"]
+    assert "cura" in data["engines"]
+    assert "flat" in data["orient_values"]
+    assert ".stl" in data["file_extensions"]
+    assert "output_dir" in data["command_variables"]
+
+
+def test_info_human(capsys):
+    """info without --json should output human-readable text."""
+    main(["info"])
+    out = capsys.readouterr().out
+    assert "Stages" in out
+    assert "Engines" in out
+    assert "flat" in out
+
+
+# --- profiles list --json ---
+
+
+@patch("estampo.profiles.discover_profile_names")
+def test_profiles_list_json(mock_discover, capsys):
+    """profiles list --json should output valid JSON."""
+    import json as json_mod
+
+    mock_discover.return_value = (
+        {"machine": ["Bambu P1S"], "process": ["0.20mm Standard"], "filament": ["PLA"]},
+        "bundled",
+    )
+    main(["profiles", "list", "--engine", "orca", "--json"])
+    out = capsys.readouterr().out
+    data = json_mod.loads(out)
+    assert data["source"] == "bundled"
+    assert data["engine"] == "orca"
+    assert "Bambu P1S" in data["profiles"]["machine"]
+
+
+@patch("estampo.profiles.discover_profile_names")
+def test_profiles_list_json_with_category(mock_discover, capsys):
+    """profiles list --json --category should filter."""
+    import json as json_mod
+
+    mock_discover.return_value = (
+        {"machine": ["P1S"], "process": ["Standard"], "filament": ["PLA"]},
+        "bundled",
+    )
+    main(["profiles", "list", "--engine", "orca", "--category", "machine", "--json"])
+    out = capsys.readouterr().out
+    data = json_mod.loads(out)
+    assert "machine" in data["profiles"]
+    assert "process" not in data["profiles"]
+
+
+# --- profiles pin --yes ---
+
+
+@patch("estampo.profiles.pin_profiles", return_value=[Path("/a/b.json")])
+@patch("estampo.cli.load_config")
+def test_profiles_pin_yes_skips_prompts(mock_load, mock_pin, tmp_path, capsys):
+    """profiles pin --yes should overwrite without prompting."""
+    config = tmp_path / "estampo.toml"
+    config.write_text("[slicer]\n")
+    (tmp_path / "profiles" / "orca").mkdir(parents=True)
+    (tmp_path / "profiles" / "orca" / "old.json").write_text("{}")
+    mock_load.return_value = _mock_pin_cfg(tmp_path)
+
+    # No input() mock needed — --yes should skip prompts
+    main(["profiles", "pin", str(config), "--yes"])
+    out = capsys.readouterr().out
+    assert "Pinned 1 profile(s)" in out
+    mock_pin.assert_called_once()
+
+
+@patch("estampo.profiles.pin_profiles", return_value=[Path("/a/b.json")])
+@patch("estampo.cli.load_config")
+def test_profiles_pin_yes_updates_toml(mock_load, mock_pin, tmp_path, capsys):
+    """profiles pin --yes should auto-accept TOML updates."""
+    config = tmp_path / "estampo.toml"
+    config.write_text('[slicer]\nengine = "orca"\nprofiles_dir = "old"\n')
+    mock_load.return_value = _mock_pin_cfg(tmp_path, profiles_dir="new")
+
+    main(["profiles", "pin", str(config), "--yes"])
+    updated = config.read_text()
+    assert 'profiles_dir = "new"' in updated
+
+
+# --- validate ---
+
+
 def test_validate_missing_config(tmp_path):
     """validate should fail when config file doesn't exist."""
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary

- `estampo info --json` — dump valid stages, engines, orient values, bed types, file extensions, and command stage variables as JSON
- `estampo profiles list --json` — structured JSON output of available profiles
- `estampo profiles pin --yes` — skip confirmation prompts for headless/CI use
- `estampo init --engine orca --printer "..." --filament "..." --part cube.stl` — generate config without the interactive wizard (`--part` is repeatable)

These features let AI assistants and CI scripts discover valid config values and generate configs programmatically, without needing an interactive terminal.

Ref #500

## Test plan
- [x] `estampo info --json` outputs valid JSON with all expected keys
- [x] `estampo info` (no --json) outputs human-readable text
- [x] `profiles list --json` outputs profiles with source and engine
- [x] `profiles list --json --category` filters correctly
- [x] `profiles pin --yes` skips overwrite prompt
- [x] `profiles pin --yes` auto-accepts TOML updates
- [x] Non-interactive init generates valid TOML with all params
- [x] Partial non-interactive params warn and fall back to wizard
- [x] All 561 existing + new tests pass
- [x] mypy, ruff lint, ruff format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)