### PR TITLE
Validate overrides: cross-engine detection and did-you-mean suggestions

### DIFF
--- a/changes/503.feature
+++ b/changes/503.feature
@@ -1,0 +1,1 @@
+Validate slicer override keys against full settings lists with cross-engine detection and "did you mean?" suggestions

--- a/src/estampo/data/cura-settings.json
+++ b/src/estampo/data/cura-settings.json
@@ -1,0 +1,6959 @@
+{
+  "engine": "cura",
+  "version": "5.12.0",
+  "source": "fdmprinter.def.json (base definition for all CuraEngine printers)",
+  "note": "These are the settings available in [slicer.cura.overrides]. Use the 'key' field as the override key.",
+  "settings_count": 711,
+  "settings": [
+    {
+      "key": "build_volume_fan_nr",
+      "label": "Build volume fan number",
+      "description": "The number of the fan that cools the build volume. If this is set to 0, it's means that there is no build volume fan",
+      "type": "int",
+      "category": "Machine",
+      "default": 0,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "machine_name",
+      "label": "Machine Type",
+      "description": "The name of your 3D printer model.",
+      "type": "str",
+      "category": "Machine",
+      "default": "Unknown"
+    },
+    {
+      "key": "machine_show_variants",
+      "label": "Show Machine Variants",
+      "description": "Whether to show the different variants of this machine, which are described in separate json files.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_start_gcode",
+      "label": "Start G-code",
+      "description": "G-code commands to be executed at the very start - separated by \\n.",
+      "type": "str",
+      "category": "Machine",
+      "default": "G28 ;Home\nG1 Z15.0 F6000 ;Move the platform down 15mm\n;Prime the extruder\nG92 E0\nG1 F200 E3\nG92 E0"
+    },
+    {
+      "key": "machine_end_gcode",
+      "label": "End G-code",
+      "description": "G-code commands to be executed at the very end - separated by \\n.",
+      "type": "str",
+      "category": "Machine",
+      "default": "M104 S0\nM140 S0\n;Retract the filament\nG92 E1\nG1 E-1 F300\nG28 X0 Y0\nM84"
+    },
+    {
+      "key": "material_guid",
+      "label": "Material GUID",
+      "description": "GUID of the material. This is set automatically.",
+      "type": "str",
+      "category": "Machine",
+      "default": ""
+    },
+    {
+      "key": "material_type",
+      "label": "Material Type",
+      "description": "The type of material used.",
+      "type": "str",
+      "category": "Machine",
+      "default": ""
+    },
+    {
+      "key": "material_brand",
+      "label": "Material Brand",
+      "description": "The brand of material used.",
+      "type": "str",
+      "category": "Machine",
+      "default": ""
+    },
+    {
+      "key": "material_diameter",
+      "label": "Diameter",
+      "description": "Adjusts the diameter of the filament used. Match this value with the diameter of the used filament.",
+      "type": "float",
+      "category": "Machine",
+      "default": 2.85,
+      "unit": "mm",
+      "min": "0.0001"
+    },
+    {
+      "key": "material_bed_temp_wait",
+      "label": "Wait for Build Plate Heatup",
+      "description": "Whether to insert a command to wait until the build plate temperature is reached at the start.",
+      "type": "bool",
+      "category": "Machine",
+      "default": true
+    },
+    {
+      "key": "material_print_temp_wait",
+      "label": "Wait for Nozzle Heatup",
+      "description": "Whether to wait until the nozzle temperature is reached at the start.",
+      "type": "bool",
+      "category": "Machine",
+      "default": true
+    },
+    {
+      "key": "material_print_temp_prepend",
+      "label": "Include Material Temperatures",
+      "description": "Whether to include nozzle temperature commands at the start of the gcode. When the start_gcode already contains nozzle temperature commands Cura frontend will automatically disable this setting.",
+      "type": "bool",
+      "category": "Machine",
+      "default": true
+    },
+    {
+      "key": "material_bed_temp_prepend",
+      "label": "Include Build Plate Temperature",
+      "description": "Whether to include build plate temperature commands at the start of the gcode. When the start_gcode already contains build plate temperature commands Cura frontend will automatically disable this setting.",
+      "type": "bool",
+      "category": "Machine",
+      "default": true
+    },
+    {
+      "key": "machine_width",
+      "label": "Machine Width",
+      "description": "The width (X-direction) of the printable area.",
+      "type": "float",
+      "category": "Machine",
+      "default": 100,
+      "min": "0.001",
+      "max": "2000000"
+    },
+    {
+      "key": "machine_depth",
+      "label": "Machine Depth",
+      "description": "The depth (Y-direction) of the printable area.",
+      "type": "float",
+      "category": "Machine",
+      "default": 100,
+      "min": "0.001",
+      "max": "2000000"
+    },
+    {
+      "key": "machine_height",
+      "label": "Machine Height",
+      "description": "The height (Z-direction) of the printable area.",
+      "type": "float",
+      "category": "Machine",
+      "default": 100
+    },
+    {
+      "key": "machine_shape",
+      "label": "Build Plate Shape",
+      "description": "The shape of the build plate without taking unprintable areas into account.",
+      "type": "enum",
+      "category": "Machine",
+      "default": "rectangular",
+      "options": {
+        "rectangular": "Rectangular",
+        "elliptic": "Elliptic"
+      }
+    },
+    {
+      "key": "machine_buildplate_type",
+      "label": "Build Plate Type",
+      "description": "The type of build plate installed on the printer.",
+      "type": "enum",
+      "category": "Machine",
+      "default": "glass",
+      "options": {
+        "glass": "Glass",
+        "aluminum": "Aluminum"
+      }
+    },
+    {
+      "key": "machine_heated_bed",
+      "label": "Has Heated Build Plate",
+      "description": "Whether the machine has a heated build plate present.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_heated_build_volume",
+      "label": "Has Build Volume Temperature Stabilization",
+      "description": "Whether the machine is able to stabilize the build volume temperature.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_always_write_active_tool",
+      "label": "Always Write Active Tool",
+      "description": "Write active tool after sending temp commands to inactive tool. Required for Dual Extruder printing with Smoothie or other firmware with modal tool commands.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_center_is_zero",
+      "label": "Is Center Origin",
+      "description": "Whether the X/Y coordinates of the zero position of the printer is at the center of the printable area.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_extruder_count",
+      "label": "Number of Extruders",
+      "description": "Number of extruder trains. An extruder train is the combination of a feeder, bowden tube, and nozzle.",
+      "type": "int",
+      "category": "Machine",
+      "default": 1,
+      "min": "1",
+      "max": "16"
+    },
+    {
+      "key": "extruders_enabled_count",
+      "label": "Number of Extruders That Are Enabled",
+      "description": "Number of extruder trains that are enabled; automatically set in software",
+      "type": "int",
+      "category": "Machine",
+      "default": 1,
+      "min": "1",
+      "max": "16"
+    },
+    {
+      "key": "machine_nozzle_tip_outer_diameter",
+      "label": "Outer Nozzle Diameter",
+      "description": "The outer diameter of the tip of the nozzle.",
+      "type": "float",
+      "category": "Machine",
+      "default": 1,
+      "unit": "mm"
+    },
+    {
+      "key": "machine_nozzle_expansion_angle",
+      "label": "Nozzle Angle",
+      "description": "The angle between the horizontal plane and the conical part right above the tip of the nozzle.",
+      "type": "int",
+      "category": "Machine",
+      "default": 45,
+      "unit": "\u00b0",
+      "min": "1",
+      "max": "89"
+    },
+    {
+      "key": "machine_heat_zone_length",
+      "label": "Heat Zone Length",
+      "description": "The distance from the tip of the nozzle in which heat from the nozzle is transferred to the filament.",
+      "type": "float",
+      "category": "Machine",
+      "default": 16,
+      "unit": "mm"
+    },
+    {
+      "key": "machine_nozzle_temp_enabled",
+      "label": "Enable Nozzle Temperature Control",
+      "description": "Whether to control temperature from Cura. Turn this off to control nozzle temperature from outside of Cura.",
+      "type": "bool",
+      "category": "Machine",
+      "default": true
+    },
+    {
+      "key": "machine_nozzle_heat_up_speed",
+      "label": "Heat Up Speed",
+      "description": "The speed (\u00b0C/s) by which the nozzle heats up averaged over the window of normal printing temperatures and the standby temperature.",
+      "type": "float",
+      "category": "Machine",
+      "default": 2.0,
+      "unit": "\u00b0C/s"
+    },
+    {
+      "key": "machine_nozzle_cool_down_speed",
+      "label": "Cool Down Speed",
+      "description": "The speed (\u00b0C/s) by which the nozzle cools down averaged over the window of normal printing temperatures and the standby temperature.",
+      "type": "float",
+      "category": "Machine",
+      "default": 2.0,
+      "unit": "\u00b0C/s"
+    },
+    {
+      "key": "machine_min_cool_heat_time_window",
+      "label": "Minimal Time Standby Temperature",
+      "description": "The minimal time an extruder has to be inactive before the nozzle is cooled. Only when an extruder is not used for longer than this time will it be allowed to cool down to the standby temperature.",
+      "type": "float",
+      "category": "Machine",
+      "default": 50.0,
+      "unit": "s"
+    },
+    {
+      "key": "machine_gcode_flavor",
+      "label": "G-code Flavor",
+      "description": "The type of g-code to be generated.",
+      "type": "enum",
+      "category": "Machine",
+      "default": "RepRap (Marlin/Sprinter)",
+      "options": {
+        "RepRap (Marlin/Sprinter)": "Marlin",
+        "RepRap (Volumetric)": "Marlin (Volumetric)",
+        "RepRap (RepRap)": "RepRap",
+        "UltiGCode": "Ultimaker 2",
+        "Griffin": "Griffin",
+        "Cheetah": "Griffin+Cheetah",
+        "Makerbot": "Makerbot",
+        "BFB": "Bits from Bytes",
+        "MACH3": "Mach3",
+        "Repetier": "Repetier",
+        "BambuLab": "BambuLab"
+      }
+    },
+    {
+      "key": "machine_firmware_retract",
+      "label": "Firmware Retraction",
+      "description": "Whether to use firmware retract commands (G10/G11) instead of using the E property in G1 commands to retract the material.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_extruders_share_heater",
+      "label": "Extruders Share Heater",
+      "description": "Whether the extruders share a single heater rather than each extruder having its own heater.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_extruders_share_nozzle",
+      "label": "Extruders Share Nozzle",
+      "description": "Whether the extruders share a single nozzle rather than each extruder having its own nozzle. When set to true, it is expected that the printer-start gcode script properly sets up all extruders in an initial retraction state that is known and mutually compatible (either zero or one filament not retracted); in that case the initial retraction status is described, per extruder, by the 'machine_extruders_shared_nozzle_initial_retraction' parameter.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_extruders_shared_nozzle_initial_retraction",
+      "label": "Shared Nozzle Initial Retraction",
+      "description": "How much the filament of each extruder is assumed to have been retracted from the shared nozzle tip at the completion of the printer-start gcode script; the value should be equal to or greater than the length of the common part of the nozzle's ducts.",
+      "type": "float",
+      "category": "Machine",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "machine_disallowed_areas",
+      "label": "Disallowed Areas",
+      "description": "A list of polygons with areas the print head is not allowed to enter.",
+      "type": "polygons",
+      "category": "Machine",
+      "default": []
+    },
+    {
+      "key": "nozzle_disallowed_areas",
+      "label": "Nozzle Disallowed Areas",
+      "description": "A list of polygons with areas the nozzle is not allowed to enter.",
+      "type": "polygons",
+      "category": "Machine",
+      "default": []
+    },
+    {
+      "key": "machine_head_with_fans_polygon",
+      "label": "Machine Head & Fan Polygon",
+      "description": "The dimensions of the print head used to determine 'Safe Model Distance' when printing 'One at a Time'. These numbers relate to the centerline of the first extruder nozzle. Left of the nozzle is 'X Min' and must be negative.  Rear of the nozzle is 'Y Min' and must be negative.  X Max (right) and Y Max (front) are positive numbers.  Gantry height is the dimension from the build plate to the X gantry beam.",
+      "type": "polygon",
+      "category": "Machine",
+      "default": [
+        [
+          -20,
+          10
+        ],
+        [
+          10,
+          10
+        ],
+        [
+          10,
+          -10
+        ],
+        [
+          -20,
+          -10
+        ]
+      ]
+    },
+    {
+      "key": "gantry_height",
+      "label": "Gantry Height",
+      "description": "The height difference between the tip of the nozzle and the gantry system (X and Y axes).",
+      "type": "float",
+      "category": "Machine",
+      "default": 99999999999
+    },
+    {
+      "key": "machine_time_estimation_factor",
+      "label": "Print Time Estimation Factor",
+      "description": "Multiplier for adjusting print time estimates. 100% shows original estimate. Higher values indicate longer actual print times.",
+      "type": "float",
+      "category": "Machine",
+      "default": 100,
+      "unit": "%",
+      "min": 1,
+      "max": 1000
+    },
+    {
+      "key": "machine_nozzle_id",
+      "label": "Nozzle ID",
+      "description": "The nozzle ID for an extruder train, such as \"AA 0.4\" and \"BB 0.8\".",
+      "type": "str",
+      "category": "Machine",
+      "default": "unknown"
+    },
+    {
+      "key": "machine_nozzle_size",
+      "label": "Nozzle Diameter",
+      "description": "The inner diameter of the nozzle. Change this setting when using a non-standard nozzle size.",
+      "type": "float",
+      "category": "Machine",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "machine_use_extruder_offset_to_offset_coords",
+      "label": "Offset with Extruder",
+      "description": "Apply the extruder offset to the coordinate system. Affects all extruders.",
+      "type": "bool",
+      "category": "Machine",
+      "default": true
+    },
+    {
+      "key": "machine_start_gcode_first",
+      "label": "Start GCode must be first",
+      "description": "This setting controls if the start-gcode is forced to always be the first g-code. Without this option other g-code, such as a T0 can be inserted before the start g-code.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "extruder_prime_pos_z",
+      "label": "Extruder Prime Z Position",
+      "description": "The Z coordinate of the position where the nozzle primes at the start of printing.",
+      "type": "float",
+      "category": "Machine",
+      "default": 0,
+      "unit": "mm",
+      "max": "machine_height"
+    },
+    {
+      "key": "extruder_prime_pos_abs",
+      "label": "Absolute Extruder Prime Position",
+      "description": "Make the extruder prime position absolute rather than relative to the last-known location of the head.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_max_feedrate_x",
+      "label": "Maximum Speed X",
+      "description": "The maximum speed for the motor of the X-direction.",
+      "type": "float",
+      "category": "Machine",
+      "default": 299792458000,
+      "unit": "mm/s"
+    },
+    {
+      "key": "machine_max_feedrate_y",
+      "label": "Maximum Speed Y",
+      "description": "The maximum speed for the motor of the Y-direction.",
+      "type": "float",
+      "category": "Machine",
+      "default": 299792458000,
+      "unit": "mm/s"
+    },
+    {
+      "key": "machine_max_feedrate_z",
+      "label": "Maximum Speed Z",
+      "description": "The maximum speed for the motor of the Z-direction.",
+      "type": "float",
+      "category": "Machine",
+      "default": 299792458000,
+      "unit": "mm/s"
+    },
+    {
+      "key": "machine_max_feedrate_e",
+      "label": "Maximum Speed E",
+      "description": "The maximum speed of the filament.",
+      "type": "float",
+      "category": "Machine",
+      "default": 299792458000,
+      "unit": "mm/s"
+    },
+    {
+      "key": "machine_max_acceleration_x",
+      "label": "Maximum Acceleration X",
+      "description": "Maximum acceleration for the motor of the X-direction",
+      "type": "float",
+      "category": "Machine",
+      "default": 9000,
+      "unit": "mm/s\u00b2"
+    },
+    {
+      "key": "machine_max_acceleration_y",
+      "label": "Maximum Acceleration Y",
+      "description": "Maximum acceleration for the motor of the Y-direction.",
+      "type": "float",
+      "category": "Machine",
+      "default": 9000,
+      "unit": "mm/s\u00b2"
+    },
+    {
+      "key": "machine_max_acceleration_z",
+      "label": "Maximum Acceleration Z",
+      "description": "Maximum acceleration for the motor of the Z-direction.",
+      "type": "float",
+      "category": "Machine",
+      "default": 100,
+      "unit": "mm/s\u00b2"
+    },
+    {
+      "key": "machine_max_acceleration_e",
+      "label": "Maximum Filament Acceleration",
+      "description": "Maximum acceleration for the motor of the filament.",
+      "type": "float",
+      "category": "Machine",
+      "default": 10000,
+      "unit": "mm/s\u00b2"
+    },
+    {
+      "key": "machine_acceleration",
+      "label": "Default Acceleration",
+      "description": "The default acceleration of print head movement.",
+      "type": "float",
+      "category": "Machine",
+      "default": 4000,
+      "unit": "mm/s\u00b2"
+    },
+    {
+      "key": "machine_max_jerk_xy",
+      "label": "Default X-Y Jerk",
+      "description": "Default jerk for movement in the horizontal plane.",
+      "type": "float",
+      "category": "Machine",
+      "default": 20.0,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "machine_max_jerk_z",
+      "label": "Default Z Jerk",
+      "description": "Default jerk for the motor of the Z-direction.",
+      "type": "float",
+      "category": "Machine",
+      "default": 0.4,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "machine_max_jerk_e",
+      "label": "Default Filament Jerk",
+      "description": "Default jerk for the motor of the filament.",
+      "type": "float",
+      "category": "Machine",
+      "default": 5.0,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "machine_steps_per_mm_x",
+      "label": "Steps per Millimeter (X)",
+      "description": "How many steps of the stepper motor will result in one millimeter of movement in the X direction.",
+      "type": "float",
+      "category": "Machine",
+      "default": 50,
+      "min": "0.0000001"
+    },
+    {
+      "key": "machine_steps_per_mm_y",
+      "label": "Steps per Millimeter (Y)",
+      "description": "How many steps of the stepper motor will result in one millimeter of movement in the Y direction.",
+      "type": "float",
+      "category": "Machine",
+      "default": 50,
+      "min": "0.0000001"
+    },
+    {
+      "key": "machine_steps_per_mm_z",
+      "label": "Steps per Millimeter (Z)",
+      "description": "How many steps of the stepper motor will result in one millimeter of movement in the Z direction.",
+      "type": "float",
+      "category": "Machine",
+      "default": 50,
+      "min": "0.0000001"
+    },
+    {
+      "key": "machine_steps_per_mm_e",
+      "label": "Steps per Millimeter (E)",
+      "description": "How many steps of the stepper motors will result in moving the feeder wheel by one millimeter around its circumference.",
+      "type": "float",
+      "category": "Machine",
+      "default": 1600,
+      "min": "0.0000001"
+    },
+    {
+      "key": "machine_endstop_positive_direction_x",
+      "label": "X Endstop in Positive Direction",
+      "description": "Whether the endstop of the X axis is in the positive direction (high X coordinate) or negative (low X coordinate).",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_endstop_positive_direction_y",
+      "label": "Y Endstop in Positive Direction",
+      "description": "Whether the endstop of the Y axis is in the positive direction (high Y coordinate) or negative (low Y coordinate).",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "machine_endstop_positive_direction_z",
+      "label": "Z Endstop in Positive Direction",
+      "description": "Whether the endstop of the Z axis is in the positive direction (high Z coordinate) or negative (low Z coordinate).",
+      "type": "bool",
+      "category": "Machine",
+      "default": true
+    },
+    {
+      "key": "machine_minimum_feedrate",
+      "label": "Minimum Feedrate",
+      "description": "The minimal movement speed of the print head.",
+      "type": "float",
+      "category": "Machine",
+      "default": 0.0,
+      "unit": "mm/s"
+    },
+    {
+      "key": "machine_feeder_wheel_diameter",
+      "label": "Feeder Wheel Diameter",
+      "description": "The diameter of the wheel that drives the material in the feeder.",
+      "type": "float",
+      "category": "Machine",
+      "default": 10.0,
+      "unit": "mm"
+    },
+    {
+      "key": "machine_scale_fan_speed_zero_to_one",
+      "label": "Scale Fan Speed To 0-1",
+      "description": "Scale the fan speed to be between 0 and 1 instead of between 0 and 256.",
+      "type": "bool",
+      "category": "Machine",
+      "default": false
+    },
+    {
+      "key": "reset_flow_duration",
+      "label": "Reset flow duration",
+      "description": "For any travel move longer than this value, the material flow is reset to the paths target flow",
+      "type": "float",
+      "category": "Machine",
+      "unit": "s"
+    },
+    {
+      "key": "layer_height",
+      "label": "Layer Height",
+      "description": "The height of each layer in mm. Higher values produce faster prints in lower resolution, lower values produce slower prints in higher resolution.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "layer_height_0",
+      "label": "Initial Layer Height",
+      "description": "The height of the initial layer in mm. A thicker initial layer makes adhesion to the build plate easier.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.3,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "line_width",
+      "label": "Line Width",
+      "description": "Width of a single line. Generally, the width of each line should correspond to the width of the nozzle. However, slightly reducing this value could produce better prints.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "wall_line_width",
+      "label": "Wall Line Width",
+      "description": "Width of a single wall line.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "wall_line_width_0",
+      "label": "Outer Wall Line Width",
+      "description": "Width of the outermost wall line. By lowering this value, higher levels of detail can be printed.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "wall_line_width_x",
+      "label": "Inner Wall(s) Line Width",
+      "description": "Width of a single wall line for all wall lines except the outermost one.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "skin_line_width",
+      "label": "Top/Bottom Line Width",
+      "description": "Width of a single top/bottom line.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "infill_line_width",
+      "label": "Infill Line Width",
+      "description": "Width of a single infill line.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "skirt_brim_line_width",
+      "label": "Skirt/Brim Line Width",
+      "description": "Width of a single skirt or brim line.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "support_line_width",
+      "label": "Support Line Width",
+      "description": "Width of a single support structure line.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "support_interface_line_width",
+      "label": "Support Interface Line Width",
+      "description": "Width of a single line of support roof or floor.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "support_roof_line_width",
+      "label": "Support Roof Line Width",
+      "description": "Width of a single support roof line.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "support_bottom_line_width",
+      "label": "Support Floor Line Width",
+      "description": "Width of a single support floor line.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "prime_tower_line_width",
+      "label": "Prime Tower Line Width",
+      "description": "Width of a single prime tower line.",
+      "type": "float",
+      "category": "Quality",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "initial_layer_line_width_factor",
+      "label": "Initial Layer Line Width",
+      "description": "Multiplier of the line width on the first layer. Increasing this could improve bed adhesion.",
+      "type": "float",
+      "category": "Quality",
+      "default": 100.0,
+      "unit": "%",
+      "min": "0.001"
+    },
+    {
+      "key": "wall_extruder_nr",
+      "label": "Wall Extruder",
+      "description": "The extruder train used for printing the walls. This is used in multi-extrusion.",
+      "type": "optional_extruder",
+      "category": "Walls",
+      "default": "-1"
+    },
+    {
+      "key": "wall_0_extruder_nr",
+      "label": "Outer Wall Extruder",
+      "description": "The extruder train used for printing the outer wall. This is used in multi-extrusion.",
+      "type": "optional_extruder",
+      "category": "Walls",
+      "default": "-1"
+    },
+    {
+      "key": "wall_x_extruder_nr",
+      "label": "Inner Wall Extruder",
+      "description": "The extruder train used for printing the inner walls. This is used in multi-extrusion.",
+      "type": "optional_extruder",
+      "category": "Walls",
+      "default": "-1"
+    },
+    {
+      "key": "wall_thickness",
+      "label": "Wall Thickness",
+      "description": "The thickness of the walls in the horizontal direction. This value divided by the wall line width defines the number of walls.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.8,
+      "unit": "mm",
+      "min": "0",
+      "max": "999999 * line_width"
+    },
+    {
+      "key": "wall_line_count",
+      "label": "Wall Line Count",
+      "description": "The number of walls. When calculated by the wall thickness, this value is rounded to a whole number.",
+      "type": "int",
+      "category": "Walls",
+      "default": 2,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "wall_transition_length",
+      "label": "Wall Transition Length",
+      "description": "When transitioning between different numbers of walls as the part becomes thinner, a certain amount of space is allotted to split or join the wall lines.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001",
+      "max": "min_bead_width * 3 * math.pi"
+    },
+    {
+      "key": "wall_distribution_count",
+      "label": "Wall Distribution Count",
+      "description": "The number of walls, counted from the center, over which the variation needs to be spread. Lower values mean that the outer walls don't change in width.",
+      "type": "int",
+      "category": "Walls",
+      "default": 1,
+      "min": "1",
+      "max": "999999"
+    },
+    {
+      "key": "wall_transition_angle",
+      "label": "Wall Transitioning Threshold Angle",
+      "description": "When to create transitions between even and odd numbers of walls. A wedge shape with an angle greater than this setting will not have transitions and no walls will be printed in the center to fill the remaining space. Reducing this setting reduces the number and length of these center walls, but may leave gaps or overextrude.",
+      "type": "float",
+      "category": "Walls",
+      "default": 10,
+      "unit": "\u00b0",
+      "min": "1",
+      "max": "59"
+    },
+    {
+      "key": "wall_transition_filter_distance",
+      "label": "Wall Transitioning Filter Distance",
+      "description": "If it would be transitioning back and forth between different numbers of walls in quick succession, don't transition at all. Remove transitions if they are closer together than this distance.",
+      "type": "float",
+      "category": "Walls",
+      "default": 100,
+      "unit": "mm",
+      "min": "wall_transition_length",
+      "max": "999999"
+    },
+    {
+      "key": "wall_transition_filter_deviation",
+      "label": "Wall Transitioning Filter Margin",
+      "description": "Prevent transitioning back and forth between one extra wall and one less. This margin extends the range of line widths which follow to [Minimum Wall Line Width - Margin, 2 * Minimum Wall Line Width + Margin]. Increasing this margin reduces the number of transitions, which reduces the number of extrusion starts/stops and travel time. However, large line width variation can lead to under- or overextrusion problems.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "wall_0_wipe_dist",
+      "label": "Outer Wall Wipe Distance",
+      "description": "Distance of a travel move inserted after the outer wall, to hide the Z seam better.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.2,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "wall_0_inset",
+      "label": "Outer Wall Inset",
+      "description": "Inset applied to the path of the outer wall. If the outer wall is smaller than the nozzle, and printed after the inner walls, use this offset to get the hole in the nozzle to overlap with the inner walls instead of the outside of the model.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.0,
+      "unit": "mm"
+    },
+    {
+      "key": "optimize_wall_printing_order",
+      "label": "Optimize Wall Printing Order",
+      "description": "Optimize the order in which walls are printed so as to reduce the number of retractions and the distance travelled. Most parts will benefit from this being enabled but some may actually take longer so please compare the print time estimates with and without optimization. First layer is not optimized when choosing brim as build plate adhesion type.",
+      "type": "bool",
+      "category": "Walls",
+      "default": true
+    },
+    {
+      "key": "inset_direction",
+      "label": "Wall Ordering",
+      "description": "Determines the order in which walls are printed. Printing outer walls earlier helps with dimensional accuracy, as faults from inner walls cannot propagate to the outside. However printing them later allows them to stack better when overhangs are printed. When there is an uneven amount of total innner walls, the 'center last line' is always printed last.",
+      "type": "enum",
+      "category": "Walls",
+      "default": "inside_out",
+      "options": {
+        "inside_out": "Inside To Outside",
+        "outside_in": "Outside To Inside"
+      }
+    },
+    {
+      "key": "alternate_extra_perimeter",
+      "label": "Alternate Extra Wall",
+      "description": "Prints an extra wall at every other layer. This way infill gets caught between these extra walls, resulting in stronger prints.",
+      "type": "bool",
+      "category": "Walls",
+      "default": false
+    },
+    {
+      "key": "min_wall_line_width",
+      "label": "Minimum Wall Line Width",
+      "description": "For thin structures around once or twice the nozzle size, the line widths need to be altered to adhere to the thickness of the model. This setting controls the minimum line width allowed for the walls. The minimum line widths inherently also determine the maximum line widths, since we transition from N to N+1 walls at some geometry thickness where the N walls are wide and the N+1 walls are narrow. The widest possible wall line is twice the Minimum Wall Line Width.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.3,
+      "unit": "mm"
+    },
+    {
+      "key": "min_even_wall_line_width",
+      "label": "Minimum Even Wall Line Width",
+      "description": "The minimum line width for normal polygonal walls. This setting determines at which model thickness we switch from printing a single thin wall line, to printing two wall lines. A higher Minimum Even Wall Line Width leads to a higher maximum odd wall line width. The maximum even wall line width is calculated as Outer Wall Line Width + 0.5 * Minimum Odd Wall Line Width.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.3,
+      "unit": "mm"
+    },
+    {
+      "key": "min_odd_wall_line_width",
+      "label": "Minimum Odd Wall Line Width",
+      "description": "The minimum line width for middle line gap filler polyline walls. This setting determines at which model thickness we switch from printing two wall lines, to printing two outer walls and a single central wall in the middle. A higher Minimum Odd Wall Line Width leads to a higher maximum even wall line width. The maximum odd wall line width is calculated as 2 * Minimum Even Wall Line Width.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.3,
+      "unit": "mm"
+    },
+    {
+      "key": "fill_outline_gaps",
+      "label": "Print Thin Walls",
+      "description": "Print pieces of the model which are horizontally thinner than the nozzle size.",
+      "type": "bool",
+      "category": "Walls",
+      "default": true
+    },
+    {
+      "key": "min_feature_size",
+      "label": "Minimum Feature Size",
+      "description": "Minimum thickness of thin features. Model features that are thinner than this value will not be printed, while features thicker than the Minimum Feature Size will be widened to the Minimum Wall Line Width.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0",
+      "max": "wall_line_width_0"
+    },
+    {
+      "key": "min_bead_width",
+      "label": "Minimum Thin Wall Line Width",
+      "description": "Width of the wall that will replace thin features (according to the Minimum Feature Size) of the model. If the Minimum Wall Line Width is thinner than the thickness of the feature, the wall will become as thick as the feature itself.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0.2,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "xy_offset",
+      "label": "Horizontal Expansion",
+      "description": "Amount of offset applied to all polygons in each layer. Positive values can compensate for too big holes; negative values can compensate for too small holes.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0,
+      "unit": "mm"
+    },
+    {
+      "key": "xy_offset_layer_0",
+      "label": "Initial Layer Horizontal Expansion",
+      "description": "Amount of offset applied to all polygons in the first layer. A negative value can compensate for squishing of the first layer known as \"elephant's foot\".",
+      "type": "float",
+      "category": "Walls",
+      "default": 0,
+      "unit": "mm"
+    },
+    {
+      "key": "hole_xy_offset",
+      "label": "Hole Horizontal Expansion",
+      "description": "When greater than zero, the Hole Horizontal Expansion is the amount of offset applied to all holes in each layer. Positive values increase the size of the holes, negative values reduce the size of the holes. When this setting is enabled it can be further tuned with Hole Horizontal Expansion Max Diameter.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0,
+      "unit": "mm"
+    },
+    {
+      "key": "hole_xy_offset_max_diameter",
+      "label": "Hole Horizontal Expansion Max Diameter",
+      "description": "When greater than zero, the Hole Horizontal Expansion is gradually applied on small holes (small holes are expanded more). When set to zero the Hole Horizontal Expansion will be applied to all holes. Holes larger than the Hole Horizontal Expansion Max Diameter are not expanded.",
+      "type": "float",
+      "category": "Walls",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "z_seam_type",
+      "label": "Z Seam Alignment",
+      "description": "Starting point of each path in a layer. When paths in consecutive layers start at the same point a vertical seam may show on the print. When aligning these near a user specified location, the seam is easiest to remove. When placed randomly the inaccuracies at the paths' start will be less noticeable. When taking the shortest path the print will be quicker.",
+      "type": "enum",
+      "category": "Walls",
+      "default": "sharpest_corner",
+      "options": {
+        "back": "User Specified",
+        "shortest": "Shortest",
+        "random": "Random",
+        "sharpest_corner": "Sharpest Corner"
+      }
+    },
+    {
+      "key": "z_seam_on_vertex",
+      "label": "Z Seam On Vertex",
+      "description": "Place the z-seam on a polygon vertex. Switching this off can place the seam between vertices as well. (Keep in mind that this won't override the restrictions on placing the seam on an unsupported overhang.)",
+      "type": "bool",
+      "category": "Walls",
+      "default": false
+    },
+    {
+      "key": "z_seam_position",
+      "label": "Z Seam Position",
+      "description": "The position near where to start printing each part in a layer. Note: For the 'Middle' option, the reference point differs critically based on Z Seam Relative setting - it will be the middle of the buildplate (absolute) or the middle of each object (relative), resulting in completely different seam placements.",
+      "type": "enum",
+      "category": "Walls",
+      "default": "back",
+      "options": {
+        "backleft": "Back Left",
+        "back": "Back",
+        "backright": "Back Right",
+        "right": "Right",
+        "frontright": "Front Right",
+        "front": "Front",
+        "frontleft": "Front Left",
+        "left": "Left",
+        "middle": "Middle"
+      }
+    },
+    {
+      "key": "z_seam_x",
+      "label": "Z Seam X",
+      "description": "The X coordinate of the position near where to start printing each part in a layer. When Z Seam Relative is disabled, this is an absolute position on the buildplate. When enabled, this is relative to each object's center.",
+      "type": "float",
+      "category": "Walls",
+      "default": 100.0,
+      "unit": "mm"
+    },
+    {
+      "key": "z_seam_y",
+      "label": "Z Seam Y",
+      "description": "The Y coordinate of the position near where to start printing each part in a layer. When Z Seam Relative is disabled, this is an absolute position on the buildplate. When enabled, this is relative to each object's center.",
+      "type": "float",
+      "category": "Walls",
+      "default": 100.0,
+      "unit": "mm"
+    },
+    {
+      "key": "z_seam_corner",
+      "label": "Seam Corner Preference",
+      "description": "Control how corners on the model outline influence the position of the seam. Hide Seam makes the seam more likely to occur on an inside corner. Expose Seam makes the seam more likely to occur on an outside corner. Hide or Expose Seam makes the seam more likely to occur at an inside or outside corner. Smart Hiding allows both inside and outside corners, but chooses inside corners more frequently, if appropriate.",
+      "type": "enum",
+      "category": "Walls",
+      "default": "z_seam_corner_inner",
+      "options": {
+        "z_seam_corner_inner": "Hide Seam",
+        "z_seam_corner_outer": "Expose Seam",
+        "z_seam_corner_any": "Hide or Expose Seam",
+        "z_seam_corner_weighted": "Smart Hiding"
+      }
+    },
+    {
+      "key": "z_seam_relative",
+      "label": "Z Seam Relative",
+      "description": "When enabled, the z seam coordinates are relative to each part's centre. When disabled, the coordinates define an absolute position on the build plate. This setting is critical for the 'Middle' Z Seam Position option: relative positioning places the seam at the middle of each object, while absolute positioning places it at the middle of the buildplate, resulting in completely different seam placements.",
+      "type": "bool",
+      "category": "Walls",
+      "default": false
+    },
+    {
+      "key": "roofing_extruder_nr",
+      "label": "Top Surface Skin Extruder",
+      "description": "The extruder train used for printing the top most skin. This is used in multi-extrusion.",
+      "type": "optional_extruder",
+      "category": "Top/Bottom",
+      "default": "-1"
+    },
+    {
+      "key": "roofing_layer_count",
+      "label": "Top Surface Skin Layers",
+      "description": "The number of top most skin layers. Usually only one top most layer is sufficient to generate higher quality top surfaces.",
+      "type": "int",
+      "category": "Top/Bottom",
+      "default": 0,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "roofing_line_width",
+      "label": "Top Surface Skin Line Width",
+      "description": "Width of a single line of the areas at the top of the print.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "roofing_pattern",
+      "label": "Top Surface Skin Pattern",
+      "description": "The pattern of the top most layers.",
+      "type": "enum",
+      "category": "Top/Bottom",
+      "default": "lines",
+      "options": {
+        "lines": "Lines",
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag"
+      }
+    },
+    {
+      "key": "roofing_monotonic",
+      "label": "Monotonic Top Surface Order",
+      "description": "Print top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent.",
+      "type": "bool",
+      "category": "Top/Bottom",
+      "default": true
+    },
+    {
+      "key": "roofing_angles",
+      "label": "Top Surface Skin Line Directions",
+      "description": "A list of integer line directions to use when the top surface skin layers use the lines or zig zag pattern. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees).",
+      "type": "[int]",
+      "category": "Top/Bottom",
+      "default": "[ ]"
+    },
+    {
+      "key": "roofing_expansion",
+      "label": "Top Surface Expansion",
+      "description": "Determines how much the top surfaces are expanded beneath overlapping surfaces. By adjusting this value, you can ensure that the outer edges of the top surfaces are concealed by the layers above, resulting in a better visual quality, particularly for models with curved surfaces.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": "0",
+      "min": "0"
+    },
+    {
+      "key": "flooring_extruder_nr",
+      "label": "Bottom Surface Skin Extruder",
+      "description": "The extruder train used for printing the bottom most skin. This is used in multi-extrusion.",
+      "type": "optional_extruder",
+      "category": "Top/Bottom",
+      "default": "-1"
+    },
+    {
+      "key": "flooring_layer_count",
+      "label": "Bottom Surface Skin Layers",
+      "description": "The number of bottom most skin layers. Usually only one bottom most layer is sufficient to generate higher quality bottom surfaces.",
+      "type": "int",
+      "category": "Top/Bottom",
+      "default": 0,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "flooring_line_width",
+      "label": "Bottom Surface Skin Line Width",
+      "description": "Width of a single line of the areas at the bottom of the print.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "flooring_pattern",
+      "label": "Bottom Surface Skin Pattern",
+      "description": "The pattern of the bottom most layers.",
+      "type": "enum",
+      "category": "Top/Bottom",
+      "default": "lines",
+      "options": {
+        "lines": "Lines",
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag"
+      }
+    },
+    {
+      "key": "flooring_monotonic",
+      "label": "Monotonic Bottom Surface Order",
+      "description": "Print bottom surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent.",
+      "type": "bool",
+      "category": "Top/Bottom",
+      "default": true
+    },
+    {
+      "key": "flooring_angles",
+      "label": "Bottom Surface Skin Line Directions",
+      "description": "A list of integer line directions to use when the bottom surface skin layers use the lines or zig zag pattern. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees).",
+      "type": "[int]",
+      "category": "Top/Bottom",
+      "default": "[ ]"
+    },
+    {
+      "key": "top_bottom_extruder_nr",
+      "label": "Top/Bottom Extruder",
+      "description": "The extruder train used for printing the top and bottom skin. This is used in multi-extrusion.",
+      "type": "optional_extruder",
+      "category": "Top/Bottom",
+      "default": "-1"
+    },
+    {
+      "key": "top_bottom_thickness",
+      "label": "Top/Bottom Thickness",
+      "description": "The thickness of the top/bottom layers in the print. This value divided by the layer height defines the number of top/bottom layers.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 0.8,
+      "unit": "mm",
+      "min": "0",
+      "max": "machine_height"
+    },
+    {
+      "key": "top_thickness",
+      "label": "Top Thickness",
+      "description": "The thickness of the top layers in the print. This value divided by the layer height defines the number of top layers.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 0.8,
+      "unit": "mm",
+      "min": "0",
+      "max": "machine_height"
+    },
+    {
+      "key": "top_layers",
+      "label": "Top Layers",
+      "description": "The number of top layers. When calculated by the top thickness, this value is rounded to a whole number.",
+      "type": "int",
+      "category": "Top/Bottom",
+      "default": 8,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "bottom_thickness",
+      "label": "Bottom Thickness",
+      "description": "The thickness of the bottom layers in the print. This value divided by the layer height defines the number of bottom layers.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 0.6,
+      "unit": "mm",
+      "min": "0",
+      "max": "machine_height"
+    },
+    {
+      "key": "bottom_layers",
+      "label": "Bottom Layers",
+      "description": "The number of bottom layers. When calculated by the bottom thickness, this value is rounded to a whole number.",
+      "type": "int",
+      "category": "Top/Bottom",
+      "default": 6,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "initial_bottom_layers",
+      "label": "Initial Bottom Layers",
+      "description": "The number of initial bottom layers, from the build-plate upwards. When calculated by the bottom thickness, this value is rounded to a whole number.",
+      "type": "int",
+      "category": "Top/Bottom",
+      "default": 6,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "top_bottom_pattern",
+      "label": "Top/Bottom Pattern",
+      "description": "The pattern of the top/bottom layers.",
+      "type": "enum",
+      "category": "Top/Bottom",
+      "default": "lines",
+      "options": {
+        "lines": "Lines",
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag"
+      }
+    },
+    {
+      "key": "top_bottom_pattern_0",
+      "label": "Bottom Pattern Initial Layer",
+      "description": "The pattern on the bottom of the print on the first layer.",
+      "type": "enum",
+      "category": "Top/Bottom",
+      "default": "lines",
+      "options": {
+        "lines": "Lines",
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag"
+      }
+    },
+    {
+      "key": "connect_skin_polygons",
+      "label": "Connect Top/Bottom Polygons",
+      "description": "Connect top/bottom skin paths where they run next to each other. For the concentric pattern enabling this setting greatly reduces the travel time, but because the connections can happen midway over infill this feature can reduce the top surface quality.",
+      "type": "bool",
+      "category": "Top/Bottom",
+      "default": false
+    },
+    {
+      "key": "skin_monotonic",
+      "label": "Monotonic Top/Bottom Order",
+      "description": "Print top/bottom lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent.",
+      "type": "bool",
+      "category": "Top/Bottom",
+      "default": false
+    },
+    {
+      "key": "skin_angles",
+      "label": "Top/Bottom Line Directions",
+      "description": "A list of integer line directions to use when the top/bottom layers use the lines or zig zag pattern. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees).",
+      "type": "[int]",
+      "category": "Top/Bottom",
+      "default": "[ ]"
+    },
+    {
+      "key": "small_skin_width",
+      "label": "Small Top/Bottom Width",
+      "description": "Small top/bottom regions are filled with walls instead of the default top/bottom pattern. This helps to avoids jerky motions. Off for the topmost (air-exposed) layer by default (see 'Small Top/Bottom On Surface').",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "small_skin_on_surface",
+      "label": "Small Top/Bottom On Surface",
+      "description": "Enable small (up to 'Small Top/Bottom Width') regions on the topmost skinned layer (exposed to air) to be filled with walls instead of the default pattern.",
+      "type": "bool",
+      "category": "Top/Bottom",
+      "default": false
+    },
+    {
+      "key": "skin_no_small_gaps_heuristic",
+      "label": "No Skin in Z Gaps",
+      "description": "When the model has small vertical gaps of only a few layers, there should normally be skin around those layers in the narrow space. Enable this setting to not generate skin if the vertical gap is very small. This improves printing time and slicing time, but technically leaves infill exposed to the air.",
+      "type": "bool",
+      "category": "Top/Bottom",
+      "default": false
+    },
+    {
+      "key": "skin_outline_count",
+      "label": "Extra Skin Wall Count",
+      "description": "Replaces the outermost part of the top/bottom pattern with a number of concentric lines. Using one or two lines improves roofs that start on infill material.",
+      "type": "int",
+      "category": "Top/Bottom",
+      "default": 1,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "ironing_enabled",
+      "label": "Enable Ironing",
+      "description": "Go over the top surface one additional time, but this time extruding very little material. This is meant to melt the plastic on top further, creating a smoother surface. The pressure in the nozzle chamber is kept high so that the creases in the surface are filled with material.",
+      "type": "bool",
+      "category": "Top/Bottom",
+      "default": false
+    },
+    {
+      "key": "ironing_only_highest_layer",
+      "label": "Iron Only Highest Layer",
+      "description": "Only perform ironing on the very last layer of the mesh. This saves time if the lower layers don't need a smooth surface finish.",
+      "type": "bool",
+      "category": "Top/Bottom",
+      "default": false
+    },
+    {
+      "key": "ironing_pattern",
+      "label": "Ironing Pattern",
+      "description": "The pattern to use for ironing top surfaces.",
+      "type": "enum",
+      "category": "Top/Bottom",
+      "default": "zigzag",
+      "options": {
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag"
+      }
+    },
+    {
+      "key": "ironing_monotonic",
+      "label": "Monotonic Ironing Order",
+      "description": "Print ironing lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent.",
+      "type": "bool",
+      "category": "Top/Bottom",
+      "default": false
+    },
+    {
+      "key": "ironing_line_spacing",
+      "label": "Ironing Line Spacing",
+      "description": "The distance between the lines of ironing.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "ironing_flow",
+      "label": "Ironing Flow",
+      "description": "The amount of material, relative to a normal skin line, to extrude during ironing. Keeping the nozzle filled helps filling some of the crevices of the top surface, but too much results in overextrusion and blips on the side of the surface.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 10.0,
+      "unit": "%",
+      "min": "0"
+    },
+    {
+      "key": "ironing_inset",
+      "label": "Ironing Inset",
+      "description": "A distance to keep from the edges of the model. Ironing all the way to the edge of the mesh may result in a jagged edge on your print.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 0.35,
+      "unit": "mm"
+    },
+    {
+      "key": "speed_ironing",
+      "label": "Ironing Speed",
+      "description": "The speed at which to pass over the top surface.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 20.0,
+      "unit": "mm/s",
+      "min": "0.001",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "acceleration_ironing",
+      "label": "Ironing Acceleration",
+      "description": "The acceleration with which ironing is performed.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "jerk_ironing",
+      "label": "Ironing Jerk",
+      "description": "The maximum instantaneous velocity change while performing ironing.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "skin_overlap",
+      "label": "Skin Overlap Percentage",
+      "description": "Adjust the amount of overlap between the walls and (the endpoints of) the skin-centerlines, as a percentage of the line widths of the skin lines and the innermost wall. A slight overlap allows the walls to connect firmly to the skin. Note that, given an equal skin and wall line-width, any percentage over 50% may already cause any skin to go past the wall, because at that point the position of the nozzle of the skin-extruder may already reach past the middle of the wall.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 5,
+      "unit": "%"
+    },
+    {
+      "key": "skin_overlap_mm",
+      "label": "Skin Overlap",
+      "description": "Adjust the amount of overlap between the walls and (the endpoints of) the skin-centerlines. A slight overlap allows the walls to connect firmly to the skin. Note that, given an equal skin and wall line-width, any value over half the width of the wall may already cause any skin to go past the wall, because at that point the position of the nozzle of the skin-extruder may already reach past the middle of the wall.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 0.02,
+      "unit": "mm"
+    },
+    {
+      "key": "skin_preshrink",
+      "label": "Skin Removal Width",
+      "description": "The largest width of skin areas which are to be removed. Every skin area smaller than this value will disappear. This can help in limiting the amount of time and material spent on printing top/bottom skin at slanted surfaces in the model.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "top_skin_preshrink",
+      "label": "Top Skin Removal Width",
+      "description": "The largest width of top skin areas which are to be removed. Every skin area smaller than this value will disappear. This can help in limiting the amount of time and material spent on printing top skin at slanted surfaces in the model.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "bottom_skin_preshrink",
+      "label": "Bottom Skin Removal Width",
+      "description": "The largest width of bottom skin areas which are to be removed. Every skin area smaller than this value will disappear. This can help in limiting the amount of time and material spent on printing bottom skin at slanted surfaces in the model.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "expand_skins_expand_distance",
+      "label": "Skin Expand Distance",
+      "description": "The distance the skins are expanded into the infill. Higher values makes the skin attach better to the infill pattern and makes the walls on neighboring layers adhere better to the skin. Lower values save amount of material used.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 1,
+      "unit": "mm",
+      "min": "-skin_preshrink"
+    },
+    {
+      "key": "top_skin_expand_distance",
+      "label": "Top Skin Expand Distance",
+      "description": "The distance the top skins are expanded into the infill. Higher values makes the skin attach better to the infill pattern and makes the walls on the layer above adhere better to the skin. Lower values save amount of material used.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 1,
+      "unit": "mm",
+      "min": "-top_skin_preshrink"
+    },
+    {
+      "key": "bottom_skin_expand_distance",
+      "label": "Bottom Skin Expand Distance",
+      "description": "The distance the bottom skins are expanded into the infill. Higher values makes the skin attach better to the infill pattern and makes the skin adhere better to the walls on the layer below. Lower values save amount of material used.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 1,
+      "unit": "mm",
+      "min": "-bottom_skin_preshrink"
+    },
+    {
+      "key": "max_skin_angle_for_expansion",
+      "label": "Maximum Skin Angle for Expansion",
+      "description": "Top and/or bottom surfaces of your object with an angle larger than this setting, won't have their top/bottom skin expanded. This avoids expanding the narrow skin areas that are created when the model surface has a near vertical slope. An angle of 0\u00b0 is horizontal and will cause no skin to be expanded, while an angle of 90\u00b0 is vertical and will cause all skin to be expanded.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 90,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "min_skin_width_for_expansion",
+      "label": "Minimum Skin Width for Expansion",
+      "description": "Skin areas narrower than this are not expanded. This avoids expanding the narrow skin areas that are created when the model surface has a slope close to the vertical.",
+      "type": "float",
+      "category": "Top/Bottom",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "infill_extruder_nr",
+      "label": "Infill Extruder",
+      "description": "The extruder train used for printing infill. This is used in multi-extrusion.",
+      "type": "optional_extruder",
+      "category": "Infill",
+      "default": "-1"
+    },
+    {
+      "key": "infill_sparse_density",
+      "label": "Infill Density",
+      "description": "Adjusts the density of infill of the print.",
+      "type": "float",
+      "category": "Infill",
+      "default": 20,
+      "unit": "%",
+      "min": "0"
+    },
+    {
+      "key": "infill_line_distance",
+      "label": "Infill Line Distance",
+      "description": "Distance between the printed infill lines. This setting is calculated by the infill density and the infill line width.",
+      "type": "float",
+      "category": "Infill",
+      "default": 2,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "infill_pattern",
+      "label": "Infill Pattern",
+      "description": "<html>The pattern of the infill material of the print.<ul><li>The Line and Zig Zag infill swap direction on alternate layers, reducing material cost.</li><li>The Grid, Triangle, Tri-Hexagon, Cubic, Octet, Quarter Cubic, Cross, and Concentric patterns are fully printed every layer.</li><li>Gyroid, Honeycomb, Octagon, Cubic, Quarter Cubic, and Octet infill change with every layer to provide a more equal distribution of strength over each direction.</li><li>Lightning infill tries to minimize the infill, by only supporting the ceiling of the object.</li></ul>\u26a0 Grid, Triangles, and Cubic infill patterns contain intersecting lines, that may cause your nozzle to bump into printed lines, and your printer to vibrate. Use with caution.<br/></html>",
+      "type": "enum",
+      "category": "Infill",
+      "default": "grid",
+      "options": {
+        "lines": "Lines",
+        "trihexagon": "Tri-Hexagon",
+        "cubicsubdiv": "Cubic Subdivision",
+        "tetrahedral": "Octet",
+        "quarter_cubic": "Quarter Cubic",
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag",
+        "cross": "Cross",
+        "cross_3d": "Cross 3D",
+        "gyroid": "Gyroid",
+        "lightning": "Lightning",
+        "honeycomb": "Honeycomb",
+        "octagon": "Octagon",
+        "grid": "Grid",
+        "cubic": "Cubic",
+        "triangles": "Triangles"
+      }
+    },
+    {
+      "key": "zig_zaggify_infill",
+      "label": "Connect Infill Lines",
+      "description": "Connect the ends where the infill pattern meets the inner wall using a line which follows the shape of the inner wall. Enabling this setting can make the infill adhere to the walls better and reduce the effects of infill on the quality of vertical surfaces. Disabling this setting reduces the amount of material used.",
+      "type": "bool",
+      "category": "Infill",
+      "default": false
+    },
+    {
+      "key": "connect_infill_polygons",
+      "label": "Connect Infill Polygons",
+      "description": "Connect infill paths where they run next to each other. For infill patterns which consist of several closed polygons, enabling this setting greatly reduces the travel time.",
+      "type": "bool",
+      "category": "Infill",
+      "default": true
+    },
+    {
+      "key": "infill_angles",
+      "label": "Infill Line Directions",
+      "description": "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees for the lines and zig zag patterns and 45 degrees for all other patterns).",
+      "type": "[int]",
+      "category": "Infill",
+      "default": "[ ]"
+    },
+    {
+      "key": "infill_offset_x",
+      "label": "Infill X Offset",
+      "description": "The infill pattern is moved this distance along the X axis.",
+      "type": "float",
+      "category": "Infill",
+      "default": 0,
+      "unit": "mm"
+    },
+    {
+      "key": "infill_offset_y",
+      "label": "Infill Y Offset",
+      "description": "The infill pattern is moved this distance along the Y axis.",
+      "type": "float",
+      "category": "Infill",
+      "default": 0,
+      "unit": "mm"
+    },
+    {
+      "key": "infill_randomize_start_location",
+      "label": "Randomize Infill Start",
+      "description": "Randomize which infill line is printed first. This prevents one segment becoming the strongest, but it does so at the cost of an additional travel move.",
+      "type": "bool",
+      "category": "Infill",
+      "default": false
+    },
+    {
+      "key": "infill_multiplier",
+      "label": "Infill Line Multiplier",
+      "description": "Convert each infill line to this many lines. The extra lines do not cross over each other, but avoid each other. This makes the infill stiffer, but increases print time and material usage.",
+      "type": "int",
+      "category": "Infill",
+      "default": 1,
+      "min": "1",
+      "max": "999999"
+    },
+    {
+      "key": "infill_wall_line_count",
+      "label": "Extra Infill Wall Count",
+      "description": "Add extra walls around the infill area. Such walls can make top/bottom skin lines sag down less which means you need less top/bottom skin layers for the same quality at the cost of some extra material.\nThis feature can combine with the Connect Infill Polygons to connect all the infill into a single extrusion path without the need for travels or retractions if configured right.",
+      "type": "int",
+      "category": "Infill",
+      "default": 0,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "sub_div_rad_add",
+      "label": "Cubic Subdivision Shell",
+      "description": "An addition to the radius from the center of each cube to check for the boundary of the model, as to decide whether this cube should be subdivided. Larger values lead to a thicker shell of small cubes near the boundary of the model.",
+      "type": "float",
+      "category": "Infill",
+      "default": 0.4,
+      "unit": "mm"
+    },
+    {
+      "key": "infill_overlap",
+      "label": "Infill Overlap Percentage",
+      "description": "The amount of overlap between the infill and the walls as a percentage of the infill line width. A slight overlap allows the walls to connect firmly to the infill.",
+      "type": "float",
+      "category": "Infill",
+      "default": 10,
+      "unit": "%"
+    },
+    {
+      "key": "infill_overlap_mm",
+      "label": "Infill Overlap",
+      "description": "The amount of overlap between the infill and the walls. A slight overlap allows the walls to connect firmly to the infill.",
+      "type": "float",
+      "category": "Infill",
+      "default": 0.04,
+      "unit": "mm"
+    },
+    {
+      "key": "infill_wipe_dist",
+      "label": "Infill Wipe Distance",
+      "description": "Distance of a travel move inserted after every infill line, to make the infill stick to the walls better. This option is similar to infill overlap, but without extrusion and only on one end of the infill line.",
+      "type": "float",
+      "category": "Infill",
+      "default": 0.04,
+      "unit": "mm"
+    },
+    {
+      "key": "infill_sparse_thickness",
+      "label": "Infill Layer Thickness",
+      "description": "The thickness per layer of infill material. This value should always be a multiple of the layer height and is otherwise rounded.",
+      "type": "float",
+      "category": "Infill",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "resolveOrValue('layer_height') / 2 if infill_line_distance > 0 else -999999",
+      "max": "resolveOrValue('layer_height') * 8 if infill_line_distance > 0 else 999999"
+    },
+    {
+      "key": "gradual_infill_steps",
+      "label": "Gradual Infill Steps",
+      "description": "Number of times to reduce the infill density by half when getting further below top surfaces. Areas which are closer to top surfaces get a higher density, up to the Infill Density.",
+      "type": "int",
+      "category": "Infill",
+      "default": 0,
+      "min": "0",
+      "max": "999999 if infill_line_distance == 0 else (20 - math.log(infill_line_distance) / math.log(2))"
+    },
+    {
+      "key": "gradual_infill_step_height",
+      "label": "Gradual Infill Step Height",
+      "description": "The height of infill of a given density before switching to half the density.",
+      "type": "float",
+      "category": "Infill",
+      "default": 1.5,
+      "unit": "mm",
+      "min": "0.0001"
+    },
+    {
+      "key": "infill_before_walls",
+      "label": "Infill Before Walls",
+      "description": "Print the infill before printing the walls. Printing the walls first may lead to more accurate walls, but overhangs print worse. Printing the infill first leads to sturdier walls, but the infill pattern might sometimes show through the surface.",
+      "type": "bool",
+      "category": "Infill",
+      "default": true
+    },
+    {
+      "key": "min_infill_area",
+      "label": "Minimum Infill Area",
+      "description": "Don't generate areas of infill smaller than this (use skin instead).",
+      "type": "float",
+      "category": "Infill",
+      "default": 0,
+      "unit": "mm\u00b2",
+      "min": "0"
+    },
+    {
+      "key": "infill_support_enabled",
+      "label": "Infill Support",
+      "description": "Print infill structures only where tops of the model should be supported. Enabling this reduces print time and material usage, but leads to ununiform object strength.",
+      "type": "bool",
+      "category": "Infill",
+      "default": false
+    },
+    {
+      "key": "infill_support_angle",
+      "label": "Infill Overhang Angle",
+      "description": "The minimum angle of internal overhangs for which infill is added. At a value of 0\u00b0 objects are totally filled with infill, 90\u00b0 will not provide any infill.",
+      "type": "float",
+      "category": "Infill",
+      "default": 40,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "skin_support",
+      "label": "Infill Skin Support",
+      "description": "Print a solid infill pattern just below skin to avoid printing the skin over air.",
+      "type": "bool",
+      "category": "Infill",
+      "default": true
+    },
+    {
+      "key": "skin_support_speed",
+      "label": "Skin Support Speed",
+      "description": "The speed at which skin support regions are printed.",
+      "type": "float",
+      "category": "Infill",
+      "default": 15,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "skin_support_material_flow",
+      "label": "Skin Support Flow",
+      "description": "When printing skin support regions, the amount of material extruded is multiplied by this value.",
+      "type": "float",
+      "category": "Infill",
+      "default": 60,
+      "unit": "%",
+      "min": "5"
+    },
+    {
+      "key": "skin_support_density",
+      "label": "Skin Support Density",
+      "description": "The density of the skin support layer. Values less than 100 will increase the gaps between the lines.",
+      "type": "float",
+      "category": "Infill",
+      "default": 100,
+      "unit": "%",
+      "min": "5"
+    },
+    {
+      "key": "skin_support_fan_speed",
+      "label": "Skin Support Fan Speed",
+      "description": "Percentage fan speed to use when printing skin support.",
+      "type": "float",
+      "category": "Infill",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "skin_support_interlace_lines",
+      "label": "Interlace Skin Support Lines",
+      "description": "When enabled, skin support lines will be printed interlaced, i.e. in 2 monotonic passes so that adjacent lines won't be printed just after each other. The lines of the first pass then have more time to cool down and are stronger when the second pass is added.",
+      "type": "bool",
+      "category": "Infill",
+      "default": false
+    },
+    {
+      "key": "lightning_infill_support_angle",
+      "label": "Lightning Infill Support Angle",
+      "description": "Determines when a lightning infill layer has to support anything above it. Measured in the angle given the thickness of a layer.",
+      "type": "float",
+      "category": "Infill",
+      "default": 40,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "lightning_infill_overhang_angle",
+      "label": "Lightning Infill Overhang Angle",
+      "description": "Determines when a lightning infill layer has to support the model above it. Measured in the angle given the thickness.",
+      "type": "float",
+      "category": "Infill",
+      "default": 40,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "lightning_infill_prune_angle",
+      "label": "Lightning Infill Prune Angle",
+      "description": "The endpoints of infill lines are shortened to save on material. This setting is the angle of overhang of the endpoints of these lines.",
+      "type": "float",
+      "category": "Infill",
+      "default": 40,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "lightning_infill_straightening_angle",
+      "label": "Lightning Infill Straightening Angle",
+      "description": "The infill lines are straightened out to save on printing time. This is the maximum angle of overhang allowed across the length of the infill line.",
+      "type": "float",
+      "category": "Infill",
+      "default": 40,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "infill_move_inwards_length",
+      "label": "Infill Start/End Move Inwards Length",
+      "description": "When starting or ending infill print, add an inwards extrusion move so that the tips of the infill won't impact the outer wall. This can be useful when the infill is printed at very high speed.",
+      "type": "float",
+      "category": "Infill",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "infill_start_move_inwards_length",
+      "label": "Infill Start Move Inwards Length",
+      "description": "When starting infill print, add an inwards extrusion move so that the tips of the infill won't impact the outer wall. This can be useful when the infill is printed at very high speed.",
+      "type": "float",
+      "category": "Infill",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "infill_end_move_inwards_length",
+      "label": "Infill End Move Inwards Length",
+      "description": "When starting or ending infill print, add an inwards extrusion move so that the tips of the infill won't impact the outer wall. This can be useful when the infill is printed at very high speed.",
+      "type": "float",
+      "category": "Infill",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "default_material_print_temperature",
+      "label": "Default Printing Temperature",
+      "description": "The default temperature used for printing. This should be the \"base\" temperature of a material. All other print temperatures should use offsets based on this value",
+      "type": "float",
+      "category": "Material",
+      "default": 210,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "365"
+    },
+    {
+      "key": "build_volume_temperature",
+      "label": "Build Volume Temperature",
+      "description": "The temperature of the environment to print in. If this is 0, the build volume temperature will not be adjusted.",
+      "type": "float",
+      "category": "Material",
+      "default": 0,
+      "unit": "\u00b0C",
+      "min": "-273.15"
+    },
+    {
+      "key": "material_print_temperature",
+      "label": "Printing Temperature",
+      "description": "The temperature used for printing.",
+      "type": "float",
+      "category": "Material",
+      "default": 210,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "365"
+    },
+    {
+      "key": "material_print_temperature_layer_0",
+      "label": "Printing Temperature Initial Layer",
+      "description": "The temperature used for printing the first layer.",
+      "type": "float",
+      "category": "Material",
+      "default": 215,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "365"
+    },
+    {
+      "key": "material_initial_print_temperature",
+      "label": "Initial Printing Temperature",
+      "description": "The minimal temperature while heating up to the Printing Temperature at which printing can already start.",
+      "type": "float",
+      "category": "Material",
+      "default": 200,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "365"
+    },
+    {
+      "key": "material_final_print_temperature",
+      "label": "Final Printing Temperature",
+      "description": "The temperature to which to already start cooling down just before the end of printing.",
+      "type": "float",
+      "category": "Material",
+      "default": 195,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "365"
+    },
+    {
+      "key": "material_extrusion_cool_down_speed",
+      "label": "Extrusion Cool Down Speed Modifier",
+      "description": "The extra speed by which the nozzle cools while extruding. The same value is used to signify the heat up speed lost when heating up while extruding.",
+      "type": "float",
+      "category": "Material",
+      "default": 0.7,
+      "unit": "\u00b0C/s",
+      "min": "0",
+      "max": "machine_nozzle_heat_up_speed"
+    },
+    {
+      "key": "default_material_bed_temperature",
+      "label": "Default Build Plate Temperature",
+      "description": "The default temperature used for the heated build plate. This should be the \"base\" temperature of a build plate. All other print temperatures should use offsets based on this value",
+      "type": "float",
+      "category": "Material",
+      "default": 60,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "200"
+    },
+    {
+      "key": "material_bed_temperature",
+      "label": "Build Plate Temperature",
+      "description": "The temperature used for the heated build plate. If this is 0, the build plate is left unheated.",
+      "type": "float",
+      "category": "Material",
+      "default": 60,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "200"
+    },
+    {
+      "key": "material_bed_temperature_layer_0",
+      "label": "Build Plate Temperature Initial Layer",
+      "description": "The temperature used for the heated build plate at the first layer. If this is 0, the build plate is left unheated during the first layer.",
+      "type": "float",
+      "category": "Material",
+      "default": 60,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "200"
+    },
+    {
+      "key": "material_adhesion_tendency",
+      "label": "Adhesion Tendency",
+      "description": "Surface adhesion tendency.",
+      "type": "int",
+      "category": "Material",
+      "default": 10,
+      "min": "0",
+      "max": "10"
+    },
+    {
+      "key": "material_surface_energy",
+      "label": "Surface Energy",
+      "description": "Surface energy.",
+      "type": "int",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "material_shrinkage_percentage",
+      "label": "Scaling Factor Shrinkage Compensation",
+      "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor.",
+      "type": "float",
+      "category": "Material",
+      "default": 100.0,
+      "unit": "%",
+      "min": "0.001"
+    },
+    {
+      "key": "material_shrinkage_percentage_xy",
+      "label": "Horizontal Scaling Factor Shrinkage Compensation",
+      "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the XY-direction (horizontally).",
+      "type": "float",
+      "category": "Material",
+      "default": 100.0,
+      "unit": "%",
+      "min": "0.001"
+    },
+    {
+      "key": "material_shrinkage_percentage_z",
+      "label": "Vertical Scaling Factor Shrinkage Compensation",
+      "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the Z-direction (vertically).",
+      "type": "float",
+      "category": "Material",
+      "default": 100.0,
+      "unit": "%",
+      "min": "0.001"
+    },
+    {
+      "key": "material_crystallinity",
+      "label": "Crystalline Material",
+      "description": "Is this material the type that breaks off cleanly when heated (crystalline), or is it the type that produces long intertwined polymer chains (non-crystalline)?",
+      "type": "bool",
+      "category": "Material",
+      "default": false
+    },
+    {
+      "key": "material_anti_ooze_retracted_position",
+      "label": "Anti-ooze Retracted Position",
+      "description": "How far the material needs to be retracted before it stops oozing.",
+      "type": "float",
+      "category": "Material",
+      "default": -4,
+      "unit": "mm",
+      "max": "0"
+    },
+    {
+      "key": "material_anti_ooze_retraction_speed",
+      "label": "Anti-ooze Retraction Speed",
+      "description": "How fast the material needs to be retracted during a filament switch to prevent oozing.",
+      "type": "float",
+      "category": "Material",
+      "default": 5,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "machine_max_feedrate_e"
+    },
+    {
+      "key": "material_break_preparation_retracted_position",
+      "label": "Break Preparation Retracted Position",
+      "description": "How far the filament can be stretched before it breaks, while heated.",
+      "type": "float",
+      "category": "Material",
+      "default": -16,
+      "unit": "mm",
+      "max": "0"
+    },
+    {
+      "key": "material_break_preparation_speed",
+      "label": "Break Preparation Retraction Speed",
+      "description": "How fast the filament needs to be retracted just before breaking it off in a retraction.",
+      "type": "float",
+      "category": "Material",
+      "default": 2,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "machine_max_feedrate_e"
+    },
+    {
+      "key": "material_break_preparation_temperature",
+      "label": "Break Preparation Temperature",
+      "description": "The temperature used to purge material, should be roughly equal to the highest possible printing temperature.",
+      "type": "float",
+      "category": "Material",
+      "default": 50,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "365"
+    },
+    {
+      "key": "material_break_retracted_position",
+      "label": "Break Retracted Position",
+      "description": "How far to retract the filament in order to break it cleanly.",
+      "type": "float",
+      "category": "Material",
+      "default": -50,
+      "unit": "mm",
+      "max": "0"
+    },
+    {
+      "key": "material_break_speed",
+      "label": "Break Retraction Speed",
+      "description": "The speed at which to retract the filament in order to break it cleanly.",
+      "type": "float",
+      "category": "Material",
+      "default": 25,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "machine_max_feedrate_e"
+    },
+    {
+      "key": "material_break_temperature",
+      "label": "Break Temperature",
+      "description": "The temperature at which the filament is broken for a clean break.",
+      "type": "float",
+      "category": "Material",
+      "default": 50,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "365"
+    },
+    {
+      "key": "material_flush_purge_speed",
+      "label": "Flush Purge Speed",
+      "description": "How fast to prime the material after switching to a different material.",
+      "type": "float",
+      "category": "Material",
+      "default": 0.5
+    },
+    {
+      "key": "material_flush_purge_length",
+      "label": "Flush Purge Length",
+      "description": "How much material to use to purge the previous material out of the nozzle (in length of filament) when switching to a different material.",
+      "type": "float",
+      "category": "Material",
+      "default": 60
+    },
+    {
+      "key": "material_end_of_filament_purge_speed",
+      "label": "End of Filament Purge Speed",
+      "description": "How fast to prime the material after replacing an empty spool with a fresh spool of the same material.",
+      "type": "float",
+      "category": "Material",
+      "default": 0.5
+    },
+    {
+      "key": "material_end_of_filament_purge_length",
+      "label": "End of Filament Purge Length",
+      "description": "How much material to use to purge the previous material out of the nozzle (in length of filament) when replacing an empty spool with a fresh spool of the same material.",
+      "type": "float",
+      "category": "Material",
+      "default": 20
+    },
+    {
+      "key": "material_maximum_park_duration",
+      "label": "Maximum Park Duration",
+      "description": "How long the material can be kept out of dry storage safely.",
+      "type": "float",
+      "category": "Material",
+      "default": 300
+    },
+    {
+      "key": "material_no_load_move_factor",
+      "label": "No Load Move Factor",
+      "description": "A factor indicating how much the filament gets compressed between the feeder and the nozzle chamber, used to determine how far to move the material for a filament switch.",
+      "type": "float",
+      "category": "Material",
+      "default": 0.940860215
+    },
+    {
+      "key": "material_flow",
+      "label": "Flow",
+      "description": "Flow compensation: the amount of material extruded is multiplied by this value.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "wall_material_flow",
+      "label": "Wall Flow",
+      "description": "Flow compensation on wall lines.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "wall_0_material_flow",
+      "label": "Outer Wall Flow",
+      "description": "Flow compensation on the outermost wall line.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "wall_x_material_flow",
+      "label": "Inner Wall(s) Flow",
+      "description": "Flow compensation on wall lines for all wall lines except the outermost one.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "wall_0_material_flow_roofing",
+      "label": "Top Surface Outer Wall Flow",
+      "description": "Flow compensation on the top surface outermost wall line.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "wall_x_material_flow_roofing",
+      "label": "Top Surface Inner Wall(s) Flow",
+      "description": "Flow compensation on top surface wall lines for all wall lines except the outermost one.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "wall_0_material_flow_flooring",
+      "label": "Bottom Surface Outer Wall Flow",
+      "description": "Flow compensation on the bottom surface outermost wall line.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "wall_x_material_flow_flooring",
+      "label": "Bottom Surface Inner Wall(s) Flow",
+      "description": "Flow compensation on bottom surface wall lines for all wall lines except the outermost one.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "skin_material_flow",
+      "label": "Top/Bottom Flow",
+      "description": "Flow compensation on top/bottom lines.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "roofing_material_flow",
+      "label": "Top Surface Skin Flow",
+      "description": "Flow compensation on lines of the areas at the top of the print.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "flooring_material_flow",
+      "label": "Bottom Surface Skin Flow",
+      "description": "Flow compensation on lines of the areas at the bottom of the print.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "infill_material_flow",
+      "label": "Infill Flow",
+      "description": "Flow compensation on infill lines.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "skirt_brim_material_flow",
+      "label": "Skirt/Brim Flow",
+      "description": "Flow compensation on skirt or brim lines.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "support_material_flow",
+      "label": "Support Flow",
+      "description": "Flow compensation on support structure lines.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "support_interface_material_flow",
+      "label": "Support Interface Flow",
+      "description": "Flow compensation on lines of support roof or floor.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "support_roof_material_flow",
+      "label": "Support Roof Flow",
+      "description": "Flow compensation on support roof lines.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "support_bottom_material_flow",
+      "label": "Support Floor Flow",
+      "description": "Flow compensation on support floor lines.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "prime_tower_flow",
+      "label": "Prime Tower Flow",
+      "description": "Flow compensation on prime tower lines.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "material_flow_layer_0",
+      "label": "Initial Layer Flow",
+      "description": "Flow compensation for the first layer: the amount of material extruded on the initial layer is multiplied by this value.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "wall_x_material_flow_layer_0",
+      "label": "Initial Layer Inner Wall Flow",
+      "description": "Flow compensation on wall lines for all wall lines except the outermost one, but only for the first layer",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "wall_0_material_flow_layer_0",
+      "label": "Initial Layer Outer Wall Flow",
+      "description": "Flow compensation on the outermost wall line of the first layer.",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "skin_material_flow_layer_0",
+      "label": "Initial Layer Bottom Flow",
+      "description": "Flow compensation on bottom lines of the first layer",
+      "type": "float",
+      "category": "Material",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "material_standby_temperature",
+      "label": "Standby Temperature",
+      "description": "The temperature of the nozzle when another nozzle is currently used for printing.",
+      "type": "float",
+      "category": "Material",
+      "default": 150,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "365"
+    },
+    {
+      "key": "material_is_support_material",
+      "label": "Is support material",
+      "description": "Is this material typically used as a support material during printing.",
+      "type": "bool",
+      "category": "Material",
+      "default": false
+    },
+    {
+      "key": "gradual_flow_enabled",
+      "label": "Gradual flow enabled",
+      "description": "Enable gradual flow changes. When enabled, the flow is gradually increased/decreased to the target flow. This is useful for printers with a bowden tube where the flow is not immediately changed when the extruder motor starts/stops.",
+      "type": "bool",
+      "category": "Material",
+      "default": false
+    },
+    {
+      "key": "max_flow_acceleration",
+      "label": "Gradual flow max acceleration",
+      "description": "Maximum acceleration for gradual flow changes",
+      "type": "float",
+      "category": "Material",
+      "default": 1,
+      "unit": "mm\u00b3/s\u00b2",
+      "min": 0.01
+    },
+    {
+      "key": "layer_0_max_flow_acceleration",
+      "label": "Initial layer max flow acceleration",
+      "description": "Minimum speed for gradual flow changes for the first layer",
+      "type": "float",
+      "category": "Material",
+      "default": 1,
+      "unit": "mm\u00b3/s\u00b2",
+      "min": 0.01
+    },
+    {
+      "key": "gradual_flow_discretisation_step_size",
+      "label": "Gradual flow discretisation step size",
+      "description": "Duration of each step in the gradual flow change",
+      "type": "float",
+      "category": "Material",
+      "default": 0.2,
+      "unit": "s",
+      "min": 0.01,
+      "max": 5.0
+    },
+    {
+      "key": "material_pressure_advance_factor",
+      "label": "Pressure advance factor",
+      "description": "Tuning factor for pressure advance, which is meant to synchronize extrusion with motion",
+      "type": "float",
+      "category": "Material",
+      "default": 0.05,
+      "min": 0
+    },
+    {
+      "key": "material_max_flowrate",
+      "label": "Material Maximum Flow Rate",
+      "description": "Maximum flow rate that the printer can extrude for the material",
+      "type": "float",
+      "category": "Material",
+      "default": 16,
+      "unit": "mm\u00b3/s",
+      "min": "0",
+      "max": "machine_max_feedrate_e * (material_diameter/2)**2 * math.pi"
+    },
+    {
+      "key": "speed_print",
+      "label": "Print Speed",
+      "description": "The speed at which printing happens.",
+      "type": "float",
+      "category": "Speed",
+      "default": 60,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_infill",
+      "label": "Infill Speed",
+      "description": "The speed at which infill is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 60,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_wall",
+      "label": "Wall Speed",
+      "description": "The speed at which the walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 30,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_wall_0",
+      "label": "Outer Wall Speed",
+      "description": "The speed at which the outermost walls are printed. Printing the outer wall at a lower speed improves the final skin quality. However, having a large difference between the inner wall speed and the outer wall speed will affect quality in a negative way.",
+      "type": "float",
+      "category": "Speed",
+      "default": 30,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_wall_x",
+      "label": "Inner Wall Speed",
+      "description": "The speed at which all inner walls are printed. Printing the inner wall faster than the outer wall will reduce printing time. It works well to set this in between the outer wall speed and the infill speed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 60,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_wall_0_roofing",
+      "label": "Top Surface Outer Wall Speed",
+      "description": "The speed at which the top surface outermost wall is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 30,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_wall_x_roofing",
+      "label": "Top Surface Inner Wall Speed",
+      "description": "The speed at which the top surface inner walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 60,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_wall_0_flooring",
+      "label": "Bottom Surface Outer Wall Speed",
+      "description": "The speed at which the bottom surface outermost wall is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 30,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_wall_x_flooring",
+      "label": "Bottom Surface Inner Wall Speed",
+      "description": "The speed at which the bottom surface inner walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 60,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_roofing",
+      "label": "Top Surface Skin Speed",
+      "description": "The speed at which top surface skin layers are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 25,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_flooring",
+      "label": "Bottom Surface Skin Speed",
+      "description": "The speed at which bottom surface skin layers are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 25,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_topbottom",
+      "label": "Top/Bottom Speed",
+      "description": "The speed at which top/bottom layers are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 30,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_support",
+      "label": "Support Speed",
+      "description": "The speed at which the support structure is printed. Printing support at higher speeds can greatly reduce printing time. The surface quality of the support structure is not important since it is removed after printing.",
+      "type": "float",
+      "category": "Speed",
+      "default": 60,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_support_infill",
+      "label": "Support Infill Speed",
+      "description": "The speed at which the infill of support is printed. Printing the infill at lower speeds improves stability.",
+      "type": "float",
+      "category": "Speed",
+      "default": 60,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_support_interface",
+      "label": "Support Interface Speed",
+      "description": "The speed at which the roofs and floors of support are printed. Printing them at lower speeds can improve overhang quality.",
+      "type": "float",
+      "category": "Speed",
+      "default": 40,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_support_roof",
+      "label": "Support Roof Speed",
+      "description": "The speed at which the roofs of support are printed. Printing them at lower speeds can improve overhang quality.",
+      "type": "float",
+      "category": "Speed",
+      "default": 40,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_support_bottom",
+      "label": "Support Floor Speed",
+      "description": "The speed at which the floor of support is printed. Printing it at lower speed can improve adhesion of support on top of your model.",
+      "type": "float",
+      "category": "Speed",
+      "default": 40,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_prime_tower",
+      "label": "Prime Tower Speed",
+      "description": "The speed at which the prime tower is printed. Printing the prime tower slower can make it more stable when the adhesion between the different filaments is suboptimal.",
+      "type": "float",
+      "category": "Speed",
+      "default": 60,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_travel",
+      "label": "Travel Speed",
+      "description": "The speed at which travel moves are made.",
+      "type": "float",
+      "category": "Speed",
+      "default": 120,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_layer_0",
+      "label": "Initial Layer Speed",
+      "description": "The speed for the initial layer. A lower value is advised to improve adhesion to the build plate. Does not affect the build plate adhesion structures themselves, like brim and raft.",
+      "type": "float",
+      "category": "Speed",
+      "default": 30,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_print_layer_0",
+      "label": "Initial Layer Print Speed",
+      "description": "The speed of printing for the initial layer. A lower value is advised to improve adhesion to the build plate.",
+      "type": "float",
+      "category": "Speed",
+      "default": 30,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_travel_layer_0",
+      "label": "Initial Layer Travel Speed",
+      "description": "The speed of travel moves in the initial layer. A lower value is advised to prevent pulling previously printed parts away from the build plate. The value of this setting can automatically be calculated from the ratio between the Travel Speed and the Print Speed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 60,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "skirt_brim_speed",
+      "label": "Skirt/Brim Speed",
+      "description": "The speed at which the skirt and brim are printed. Normally this is done at the initial layer speed, but sometimes you might want to print the skirt or brim at a different speed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 30,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "speed_z_hop",
+      "label": "Z Hop Speed",
+      "description": "The speed at which the vertical Z movement is made for Z Hops. This is typically lower than the print speed since the build plate or machine's gantry is harder to move.",
+      "type": "float",
+      "category": "Speed",
+      "default": 10,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "machine_max_feedrate_z"
+    },
+    {
+      "key": "speed_slowdown_layers",
+      "label": "Number of Slower Layers",
+      "description": "The first few layers are printed slower than the rest of the model, to get better adhesion to the build plate and improve the overall success rate of prints. The speed is gradually increased over these layers.",
+      "type": "int",
+      "category": "Speed",
+      "default": 2,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "speed_equalize_flow_width_factor",
+      "label": "Flow Equalization Ratio",
+      "description": "Extrusion width based correction factor on the speed. At 0% the movement speed is kept constant at the Print Speed. At 100% the movement speed is adjusted so that the flow (in mm\u00b3/s) is kept constant, i.e. lines half the normal Line Width are printed twice as fast and lines twice as wide are printed half as fast. A value larger than 100% can help to compensate for the higher pressure required to extrude wide lines.",
+      "type": "float",
+      "category": "Speed",
+      "default": 100.0,
+      "unit": "%",
+      "min": "0.0"
+    },
+    {
+      "key": "acceleration_enabled",
+      "label": "Enable Acceleration Control",
+      "description": "Enables adjusting the print head acceleration. Increasing the accelerations can reduce printing time at the cost of print quality.",
+      "type": "bool",
+      "category": "Speed",
+      "default": false
+    },
+    {
+      "key": "acceleration_travel_enabled",
+      "label": "Enable Travel Acceleration",
+      "description": "Use a separate acceleration rate for travel moves. If disabled, travel moves will use the acceleration value of the printed line at their destination.",
+      "type": "bool",
+      "category": "Speed",
+      "default": true
+    },
+    {
+      "key": "acceleration_print",
+      "label": "Print Acceleration",
+      "description": "The acceleration with which printing happens.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_infill",
+      "label": "Infill Acceleration",
+      "description": "The acceleration with which infill is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_wall",
+      "label": "Wall Acceleration",
+      "description": "The acceleration with which the walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_wall_0",
+      "label": "Outer Wall Acceleration",
+      "description": "The acceleration with which the outermost walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_wall_x",
+      "label": "Inner Wall Acceleration",
+      "description": "The acceleration with which all inner walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_wall_0_roofing",
+      "label": "Top Surface Outer Wall Acceleration",
+      "description": "The acceleration with which the top surface outermost walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_wall_x_roofing",
+      "label": "Top Surface Inner Wall Acceleration",
+      "description": "The acceleration with which the top surface inner walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_wall_0_flooring",
+      "label": "Bottom Surface Outer Wall Acceleration",
+      "description": "The acceleration with which the bottom surface outermost walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_wall_x_flooring",
+      "label": "Bottom Surface Inner Wall Acceleration",
+      "description": "The acceleration with which the bottom surface inner walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_roofing",
+      "label": "Top Surface Skin Acceleration",
+      "description": "The acceleration with which top surface skin layers are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_flooring",
+      "label": "Bottom Surface Skin Acceleration",
+      "description": "The acceleration with which bottom surface skin layers are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_topbottom",
+      "label": "Top/Bottom Acceleration",
+      "description": "The acceleration with which top/bottom layers are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_support",
+      "label": "Support Acceleration",
+      "description": "The acceleration with which the support structure is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_support_infill",
+      "label": "Support Infill Acceleration",
+      "description": "The acceleration with which the infill of support is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_support_interface",
+      "label": "Support Interface Acceleration",
+      "description": "The acceleration with which the roofs and floors of support are printed. Printing them at lower acceleration can improve overhang quality.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_support_roof",
+      "label": "Support Roof Acceleration",
+      "description": "The acceleration with which the roofs of support are printed. Printing them at lower acceleration can improve overhang quality.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_support_bottom",
+      "label": "Support Floor Acceleration",
+      "description": "The acceleration with which the floors of support are printed. Printing them at lower acceleration can improve adhesion of support on top of your model.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_prime_tower",
+      "label": "Prime Tower Acceleration",
+      "description": "The acceleration with which the prime tower is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_travel",
+      "label": "Travel Acceleration",
+      "description": "The acceleration with which travel moves are made.",
+      "type": "float",
+      "category": "Speed",
+      "default": 5000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_layer_0",
+      "label": "Initial Layer Acceleration",
+      "description": "The acceleration for the initial layer.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_print_layer_0",
+      "label": "Initial Layer Print Acceleration",
+      "description": "The acceleration during the printing of the initial layer.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_travel_layer_0",
+      "label": "Initial Layer Travel Acceleration",
+      "description": "The acceleration for travel moves in the initial layer.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "acceleration_skirt_brim",
+      "label": "Skirt/Brim Acceleration",
+      "description": "The acceleration with which the skirt and brim are printed. Normally this is done with the initial layer acceleration, but sometimes you might want to print the skirt or brim at a different acceleration.",
+      "type": "float",
+      "category": "Speed",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "jerk_enabled",
+      "label": "Enable Jerk Control",
+      "description": "Enables adjusting the jerk of print head when the velocity in the X or Y axis changes. Increasing the jerk can reduce printing time at the cost of print quality.",
+      "type": "bool",
+      "category": "Speed",
+      "default": false
+    },
+    {
+      "key": "jerk_travel_enabled",
+      "label": "Enable Travel Jerk",
+      "description": "Use a separate jerk rate for travel moves. If disabled, travel moves will use the jerk value of the printed line at their destination.",
+      "type": "bool",
+      "category": "Speed",
+      "default": true
+    },
+    {
+      "key": "jerk_print",
+      "label": "Print Jerk",
+      "description": "The maximum instantaneous velocity change of the print head.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_infill",
+      "label": "Infill Jerk",
+      "description": "The maximum instantaneous velocity change with which infill is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_wall",
+      "label": "Wall Jerk",
+      "description": "The maximum instantaneous velocity change with which the walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_wall_0",
+      "label": "Outer Wall Jerk",
+      "description": "The maximum instantaneous velocity change with which the outermost walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_wall_x",
+      "label": "Inner Wall Jerk",
+      "description": "The maximum instantaneous velocity change with which all inner walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_wall_0_roofing",
+      "label": "Top Surface Outer Wall Jerk",
+      "description": "The maximum instantaneous velocity change with which the top surface outermost walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_wall_x_roofing",
+      "label": "Top Surface Inner Wall Jerk",
+      "description": "The maximum instantaneous velocity change with which the top surface inner walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_wall_0_flooring",
+      "label": "Bottom Surface Outer Wall Jerk",
+      "description": "The maximum instantaneous velocity change with which the bottom surface outermost walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_wall_x_flooring",
+      "label": "Bottom Surface Inner Wall Jerk",
+      "description": "The maximum instantaneous velocity change with which the bottom surface inner walls are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_roofing",
+      "label": "Top Surface Skin Jerk",
+      "description": "The maximum instantaneous velocity change with which top surface skin layers are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_flooring",
+      "label": "Bottom Surface Skin Jerk",
+      "description": "The maximum instantaneous velocity change with which bottom surface skin layers are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_topbottom",
+      "label": "Top/Bottom Jerk",
+      "description": "The maximum instantaneous velocity change with which top/bottom layers are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_support",
+      "label": "Support Jerk",
+      "description": "The maximum instantaneous velocity change with which the support structure is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_support_infill",
+      "label": "Support Infill Jerk",
+      "description": "The maximum instantaneous velocity change with which the infill of support is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_support_interface",
+      "label": "Support Interface Jerk",
+      "description": "The maximum instantaneous velocity change with which the roofs and floors of support are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_support_roof",
+      "label": "Support Roof Jerk",
+      "description": "The maximum instantaneous velocity change with which the roofs of support are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_support_bottom",
+      "label": "Support Floor Jerk",
+      "description": "The maximum instantaneous velocity change with which the floors of support are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_prime_tower",
+      "label": "Prime Tower Jerk",
+      "description": "The maximum instantaneous velocity change with which the prime tower is printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_travel",
+      "label": "Travel Jerk",
+      "description": "The maximum instantaneous velocity change with which travel moves are made.",
+      "type": "float",
+      "category": "Speed",
+      "default": 30,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_layer_0",
+      "label": "Initial Layer Jerk",
+      "description": "The print maximum instantaneous velocity change for the initial layer.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_print_layer_0",
+      "label": "Initial Layer Print Jerk",
+      "description": "The maximum instantaneous velocity change during the printing of the initial layer.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_travel_layer_0",
+      "label": "Initial Layer Travel Jerk",
+      "description": "The acceleration for travel moves in the initial layer.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "jerk_skirt_brim",
+      "label": "Skirt/Brim Jerk",
+      "description": "The maximum instantaneous velocity change with which the skirt and brim are printed.",
+      "type": "float",
+      "category": "Speed",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "retraction_enable",
+      "label": "Enable Retraction",
+      "description": "Retract the filament when the nozzle is moving over a non-printed area.",
+      "type": "bool",
+      "category": "Travel",
+      "default": true
+    },
+    {
+      "key": "retract_at_layer_change",
+      "label": "Retract at Layer Change",
+      "description": "Retract the filament when the nozzle is moving to the next layer.",
+      "type": "bool",
+      "category": "Travel",
+      "default": false
+    },
+    {
+      "key": "retraction_amount",
+      "label": "Retraction Distance",
+      "description": "The length of material retracted during a retraction move.",
+      "type": "float",
+      "category": "Travel",
+      "default": 6.5,
+      "unit": "mm"
+    },
+    {
+      "key": "retraction_speed",
+      "label": "Retraction Speed",
+      "description": "The speed at which the filament is retracted and primed during a retraction move.",
+      "type": "float",
+      "category": "Travel",
+      "default": 25,
+      "unit": "mm/s",
+      "min": "0.0001",
+      "max": "machine_max_feedrate_e if retraction_enable else float('inf')"
+    },
+    {
+      "key": "retraction_retract_speed",
+      "label": "Retraction Retract Speed",
+      "description": "The speed at which the filament is retracted during a retraction move.",
+      "type": "float",
+      "category": "Travel",
+      "default": 25,
+      "unit": "mm/s",
+      "min": "0.0001",
+      "max": "machine_max_feedrate_e if retraction_enable else float('inf')"
+    },
+    {
+      "key": "retraction_prime_speed",
+      "label": "Retraction Prime Speed",
+      "description": "The speed at which the filament is primed during a retraction move.",
+      "type": "float",
+      "category": "Travel",
+      "default": 25,
+      "unit": "mm/s",
+      "min": "0.0001",
+      "max": "machine_max_feedrate_e if retraction_enable else float('inf')"
+    },
+    {
+      "key": "retraction_extra_prime_amount",
+      "label": "Retraction Extra Prime Amount",
+      "description": "Some material can ooze away during a travel move, which can be compensated for here.",
+      "type": "float",
+      "category": "Travel",
+      "default": 0,
+      "unit": "mm\u00b3"
+    },
+    {
+      "key": "retraction_min_travel",
+      "label": "Retraction Minimum Travel",
+      "description": "The minimum distance of travel needed for a retraction to happen at all. This helps to get fewer retractions in a small area.",
+      "type": "float",
+      "category": "Travel",
+      "default": 1.5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "retraction_count_max",
+      "label": "Maximum Retraction Count",
+      "description": "This setting limits the number of retractions occurring within the minimum extrusion distance window. Further retractions within this window will be ignored. This avoids retracting repeatedly on the same piece of filament, as that can flatten the filament and cause grinding issues.",
+      "type": "int",
+      "category": "Travel",
+      "default": 90,
+      "min": "0",
+      "max": 999999999
+    },
+    {
+      "key": "retraction_extrusion_window",
+      "label": "Minimum Extrusion Distance Window",
+      "description": "The window in which the maximum retraction count is enforced. This value should be approximately the same as the retraction distance, so that effectively the number of times a retraction passes the same patch of material is limited.",
+      "type": "float",
+      "category": "Travel",
+      "default": 4.5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "retraction_combing",
+      "label": "Combing Mode",
+      "description": "Combing keeps the nozzle within already printed areas when traveling. This results in slightly longer travel moves but reduces the need for retractions. If combing is off, the material will retract and the nozzle moves in a straight line to the next point. It is also possible to avoid combing over top/bottom skin areas or to only comb within the infill.",
+      "type": "enum",
+      "category": "Travel",
+      "default": "all",
+      "options": {
+        "off": "Off",
+        "all": "All",
+        "no_outer_surfaces": "Not on Outer Surface",
+        "noskin": "Not in Skin",
+        "infill": "Within Infill"
+      }
+    },
+    {
+      "key": "retraction_combing_max_distance",
+      "label": "Max Comb Distance With No Retract",
+      "description": "When greater than zero, combing travel moves that are longer than this distance will use retraction. If set to zero, there is no maximum and combing moves will not use retraction.",
+      "type": "float",
+      "category": "Travel",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "retraction_combing_avoid_distance",
+      "label": "Inside Travel Avoid Distance",
+      "description": "The distance between the nozzle and already printed outer walls when travelling inside a model.",
+      "type": "float",
+      "category": "Travel",
+      "default": 0.6,
+      "unit": "mm",
+      "min": "machine_nozzle_size * 0.5"
+    },
+    {
+      "key": "travel_retract_before_outer_wall",
+      "label": "Retract Before Outer Wall",
+      "description": "Always retract when moving to start an outer wall.",
+      "type": "bool",
+      "category": "Travel",
+      "default": false
+    },
+    {
+      "key": "travel_avoid_other_parts",
+      "label": "Avoid Printed Parts When Traveling",
+      "description": "The nozzle avoids already printed parts when traveling. This option is only available when combing is enabled.",
+      "type": "bool",
+      "category": "Travel",
+      "default": true
+    },
+    {
+      "key": "travel_avoid_supports",
+      "label": "Avoid Supports When Traveling",
+      "description": "The nozzle avoids already printed supports when traveling. This option is only available when combing is enabled.",
+      "type": "bool",
+      "category": "Travel",
+      "default": false
+    },
+    {
+      "key": "travel_avoid_distance",
+      "label": "Travel Avoid Distance",
+      "description": "The distance between the nozzle and already printed parts when avoiding during travel moves.",
+      "type": "float",
+      "category": "Travel",
+      "default": 0.625,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "layer_start_at_z_seam",
+      "label": "Layer Start at Z Seam",
+      "description": "Start printing at the Z seam position.",
+      "type": "bool",
+      "category": "Travel",
+      "default": false
+    },
+    {
+      "key": "layer_start_x",
+      "label": "Layer Start X",
+      "description": "The X coordinate of the position near where to find the part to start printing each layer.",
+      "type": "float",
+      "category": "Travel",
+      "default": 0.0,
+      "unit": "mm",
+      "min": "machine_width / -2 if machine_center_is_zero else 0"
+    },
+    {
+      "key": "layer_start_y",
+      "label": "Layer Start Y",
+      "description": "The Y coordinate of the position near where to find the part to start printing each layer.",
+      "type": "float",
+      "category": "Travel",
+      "default": 0.0,
+      "unit": "mm",
+      "min": "machine_depth / -2 if machine_center_is_zero else 0"
+    },
+    {
+      "key": "retraction_hop_enabled",
+      "label": "Z Hop When Retracted",
+      "description": "Whenever a retraction is done, the build plate is lowered to create clearance between the nozzle and the print. It prevents the nozzle from hitting the print during travel moves, reducing the chance to knock the print from the build plate.",
+      "type": "bool",
+      "category": "Travel",
+      "default": false
+    },
+    {
+      "key": "retraction_hop_only_when_collides",
+      "label": "Z Hop Only Over Printed Parts",
+      "description": "Only perform a Z Hop when moving over printed parts which cannot be avoided by horizontal motion by Avoid Printed Parts when Traveling.",
+      "type": "bool",
+      "category": "Travel",
+      "default": false
+    },
+    {
+      "key": "retraction_hop",
+      "label": "Z Hop Height",
+      "description": "The height difference when performing a Z Hop.",
+      "type": "float",
+      "category": "Travel",
+      "default": 1,
+      "unit": "mm"
+    },
+    {
+      "key": "retraction_hop_after_extruder_switch",
+      "label": "Z Hop After Extruder Switch",
+      "description": "After the machine switched from one extruder to the other, the build plate is lowered to create clearance between the nozzle and the print. This prevents the nozzle from leaving oozed material on the outside of a print.",
+      "type": "bool",
+      "category": "Travel",
+      "default": true
+    },
+    {
+      "key": "retraction_hop_after_extruder_switch_height",
+      "label": "Z Hop After Extruder Switch Height",
+      "description": "The height difference when performing a Z Hop after extruder switch.",
+      "type": "float",
+      "category": "Travel",
+      "default": 1,
+      "unit": "mm"
+    },
+    {
+      "key": "cool_fan_enabled",
+      "label": "Enable Print Cooling",
+      "description": "Enables the print cooling fans while printing. The fans improve print quality on layers with short layer times and bridging / overhangs.",
+      "type": "bool",
+      "category": "Cooling",
+      "default": true
+    },
+    {
+      "key": "build_fan_full_at_height",
+      "label": "Build Volume Fan Speed at Height",
+      "description": "The height at which the fans spin on regular fan speed. At the layers below the fan speed gradually increases from Initial Fan Speed to Regular Fan Speed.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "build_fan_full_layer",
+      "label": "Build Volume Fan Speed at Layer",
+      "description": "The layer at which the build-volume fans spin on full fan speed. This value is calculated and rounded to a whole number.",
+      "type": "int",
+      "category": "Cooling",
+      "default": 0,
+      "min": "0"
+    },
+    {
+      "key": "build_volume_fan_speed_0",
+      "label": "Initial Layers Build Volume Fan Speed",
+      "description": "The fan speed (as a percentage) for the auxiliary or build-volume fan, that is set until the layer specified at 'Build Volume Fan Speed at Layer' is reached. After that, the speed is set by 'Build Volume Fan Speed' instead (so not this 'Initial Layers' one).",
+      "type": "float",
+      "category": "Cooling",
+      "default": 0,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "build_volume_fan_speed",
+      "label": "Build Volume Fan Speed",
+      "description": "The fan speed (as a percentage) for the auxiliary or build-volume fan, that is set from the moment that the layer specified at 'Build Volume Fan Speed at Layer' is reached and onwards. Before that, the speed is set by 'Initial Layers Build Volume Fan Speed' instead.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "cool_fan_speed",
+      "label": "Fan Speed",
+      "description": "The speed at which the print cooling fans spin.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "cool_fan_speed_min",
+      "label": "Regular Fan Speed",
+      "description": "The speed at which the fans spin before hitting the threshold. When a layer prints faster than the threshold, the fan speed gradually inclines towards the maximum fan speed.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "cool_fan_speed_max",
+      "label": "Maximum Fan Speed",
+      "description": "The speed at which the fans spin on the minimum layer time. The fan speed gradually increases between the regular fan speed and maximum fan speed when the threshold is hit.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "cool_min_layer_time_fan_speed_max",
+      "label": "Regular/Maximum Fan Speed Threshold",
+      "description": "The layer time which sets the threshold between regular fan speed and maximum fan speed. Layers that print slower than this time use regular fan speed. For faster layers the fan speed gradually increases towards the maximum fan speed.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 10,
+      "unit": "s"
+    },
+    {
+      "key": "cool_fan_speed_0",
+      "label": "Initial Fan Speed",
+      "description": "The speed at which the fans spin at the start of the print. In subsequent layers the fan speed is gradually increased up to the layer corresponding to Regular Fan Speed at Height.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 0,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "cool_fan_full_at_height",
+      "label": "Regular Fan Speed at Height",
+      "description": "The height at which the fans spin on regular fan speed. At the layers below the fan speed gradually increases from Initial Fan Speed to Regular Fan Speed.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 0.5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "cool_fan_full_layer",
+      "label": "Regular Fan Speed at Layer",
+      "description": "The layer at which the fans spin on regular fan speed. If regular fan speed at height is set, this value is calculated and rounded to a whole number.",
+      "type": "int",
+      "category": "Cooling",
+      "default": 2,
+      "min": "1"
+    },
+    {
+      "key": "cool_min_layer_time",
+      "label": "Minimum Layer Time",
+      "description": "The minimum time spent in a layer. This forces the printer to slow down, to at least spend the time set here in one layer. This allows the printed material to cool down properly before printing the next layer. Layers may still take shorter than the minimal layer time if Lift Head is disabled and if the Minimum Speed would otherwise be violated.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 5,
+      "unit": "s",
+      "min": "0"
+    },
+    {
+      "key": "cool_min_speed",
+      "label": "Minimum Speed",
+      "description": "The minimum print speed, despite slowing down due to the minimum layer time. When the printer would slow down too much, the pressure in the nozzle would be too low and result in bad print quality.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 10,
+      "unit": "mm/s",
+      "min": "1"
+    },
+    {
+      "key": "cool_lift_head",
+      "label": "Lift Head",
+      "description": "When the minimum speed is hit because of minimum layer time, lift the head away from the print and wait the extra time until the minimum layer time is reached.",
+      "type": "bool",
+      "category": "Cooling",
+      "default": false
+    },
+    {
+      "key": "cool_min_temperature",
+      "label": "Small Layer Printing Temperature",
+      "description": "Gradually reduce to this temperature when printing at reduced speeds because of minimum layer time.",
+      "type": "float",
+      "category": "Cooling",
+      "default": 0,
+      "unit": "\u00b0C",
+      "min": "-273.15",
+      "max": "365"
+    },
+    {
+      "key": "cool_during_extruder_switch",
+      "label": "Cooling during extruder switch",
+      "description": "<html>Whether to activate the cooling fans during a nozzle switch. This can help reducing oozing by cooling the nozzle faster:<ul><li><b>Unchanged:</b> keep the fans as they were previously</li><li><b>Only last extruder:</b> turn on the fan of the last used extruder, but turn the others off (if any). This is useful if you have completely separate extruders.</li><li><b>All fans:</b> turn on all fans during nozzle switch. This is useful if you have a single cooling fan, or multiple fans that stay close to each other.</li></ul></html>",
+      "type": "enum",
+      "category": "Cooling",
+      "default": "unchanged",
+      "options": {
+        "unchanged": "Unchanged",
+        "only_last_extruder": "Only last extruder",
+        "all_fans": "All fans"
+      }
+    },
+    {
+      "key": "support_enable",
+      "label": "Generate Support",
+      "description": "Generate structures to support parts of the model which have overhangs. Without these structures, such parts would collapse during printing.",
+      "type": "bool",
+      "category": "Support",
+      "default": false
+    },
+    {
+      "key": "support_extruder_nr",
+      "label": "Support Extruder",
+      "description": "The extruder train to use for printing the support. This is used in multi-extrusion.",
+      "type": "extruder",
+      "category": "Support",
+      "default": "0"
+    },
+    {
+      "key": "support_infill_extruder_nr",
+      "label": "Support Infill Extruder",
+      "description": "The extruder train to use for printing the infill of the support. This is used in multi-extrusion.",
+      "type": "extruder",
+      "category": "Support",
+      "default": "0"
+    },
+    {
+      "key": "support_extruder_nr_layer_0",
+      "label": "First Layer Support Extruder",
+      "description": "The extruder train to use for printing the first layer of support infill. This is used in multi-extrusion.",
+      "type": "extruder",
+      "category": "Support",
+      "default": "0"
+    },
+    {
+      "key": "support_interface_extruder_nr",
+      "label": "Support Interface Extruder",
+      "description": "The extruder train to use for printing the roofs and floors of the support. This is used in multi-extrusion.",
+      "type": "extruder",
+      "category": "Support",
+      "default": "0"
+    },
+    {
+      "key": "support_roof_extruder_nr",
+      "label": "Support Roof Extruder",
+      "description": "The extruder train to use for printing the roofs of the support. This is used in multi-extrusion.",
+      "type": "extruder",
+      "category": "Support",
+      "default": "0"
+    },
+    {
+      "key": "support_bottom_extruder_nr",
+      "label": "Support Floor Extruder",
+      "description": "The extruder train to use for printing the floors of the support. This is used in multi-extrusion.",
+      "type": "extruder",
+      "category": "Support",
+      "default": "0"
+    },
+    {
+      "key": "support_structure",
+      "label": "Support Structure",
+      "description": "Chooses between the techniques available to generate support. \"Normal\" support creates a support structure directly below the overhanging parts and drops those areas straight down. \"Tree\" support creates branches towards the overhanging areas that support the model on the tips of those branches, and allows the branches to crawl around the model to support it from the build plate as much as possible.",
+      "type": "enum",
+      "category": "Support",
+      "default": "normal",
+      "options": {
+        "normal": "Normal",
+        "tree": "Tree"
+      }
+    },
+    {
+      "key": "support_tree_angle",
+      "label": "Maximum Branch Angle",
+      "description": "The maximum angle of the branches while they grow around the model. Use a lower angle to make them more vertical and more stable. Use a higher angle to be able to have more reach.",
+      "type": "float",
+      "category": "Support",
+      "default": 60,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "89"
+    },
+    {
+      "key": "support_tree_branch_diameter",
+      "label": "Branch Diameter",
+      "description": "The diameter of the thinnest branches of tree support. Thicker branches are more sturdy. Branches towards the base will be thicker than this.",
+      "type": "float",
+      "category": "Support",
+      "default": 5,
+      "unit": "mm",
+      "min": "support_tree_tip_diameter"
+    },
+    {
+      "key": "support_tree_max_diameter",
+      "label": "Trunk Diameter",
+      "description": "The diameter of the widest branches of tree support. A thicker trunk is more sturdy; a thinner trunk takes up less space on the build plate.",
+      "type": "float",
+      "category": "Support",
+      "default": 25,
+      "unit": "mm",
+      "min": "support_tree_branch_diameter"
+    },
+    {
+      "key": "support_tree_branch_diameter_angle",
+      "label": "Branch Diameter Angle",
+      "description": "The angle of the branches' diameter as they gradually become thicker towards the bottom. An angle of 0 will cause the branches to have uniform thickness over their length. A bit of an angle can increase stability of the tree support.",
+      "type": "float",
+      "category": "Support",
+      "default": 7,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "89.9999"
+    },
+    {
+      "key": "support_z_seam_away_from_model",
+      "label": "Support Z Seam Away from Model",
+      "description": "Manage the spatial relationship between the z seam of the support structure and the actual 3D model. This control is crucial as it allows users to ensure the seamless removal of support structures post-printing, without inflicting damage or leaving marks on the printed model.",
+      "type": "bool",
+      "category": "Support",
+      "default": true
+    },
+    {
+      "key": "support_z_seam_min_distance",
+      "label": "Min Z Seam Distance from Model",
+      "description": "The distance between the model and its support structure at the z-axis seam.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.8,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "support_type",
+      "label": "Support Placement",
+      "description": "Adjusts the placement of the support structures. The placement can be set to touching build plate or everywhere. When set to everywhere the support structures will also be printed on the model.",
+      "type": "enum",
+      "category": "Support",
+      "default": "everywhere",
+      "options": {
+        "buildplate": "Touching Buildplate",
+        "everywhere": "Everywhere"
+      }
+    },
+    {
+      "key": "support_tree_angle_slow",
+      "label": "Preferred Branch Angle",
+      "description": "The preferred angle of the branches, when they do not have to avoid the model. Use a lower angle to make them more vertical and more stable. Use a higher angle for branches to merge faster.",
+      "type": "float",
+      "category": "Support",
+      "default": 50,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "support_tree_angle"
+    },
+    {
+      "key": "support_tree_max_diameter_increase_by_merges_when_support_to_model",
+      "label": "Diameter Increase To Model",
+      "description": "The most the diameter of a branch that has to connect to the model may increase by merging with branches that could reach the buildplate. Increasing this reduces print time, but increases the area of support that rests on model",
+      "type": "float",
+      "category": "Support",
+      "default": 1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_tree_min_height_to_model",
+      "label": "Minimum Height To Model",
+      "description": "How tall a branch has to be if it is placed on the model. Prevents small blobs of support. This setting is ignored when a branch is supporting a support roof.",
+      "type": "float",
+      "category": "Support",
+      "default": 3,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_tree_bp_diameter",
+      "label": "Initial Layer Diameter",
+      "description": "Diameter every branch tries to achieve when reaching the buildplate. Improves bed adhesion.",
+      "type": "float",
+      "category": "Support",
+      "default": 7.5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_tree_top_rate",
+      "label": "Branch Density",
+      "description": "Adjusts the density of the support structure used to generate the tips of the branches. A higher value results in better overhangs, but the supports are harder to remove. Use Support Roof for very high values or ensure support density is similarly high at the top.",
+      "type": "float",
+      "category": "Support",
+      "default": 15,
+      "unit": "%",
+      "min": "0.1"
+    },
+    {
+      "key": "support_tree_tip_diameter",
+      "label": "Tip Diameter",
+      "description": "The diameter of the top of the tip of the branches of tree support.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "min_wall_line_width",
+      "max": "support_tree_branch_diameter"
+    },
+    {
+      "key": "support_tree_limit_branch_reach",
+      "label": "Limit Branch Reach",
+      "description": "Limit how far each branch should travel from the point it supports. This can make the support more sturdy, but will increase the amount of branches (and because of that material usage/print time)",
+      "type": "bool",
+      "category": "Support",
+      "default": true
+    },
+    {
+      "key": "support_tree_branch_reach_limit",
+      "label": "Optimal Branch Range",
+      "description": "A recomendation to how far branches can move from the points they support. Branches can violate this value to reach their destination (buildplate or a flat part of the model). Lowering this value will make the support more sturdy, but increase the amount of branches (and because of that material usage/print time)",
+      "type": "float",
+      "category": "Support",
+      "default": 30,
+      "unit": "mm",
+      "min": "1"
+    },
+    {
+      "key": "support_tree_rest_preference",
+      "label": "Rest Preference",
+      "description": "The preferred placement of the support structures. If structures can't be placed at the preferred location, they will be place elsewhere, even if that means placing them on the model.",
+      "type": "enum",
+      "category": "Support",
+      "default": "buildplate",
+      "options": {
+        "buildplate": "On buildplate when possible",
+        "graceful": "On model if required"
+      }
+    },
+    {
+      "key": "support_angle",
+      "label": "Support Overhang Angle",
+      "description": "The minimum angle of overhangs for which support is added. At a value of 0\u00b0 all overhangs are supported, 90\u00b0 will not provide any support.",
+      "type": "float",
+      "category": "Support",
+      "default": 50,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "support_pattern",
+      "label": "Support Pattern",
+      "description": "The pattern of the support structures of the print. The different options available result in sturdy or easy to remove support.",
+      "type": "enum",
+      "category": "Support",
+      "default": "zigzag",
+      "options": {
+        "lines": "Lines",
+        "grid": "Grid",
+        "triangles": "Triangles",
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag",
+        "cross": "Cross",
+        "gyroid": "Gyroid",
+        "honeycomb": "Honeycomb",
+        "octagon": "Octagon"
+      }
+    },
+    {
+      "key": "support_wall_count",
+      "label": "Support Wall Line Count",
+      "description": "The number of walls with which to surround support infill. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used.",
+      "type": "int",
+      "category": "Support",
+      "default": 1,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "support_interface_wall_count",
+      "label": "Support Interface Wall Line Count",
+      "description": "The number of walls with which to surround support interface. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used.",
+      "type": "int",
+      "category": "Support",
+      "default": 0,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "support_roof_wall_count",
+      "label": "Support Roof Wall Line Count",
+      "description": "The number of walls with which to surround support interface roof. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used.",
+      "type": "int",
+      "category": "Support",
+      "default": 0,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "support_bottom_wall_count",
+      "label": "Support Bottom Wall Line Count",
+      "description": "The number of walls with which to surround support interface floor. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used.",
+      "type": "int",
+      "category": "Support",
+      "default": 0,
+      "min": "0",
+      "max": "999999"
+    },
+    {
+      "key": "zig_zaggify_support",
+      "label": "Connect Support Lines",
+      "description": "Connect the ends of the support lines together. Enabling this setting can make your support more sturdy and reduce underextrusion, but it will cost more material.",
+      "type": "bool",
+      "category": "Support",
+      "default": false
+    },
+    {
+      "key": "support_connect_zigzags",
+      "label": "Connect Support ZigZags",
+      "description": "Connect the ZigZags. This will increase the strength of the zig zag support structure.",
+      "type": "bool",
+      "category": "Support",
+      "default": true
+    },
+    {
+      "key": "support_infill_rate",
+      "label": "Support Density",
+      "description": "Adjusts the density of the support structure. A higher value results in better overhangs, but the supports are harder to remove.",
+      "type": "float",
+      "category": "Support",
+      "default": 15,
+      "unit": "%",
+      "min": "0"
+    },
+    {
+      "key": "support_line_distance",
+      "label": "Support Line Distance",
+      "description": "Distance between the printed support structure lines. This setting is calculated by the support density.",
+      "type": "float",
+      "category": "Support",
+      "default": 2.66,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_initial_layer_line_distance",
+      "label": "Initial Layer Support Line Distance",
+      "description": "Distance between the printed initial layer support structure lines. This setting is calculated by the support density.",
+      "type": "float",
+      "category": "Support",
+      "default": 2.66,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_infill_density_multiplier_initial_layer",
+      "label": "Support Infill Density Multiplier Initial Layer",
+      "description": "Multiplier for the infill on the initial layers of the support. Increasing this may help for bed adhesion.",
+      "type": "int",
+      "category": "Support",
+      "default": 1,
+      "min": "1"
+    },
+    {
+      "key": "support_infill_angles",
+      "label": "Support Infill Line Directions",
+      "description": "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the default angle 0 degrees.",
+      "type": "[int]",
+      "category": "Support",
+      "default": "[ ]"
+    },
+    {
+      "key": "support_brim_enable",
+      "label": "Enable Support Brim",
+      "description": "Generate a brim within the support infill regions of the first layer. This brim is printed underneath the support, not around it. Enabling this setting increases the adhesion of support to the build plate.",
+      "type": "bool",
+      "category": "Support",
+      "default": true
+    },
+    {
+      "key": "support_brim_width",
+      "label": "Support Brim Width",
+      "description": "The width of the brim to print underneath the support. A larger brim enhances adhesion to the build plate, at the cost of some extra material.",
+      "type": "float",
+      "category": "Support",
+      "default": 1.2,
+      "unit": "mm",
+      "min": "0.0"
+    },
+    {
+      "key": "support_brim_line_count",
+      "label": "Support Brim Line Count",
+      "description": "The number of lines used for the support brim. More brim lines enhance adhesion to the build plate, at the cost of some extra material.",
+      "type": "int",
+      "category": "Support",
+      "default": 3,
+      "min": "0"
+    },
+    {
+      "key": "support_z_distance",
+      "label": "Support Z Distance",
+      "description": "Distance from the top/bottom of the support structure to the print. This gap provides clearance to remove the supports after the model is printed. The topmost support layer below the model might be a fraction of regular layers.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_top_distance",
+      "label": "Support Top Distance",
+      "description": "Distance from the top of the support to the print.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_bottom_distance",
+      "label": "Support Bottom Distance",
+      "description": "Distance from the print to the bottom of the support. Note that this is rounded up to the next layer height.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_xy_distance",
+      "label": "Support X/Y Distance",
+      "description": "Distance of the support structure from the print in the X/Y directions.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.7,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_xy_overrides_z",
+      "label": "Support Distance Priority",
+      "description": "Whether the Support X/Y Distance overrides the Support Z Distance or vice versa. When X/Y overrides Z the X/Y distance can push away the support from the model, influencing the actual Z distance to the overhang. We can disable this by not applying the X/Y distance around overhangs.",
+      "type": "enum",
+      "category": "Support",
+      "default": "z_overrides_xy",
+      "options": {
+        "xy_overrides_z": "X/Y overrides Z",
+        "z_overrides_xy": "Z overrides X/Y"
+      }
+    },
+    {
+      "key": "support_xy_distance_overhang",
+      "label": "Minimum Support X/Y Distance",
+      "description": "Distance of the support structure from the overhang in the X/Y directions.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.2,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_bottom_stair_step_height",
+      "label": "Support Stair Step Height",
+      "description": "The height of the steps of the stair-like bottom of support resting on the model. A low value makes the support harder to remove, but too high values can lead to unstable support structures. Set to zero to turn off the stair-like behaviour.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.3,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_bottom_stair_step_width",
+      "label": "Support Stair Step Maximum Width",
+      "description": "The maximum width of the steps of the stair-like bottom of support resting on the model. A low value makes the support harder to remove, but too high values can lead to unstable support structures.",
+      "type": "float",
+      "category": "Support",
+      "default": 5.0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_bottom_stair_step_min_slope",
+      "label": "Support Stair Step Minimum Slope Angle",
+      "description": "The minimum slope of the area for stair-stepping to take effect. Low values should make support easier to remove on shallower slopes, but really low values may result in some very counter-intuitive results on other parts of the model.",
+      "type": "float",
+      "category": "Support",
+      "default": 10.0,
+      "unit": "\u00b0",
+      "min": "0.01",
+      "max": "89.99"
+    },
+    {
+      "key": "support_join_distance",
+      "label": "Support Join Distance",
+      "description": "The maximum distance between support structures in the X/Y directions. When separate structures are closer together than this value, the structures merge into one.",
+      "type": "float",
+      "category": "Support",
+      "default": 2.0,
+      "unit": "mm"
+    },
+    {
+      "key": "support_offset",
+      "label": "Support Horizontal Expansion",
+      "description": "Amount of offset applied to all support polygons in each layer. Positive values can smooth out the support areas and result in more sturdy support.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.8,
+      "unit": "mm"
+    },
+    {
+      "key": "support_infill_sparse_thickness",
+      "label": "Support Infill Layer Thickness",
+      "description": "The thickness per layer of support infill material. This value should always be a multiple of the layer height and is otherwise rounded.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "resolveOrValue('layer_height')",
+      "max": "resolveOrValue('layer_height') * 8"
+    },
+    {
+      "key": "gradual_support_infill_steps",
+      "label": "Gradual Support Infill Steps",
+      "description": "Number of times to reduce the support infill density by half when getting further below top surfaces. Areas which are closer to top surfaces get a higher density, up to the Support Infill Density.",
+      "type": "int",
+      "category": "Support",
+      "default": 0,
+      "min": "0",
+      "max": "(999999 if support_line_distance == 0 else (20 - math.log(support_line_distance) / math.log(2))) if support_structure != 'tree' else 0"
+    },
+    {
+      "key": "gradual_support_infill_step_height",
+      "label": "Gradual Support Infill Step Height",
+      "description": "The height of support infill of a given density before switching to half the density.",
+      "type": "float",
+      "category": "Support",
+      "default": 1,
+      "unit": "mm",
+      "min": "0.0001"
+    },
+    {
+      "key": "minimum_support_area",
+      "label": "Minimum Support Area",
+      "description": "Minimum area size for support polygons. Polygons which have an area smaller than this value will not be generated.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.0,
+      "unit": "mm\u00b2",
+      "min": "0"
+    },
+    {
+      "key": "support_interface_enable",
+      "label": "Enable Support Interface",
+      "description": "Generate a dense interface between the model and the support. This will create a skin at the top of the support on which the model is printed and at the bottom of the support, where it rests on the model.",
+      "type": "bool",
+      "category": "Support",
+      "default": false
+    },
+    {
+      "key": "support_roof_enable",
+      "label": "Enable Support Roof",
+      "description": "Generate a dense slab of material between the top of support and the model. This will create a skin between the model and support.",
+      "type": "bool",
+      "category": "Support",
+      "default": false
+    },
+    {
+      "key": "support_bottom_enable",
+      "label": "Enable Support Floor",
+      "description": "Generate a dense slab of material between the bottom of the support and the model. This will create a skin between the model and support.",
+      "type": "bool",
+      "category": "Support",
+      "default": false
+    },
+    {
+      "key": "support_interface_height",
+      "label": "Support Interface Thickness",
+      "description": "The thickness of the interface of the support where it touches with the model on the bottom or the top.",
+      "type": "float",
+      "category": "Support",
+      "default": 1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_roof_height",
+      "label": "Support Roof Thickness",
+      "description": "The thickness of the support roofs. This controls the amount of dense layers at the top of the support on which the model rests.",
+      "type": "float",
+      "category": "Support",
+      "default": 1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_bottom_height",
+      "label": "Support Floor Thickness",
+      "description": "The thickness of the support floors. This controls the number of dense layers that are printed on top of places of a model on which support rests.",
+      "type": "float",
+      "category": "Support",
+      "default": 1,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_interface_density",
+      "label": "Support Interface Density",
+      "description": "Adjusts the density of the roofs and floors of the support structure. A higher value results in better overhangs, but the supports are harder to remove.",
+      "type": "float",
+      "category": "Support",
+      "default": 100,
+      "unit": "%",
+      "min": "0"
+    },
+    {
+      "key": "support_roof_density",
+      "label": "Support Roof Density",
+      "description": "The density of the roofs of the support structure. A higher value results in better overhangs, but the supports are harder to remove.",
+      "type": "float",
+      "category": "Support",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "support_roof_line_distance",
+      "label": "Support Roof Line Distance",
+      "description": "Distance between the printed support roof lines. This setting is calculated by the Support Roof Density, but can be adjusted separately.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_bottom_density",
+      "label": "Support Floor Density",
+      "description": "The density of the floors of the support structure. A higher value results in better adhesion of the support on top of the model.",
+      "type": "float",
+      "category": "Support",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "support_bottom_line_distance",
+      "label": "Support Floor Line Distance",
+      "description": "Distance between the printed support floor lines. This setting is calculated by the Support Floor Density, but can be adjusted separately.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_interface_pattern",
+      "label": "Support Interface Pattern",
+      "description": "The pattern with which the interface of the support with the model is printed.",
+      "type": "enum",
+      "category": "Support",
+      "default": "concentric",
+      "options": {
+        "lines": "Lines",
+        "grid": "Grid",
+        "triangles": "Triangles",
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag"
+      }
+    },
+    {
+      "key": "support_roof_pattern",
+      "label": "Support Roof Pattern",
+      "description": "The pattern with which the roofs of the support are printed.",
+      "type": "enum",
+      "category": "Support",
+      "default": "concentric",
+      "options": {
+        "lines": "Lines",
+        "grid": "Grid",
+        "triangles": "Triangles",
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag"
+      }
+    },
+    {
+      "key": "support_bottom_pattern",
+      "label": "Support Floor Pattern",
+      "description": "The pattern with which the floors of the support are printed.",
+      "type": "enum",
+      "category": "Support",
+      "default": "concentric",
+      "options": {
+        "lines": "Lines",
+        "grid": "Grid",
+        "triangles": "Triangles",
+        "concentric": "Concentric",
+        "zigzag": "Zig Zag"
+      }
+    },
+    {
+      "key": "minimum_interface_area",
+      "label": "Minimum Support Interface Area",
+      "description": "Minimum area size for support interface polygons. Polygons which have an area smaller than this value will be printed as normal support.",
+      "type": "float",
+      "category": "Support",
+      "default": 1.0,
+      "unit": "mm\u00b2",
+      "min": "0"
+    },
+    {
+      "key": "minimum_roof_area",
+      "label": "Minimum Support Roof Area",
+      "description": "Minimum area size for the roofs of the support. Polygons which have an area smaller than this value will be printed as normal support.",
+      "type": "float",
+      "category": "Support",
+      "default": 1.0,
+      "unit": "mm\u00b2",
+      "min": "0"
+    },
+    {
+      "key": "minimum_bottom_area",
+      "label": "Minimum Support Floor Area",
+      "description": "Minimum area size for the floors of the support. Polygons which have an area smaller than this value will be printed as normal support.",
+      "type": "float",
+      "category": "Support",
+      "default": 1.0,
+      "unit": "mm\u00b2",
+      "min": "0"
+    },
+    {
+      "key": "support_interface_offset",
+      "label": "Support Interface Horizontal Expansion",
+      "description": "Amount of offset applied to the support interface polygons.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.0,
+      "unit": "mm",
+      "max": "extruderValue(support_extruder_nr, 'support_offset') if support_structure == 'normal' else None"
+    },
+    {
+      "key": "support_roof_offset",
+      "label": "Support Roof Horizontal Expansion",
+      "description": "Amount of offset applied to the roofs of the support.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.0,
+      "unit": "mm",
+      "max": "extruderValue(support_extruder_nr, 'support_offset') if support_structure == 'normal' else None"
+    },
+    {
+      "key": "support_bottom_offset",
+      "label": "Support Floor Horizontal Expansion",
+      "description": "Amount of offset applied to the floors of the support.",
+      "type": "float",
+      "category": "Support",
+      "default": 0.0,
+      "unit": "mm",
+      "max": "extruderValue(support_extruder_nr, 'support_offset') if support_structure == 'normal' else None"
+    },
+    {
+      "key": "support_interface_priority",
+      "label": "Support Interface Priority",
+      "description": "How support interface and support will interact when they overlap. Currently only implemented for support roof.",
+      "type": "enum",
+      "category": "Support",
+      "default": "interface_area_overwrite_support_area",
+      "options": {
+        "support_area_overwrite_interface_area": "Support preferred",
+        "interface_area_overwrite_support_area": "Interface preferred",
+        "support_lines_overwrite_interface_area": "Support lines preferred",
+        "interface_lines_overwrite_support_area": "Interface lines preferred",
+        "nothing": "Both overlap"
+      }
+    },
+    {
+      "key": "support_interface_angles",
+      "label": "Support Interface Line Directions",
+      "description": "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the default angles (alternates between 45 and 135 degrees if interfaces are quite thick or 90 degrees).",
+      "type": "[int]",
+      "category": "Support",
+      "default": "[ ]"
+    },
+    {
+      "key": "support_roof_angles",
+      "label": "Support Roof Line Directions",
+      "description": "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the default angles (alternates between 45 and 135 degrees if interfaces are quite thick or 90 degrees).",
+      "type": "[int]",
+      "category": "Support",
+      "default": "[ ]"
+    },
+    {
+      "key": "support_bottom_angles",
+      "label": "Support Floor Line Directions",
+      "description": "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the default angles (alternates between 45 and 135 degrees if interfaces are quite thick or 90 degrees).",
+      "type": "[int]",
+      "category": "Support",
+      "default": "[ ]"
+    },
+    {
+      "key": "support_fan_enable",
+      "label": "Fan Speed Override",
+      "description": "When enabled, the print cooling fan speed is altered for the skin regions immediately above the support.",
+      "type": "bool",
+      "category": "Support",
+      "default": false
+    },
+    {
+      "key": "support_supported_skin_fan_speed",
+      "label": "Supported Skin Fan Speed",
+      "description": "Percentage fan speed to use when printing the skin regions immediately above the support. Using a high fan speed can make the support easier to remove.",
+      "type": "float",
+      "category": "Support",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "support_use_towers",
+      "label": "Use Towers",
+      "description": "Use specialized towers to support tiny overhang areas. These towers have a larger diameter than the region they support. Near the overhang the towers' diameter decreases, forming a roof.",
+      "type": "bool",
+      "category": "Support",
+      "default": true
+    },
+    {
+      "key": "support_tower_diameter",
+      "label": "Tower Diameter",
+      "description": "The diameter of a special tower.",
+      "type": "float",
+      "category": "Support",
+      "default": 3.0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_tower_maximum_supported_diameter",
+      "label": "Maximum Tower-Supported Diameter",
+      "description": "Maximum diameter in the X/Y directions of a small area which is to be supported by a specialized support tower.",
+      "type": "float",
+      "category": "Support",
+      "default": 3.0,
+      "unit": "mm",
+      "min": "0",
+      "max": "support_tower_diameter"
+    },
+    {
+      "key": "support_tower_roof_angle",
+      "label": "Tower Roof Angle",
+      "description": "The angle of a rooftop of a tower. A higher value results in pointed tower roofs, a lower value results in flattened tower roofs.",
+      "type": "int",
+      "category": "Support",
+      "default": 65,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "support_mesh_drop_down",
+      "label": "Drop Down Support Mesh",
+      "description": "Make support everywhere below the support mesh, so that there's no overhang in the support mesh.",
+      "type": "bool",
+      "category": "Support",
+      "default": true
+    },
+    {
+      "key": "support_meshes_present",
+      "label": "Scene Has Support Meshes",
+      "description": "There are support meshes present in the scene. This setting is controlled by Cura.",
+      "type": "bool",
+      "category": "Support",
+      "default": false
+    },
+    {
+      "key": "prime_blob_enable",
+      "label": "Enable Prime Blob",
+      "description": "Whether to prime the filament with a blob before printing. Turning this setting on will ensure that the extruder will have material ready at the nozzle before printing. Printing Brim or Skirt can act like priming too, in which case turning this setting off saves some time.",
+      "type": "bool",
+      "category": "Build Plate Adhesion",
+      "default": false
+    },
+    {
+      "key": "extruder_prime_pos_x",
+      "label": "Extruder Prime X Position",
+      "description": "The X coordinate of the position where the nozzle primes at the start of printing.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "mm"
+    },
+    {
+      "key": "extruder_prime_pos_y",
+      "label": "Extruder Prime Y Position",
+      "description": "The Y coordinate of the position where the nozzle primes at the start of printing.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "mm"
+    },
+    {
+      "key": "adhesion_type",
+      "label": "Build Plate Adhesion Type",
+      "description": "Different options that help to improve both priming your extrusion and adhesion to the build plate. Brim adds a single layer flat area around the base of your model to prevent warping. Raft adds a thick grid with a roof below the model. Skirt is a line printed around the model, but not connected to the model.",
+      "type": "enum",
+      "category": "Build Plate Adhesion",
+      "default": "brim",
+      "options": {
+        "skirt": "Skirt",
+        "brim": "Brim",
+        "raft": "Raft",
+        "none": "None"
+      }
+    },
+    {
+      "key": "adhesion_extruder_nr",
+      "label": "Build Plate Adhesion Extruder",
+      "description": "The extruder train to use for printing the skirt/brim/raft. This is used in multi-extrusion.",
+      "type": "optional_extruder",
+      "category": "Build Plate Adhesion",
+      "default": "-1"
+    },
+    {
+      "key": "skirt_brim_extruder_nr",
+      "label": "Skirt/Brim Extruder",
+      "description": "The extruder train to use for printing the skirt or brim. This is used in multi-extrusion.",
+      "type": "optional_extruder",
+      "category": "Build Plate Adhesion",
+      "default": "-1"
+    },
+    {
+      "key": "raft_base_extruder_nr",
+      "label": "Raft Base Extruder",
+      "description": "The extruder train to use for printing the first layer of the raft. This is used in multi-extrusion.",
+      "type": "extruder",
+      "category": "Build Plate Adhesion",
+      "default": "0"
+    },
+    {
+      "key": "raft_interface_extruder_nr",
+      "label": "Raft Middle Extruder",
+      "description": "The extruder train to use for printing the middle layer of the raft. This is used in multi-extrusion.",
+      "type": "extruder",
+      "category": "Build Plate Adhesion",
+      "default": "0"
+    },
+    {
+      "key": "raft_surface_extruder_nr",
+      "label": "Raft Top Extruder",
+      "description": "The extruder train to use for printing the top layer(s) of the raft. This is used in multi-extrusion.",
+      "type": "extruder",
+      "category": "Build Plate Adhesion",
+      "default": "0"
+    },
+    {
+      "key": "skirt_line_count",
+      "label": "Skirt Line Count",
+      "description": "Multiple skirt lines help to prime your extrusion better for small models. Setting this to 0 will disable the skirt.",
+      "type": "int",
+      "category": "Build Plate Adhesion",
+      "default": 1,
+      "min": "0",
+      "max": "0.5 * min(machine_width, machine_depth) / skirt_brim_line_width"
+    },
+    {
+      "key": "skirt_height",
+      "label": "Skirt Height",
+      "description": "Printing the innermost skirt line with multiple layers makes it easy to remove the skirt.",
+      "type": "int",
+      "category": "Build Plate Adhesion",
+      "default": 3,
+      "min": "1",
+      "max": "machine_height / layer_height"
+    },
+    {
+      "key": "skirt_gap",
+      "label": "Skirt Distance",
+      "description": "The horizontal distance between the skirt and the first layer of the print.\nThis is the minimum distance. Multiple skirt lines will extend outwards from this distance.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 3,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "skirt_brim_minimal_length",
+      "label": "Skirt/Brim Minimum Length",
+      "description": "The minimum length of the skirt or brim. If this length is not reached by all skirt or brim lines together, more skirt or brim lines will be added until the minimum length is reached. Note: If the line count is set to 0 this is ignored.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 250,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "brim_width",
+      "label": "Brim Width",
+      "description": "The distance from the model to the outermost brim line. A larger brim enhances adhesion to the build plate, but also reduces the effective print area.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 8.0,
+      "unit": "mm",
+      "min": "0.0"
+    },
+    {
+      "key": "brim_line_count",
+      "label": "Brim Line Count",
+      "description": "The number of lines used for a brim. More brim lines enhance adhesion to the build plate, but also reduces the effective print area.",
+      "type": "int",
+      "category": "Build Plate Adhesion",
+      "default": 20,
+      "min": "0"
+    },
+    {
+      "key": "brim_gap",
+      "label": "Brim Distance",
+      "description": "The horizontal distance between the first brim line and the outline of the first layer of the print. A small gap can make the brim easier to remove while still providing the thermal benefits.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "mm",
+      "min": "-skirt_brim_line_width / 2"
+    },
+    {
+      "key": "brim_replaces_support",
+      "label": "Brim Replaces Support",
+      "description": "Enforce brim to be printed around the model even if that space would otherwise be occupied by support. This replaces some regions of the first layer of support by brim regions.",
+      "type": "bool",
+      "category": "Build Plate Adhesion",
+      "default": true
+    },
+    {
+      "key": "brim_location",
+      "label": "Brim Location",
+      "description": "Print a brim on the outside of the model, inside, or both. Depending on the model, this helps reducing the amount of brim you need to remove afterwards, while ensuring a proper bed adhesion.",
+      "type": "enum",
+      "category": "Build Plate Adhesion",
+      "default": "outside",
+      "options": {
+        "outside": "Outside Only",
+        "inside": "Inside Only",
+        "everywhere": "Everywhere"
+      }
+    },
+    {
+      "key": "brim_inside_margin",
+      "label": "Brim Avoid Margin",
+      "description": "A brim around a model may touch an other model where you don't want it. This removes all brim within this distance from brimless models.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": "1.6",
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "brim_smart_ordering",
+      "label": "Smart Brim",
+      "description": "Swap print order of the innermost and second innermost brim lines. This improves brim removal.",
+      "type": "bool",
+      "category": "Build Plate Adhesion",
+      "default": true
+    },
+    {
+      "key": "raft_margin",
+      "label": "Raft Extra Margin",
+      "description": "If the raft is enabled, this is the extra raft area around the model which is also given a raft. Increasing this margin will create a stronger raft while using more material and leaving less area for your print.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 15,
+      "unit": "mm"
+    },
+    {
+      "key": "raft_base_margin",
+      "label": "Raft Base Extra Margin",
+      "description": "If the raft base is enabled, this is the extra raft area around the model which is also given a raft. Increasing this margin will create a stronger raft while using more material and leaving less area for your print.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 15,
+      "unit": "mm"
+    },
+    {
+      "key": "raft_interface_margin",
+      "label": "Raft Middle Extra Margin",
+      "description": "If the raft middle is enabled, this is the extra raft area around the model which is also given a raft. Increasing this margin will create a stronger raft while using more material and leaving less area for your print.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 15,
+      "unit": "mm"
+    },
+    {
+      "key": "raft_surface_margin",
+      "label": "Raft Top Extra Margin",
+      "description": "If the raft top is enabled, this is the extra raft area around the model which is also given a raft. Increasing this margin will create a stronger raft while using more material and leaving less area for your print.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 15,
+      "unit": "mm"
+    },
+    {
+      "key": "raft_remove_inside_corners",
+      "label": "Remove Raft Inside Corners",
+      "description": "Remove inside corners from the raft, causing the raft to become convex.",
+      "type": "bool",
+      "category": "Build Plate Adhesion",
+      "default": false
+    },
+    {
+      "key": "raft_base_remove_inside_corners",
+      "label": "Remove Raft Base Inside Corners",
+      "description": "Remove inside corners from the raft base, causing the raft to become convex.",
+      "type": "bool",
+      "category": "Build Plate Adhesion",
+      "default": false
+    },
+    {
+      "key": "raft_interface_remove_inside_corners",
+      "label": "Remove Raft Middle Inside Corners",
+      "description": "Remove inside corners from the raft middle part, causing the raft to become convex.",
+      "type": "bool",
+      "category": "Build Plate Adhesion",
+      "default": false
+    },
+    {
+      "key": "raft_surface_remove_inside_corners",
+      "label": "Remove Raft Top Inside Corners",
+      "description": "Remove inside corners from the raft top part, causing the raft to become convex.",
+      "type": "bool",
+      "category": "Build Plate Adhesion",
+      "default": false
+    },
+    {
+      "key": "raft_smoothing",
+      "label": "Raft Smoothing",
+      "description": "This setting controls how much inner corners in the raft outline are rounded. Inward corners are rounded to a semi circle with a radius equal to the value given here. This setting also removes holes in the raft outline which are smaller than such a circle.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "raft_base_smoothing",
+      "label": "Raft Base Smoothing",
+      "description": "This setting controls how much inner corners in the raft base outline are rounded. Inward corners are rounded to a semi circle with a radius equal to the value given here. This setting also removes holes in the raft outline which are smaller than such a circle.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "raft_interface_smoothing",
+      "label": "Raft Middle Smoothing",
+      "description": "This setting controls how much inner corners in the raft middle outline are rounded. Inward corners are rounded to a semi circle with a radius equal to the value given here. This setting also removes holes in the raft outline which are smaller than such a circle.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "raft_surface_smoothing",
+      "label": "Raft Top Smoothing",
+      "description": "This setting controls how much inner corners in the raft top outline are rounded. Inward corners are rounded to a semi circle with a radius equal to the value given here. This setting also removes holes in the raft outline which are smaller than such a circle.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "raft_airgap",
+      "label": "Raft Air Gap",
+      "description": "The gap between the final raft layer and the first layer of the model. Only the first layer is raised by this amount to lower the bonding between the raft layer and the model. Makes it easier to peel off the raft.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.3,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "layer_0_z_overlap",
+      "label": "Initial Layer Z Overlap",
+      "description": "Make the first and second layer of the model overlap in the Z direction to compensate for the filament lost in the airgap. All models above the first model layer will be shifted down by this amount.\nIt may be noted that sometimes the second layer is printed below initial layer because of this setting. This is intended behavior",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.22,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "raft_base_thickness",
+      "label": "Raft Base Thickness",
+      "description": "Layer thickness of the base raft layer. This should be a thick layer which sticks firmly to the printer build plate.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.3,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "raft_base_line_width",
+      "label": "Raft Base Line Width",
+      "description": "Width of the lines in the base raft layer. These should be thick lines to assist in build plate adhesion.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.8,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "raft_base_line_spacing",
+      "label": "Raft Base Line Spacing",
+      "description": "The distance between the raft lines for the base raft layer. Wide spacing makes for easy removal of the raft from the build plate.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 1.6,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "raft_base_infill_overlap",
+      "label": "Raft Base Infill Overlap Percentage",
+      "description": "The amount of overlap between the infill and the walls of the raft base, as a percentage of the infill line width. A slight overlap allows the walls to connect firmly to the infill.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "%"
+    },
+    {
+      "key": "raft_base_infill_overlap_mm",
+      "label": "Raft Base Infill Overlap",
+      "description": "The amount of overlap between the infill and the walls of the raft base. A slight overlap allows the walls to connect firmly to the infill.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.0,
+      "unit": "mm"
+    },
+    {
+      "key": "raft_interface_layers",
+      "label": "Raft Middle Layers",
+      "description": "The number of layers between the base and the surface of the raft. These comprise the main thickness of the raft. Increasing this creates a thicker, sturdier raft.",
+      "type": "int",
+      "category": "Build Plate Adhesion",
+      "default": 1,
+      "min": "0"
+    },
+    {
+      "key": "raft_interface_thickness",
+      "label": "Raft Middle Thickness",
+      "description": "Layer thickness of the middle raft layer.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.15,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "raft_interface_line_width",
+      "label": "Raft Middle Line Width",
+      "description": "Width of the lines in the middle raft layer. Making the second layer extrude more causes the lines to stick to the build plate.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.7,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "raft_interface_line_spacing",
+      "label": "Raft Middle Spacing",
+      "description": "The distance between the raft lines for the middle raft layer. The spacing of the middle should be quite wide, while being dense enough to support the top raft layers.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.9,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "raft_interface_z_offset",
+      "label": "Raft Interface Z Offset",
+      "description": "When printing the first layer of the raft interface, translate by this offset to customize the adhesion between base and interface. A negative offset should improve the adhesion.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.0,
+      "unit": "mm",
+      "min": "-raft_interface_thickness",
+      "max": "raft_interface_thickness"
+    },
+    {
+      "key": "raft_interface_infill_overlap",
+      "label": "Raft Interface Infill Overlap Percentage",
+      "description": "The amount of overlap between the infill and the walls of the raft interface, as a percentage of the infill line width. A slight overlap allows the walls to connect firmly to the infill.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "%"
+    },
+    {
+      "key": "raft_interface_infill_overlap_mm",
+      "label": "Raft Interface Infill Overlap",
+      "description": "The amount of overlap between the infill and the walls of the raft interface. A slight overlap allows the walls to connect firmly to the infill.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.0,
+      "unit": "mm"
+    },
+    {
+      "key": "raft_surface_layers",
+      "label": "Raft Top Layers",
+      "description": "The number of top layers on top of the 2nd raft layer. These are fully filled layers that the model sits on. 2 layers result in a smoother top surface than 1.",
+      "type": "int",
+      "category": "Build Plate Adhesion",
+      "default": 2,
+      "min": "0"
+    },
+    {
+      "key": "raft_surface_thickness",
+      "label": "Raft Top Layer Thickness",
+      "description": "Layer thickness of the top raft layers.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "raft_surface_line_width",
+      "label": "Raft Top Line Width",
+      "description": "Width of the lines in the top surface of the raft. These can be thin lines so that the top of the raft becomes smooth.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "raft_surface_line_spacing",
+      "label": "Raft Top Spacing",
+      "description": "The distance between the raft lines for the top raft layers. The spacing should be equal to the line width, so that the surface is solid.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "raft_surface_z_offset",
+      "label": "Raft Surface Z Offset",
+      "description": "When printing the first layer of the raft surface, translate by this offset to customize the adhesion between interface and surface. A negative offset should improve the adhesion.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.0,
+      "unit": "mm",
+      "min": "-raft_surface_thickness",
+      "max": "raft_surface_thickness"
+    },
+    {
+      "key": "raft_surface_monotonic",
+      "label": "Monotonic Raft Top Surface Order",
+      "description": "Print raft top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes the surface look more consistent, which is also visible on the model bottom surface.",
+      "type": "bool",
+      "category": "Build Plate Adhesion",
+      "default": false
+    },
+    {
+      "key": "raft_surface_infill_overlap",
+      "label": "Raft Surface Infill Overlap Percentage",
+      "description": "The amount of overlap between the infill and the walls of the raft surface, as a percentage of the infill line width. A slight overlap allows the walls to connect firmly to the infill.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "%"
+    },
+    {
+      "key": "raft_surface_infill_overlap_mm",
+      "label": "Raft Surface Infill Overlap",
+      "description": "The amount of overlap between the infill and the walls of the raft surface. A slight overlap allows the walls to connect firmly to the infill.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0.0,
+      "unit": "mm"
+    },
+    {
+      "key": "raft_wall_count",
+      "label": "Raft Wall Count",
+      "description": "The number of contours to print around the linear pattern of the raft.",
+      "type": "int",
+      "category": "Build Plate Adhesion",
+      "default": 1,
+      "min": "0"
+    },
+    {
+      "key": "raft_base_wall_count",
+      "label": "Raft Base Wall Count",
+      "description": "The number of contours to print around the linear pattern in the base layer of the raft.",
+      "type": "int",
+      "category": "Build Plate Adhesion",
+      "default": 1,
+      "min": "0"
+    },
+    {
+      "key": "raft_interface_wall_count",
+      "label": "Raft Middle Wall Count",
+      "description": "The number of contours to print around the linear pattern in the middle layers of the raft.",
+      "type": "int",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "min": "0"
+    },
+    {
+      "key": "raft_surface_wall_count",
+      "label": "Raft Top Wall Count",
+      "description": "The number of contours to print around the linear pattern in the top layers of the raft.",
+      "type": "int",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "min": "0"
+    },
+    {
+      "key": "raft_speed",
+      "label": "Raft Print Speed",
+      "description": "The speed at which the raft is printed.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "raft_base_speed",
+      "label": "Raft Base Print Speed",
+      "description": "The speed at which the base raft layer is printed. This should be printed quite slowly, as the volume of material coming out of the nozzle is quite high.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 15,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "raft_interface_speed",
+      "label": "Raft Middle Print Speed",
+      "description": "The speed at which the middle raft layer is printed. This should be printed quite slowly, as the volume of material coming out of the nozzle is quite high.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 15,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "raft_surface_speed",
+      "label": "Raft Top Print Speed",
+      "description": "The speed at which the top raft layers are printed. These should be printed a bit slower, so that the nozzle can slowly smooth out adjacent surface lines.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "raft_acceleration",
+      "label": "Raft Print Acceleration",
+      "description": "The acceleration with which the raft is printed.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "raft_base_acceleration",
+      "label": "Raft Base Print Acceleration",
+      "description": "The acceleration with which the base raft layer is printed.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "raft_interface_acceleration",
+      "label": "Raft Middle Print Acceleration",
+      "description": "The acceleration with which the middle raft layer is printed.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "raft_surface_acceleration",
+      "label": "Raft Top Print Acceleration",
+      "description": "The acceleration with which the top raft layers are printed.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 3000,
+      "unit": "mm/s\u00b2",
+      "min": "0.1"
+    },
+    {
+      "key": "raft_jerk",
+      "label": "Raft Print Jerk",
+      "description": "The jerk with which the raft is printed.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "raft_base_jerk",
+      "label": "Raft Base Print Jerk",
+      "description": "The jerk with which the base raft layer is printed.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "raft_interface_jerk",
+      "label": "Raft Middle Print Jerk",
+      "description": "The jerk with which the middle raft layer is printed.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "raft_surface_jerk",
+      "label": "Raft Top Print Jerk",
+      "description": "The jerk with which the top raft layers are printed.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "raft_fan_speed",
+      "label": "Raft Fan Speed",
+      "description": "The fan speed for the raft.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "raft_base_fan_speed",
+      "label": "Raft Base Fan Speed",
+      "description": "The fan speed for the base raft layer.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "raft_interface_fan_speed",
+      "label": "Raft Middle Fan Speed",
+      "description": "The fan speed for the middle raft layer.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "raft_surface_fan_speed",
+      "label": "Raft Top Fan Speed",
+      "description": "The fan speed for the top raft layers.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 0,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "raft_flow",
+      "label": "Raft Flow",
+      "description": "The amount of material, relative to a normal extrusion line, to extrude during raft printing. Having an increased flow may improve adhesion and raft structural strength.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 100.0,
+      "unit": "%",
+      "min": "10"
+    },
+    {
+      "key": "raft_base_flow",
+      "label": "Raft Base Flow",
+      "description": "The amount of material, relative to a normal extrusion line, to extrude during raft base printing. Having an increased flow may improve adhesion and raft structural strength.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 100.0,
+      "unit": "%",
+      "min": "10"
+    },
+    {
+      "key": "raft_interface_flow",
+      "label": "Raft Interface Flow",
+      "description": "The amount of material, relative to a normal extrusion line, to extrude during raft interface printing. Having an increased flow may improve adhesion and raft structural strength.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 100.0,
+      "unit": "%",
+      "min": "10"
+    },
+    {
+      "key": "raft_surface_flow",
+      "label": "Raft Surface Flow",
+      "description": "The amount of material, relative to a normal extrusion line, to extrude during raft surface printing. Having an increased flow may improve adhesion and raft structural strength.",
+      "type": "float",
+      "category": "Build Plate Adhesion",
+      "default": 100.0,
+      "unit": "%",
+      "min": "10"
+    },
+    {
+      "key": "machine_scan_first_layer",
+      "label": "Scan the first layer",
+      "description": "Whether to scan the first layer for layer adhesion problems.",
+      "type": "bool",
+      "category": "Build Plate Adhesion",
+      "default": false
+    },
+    {
+      "key": "prime_tower_enable",
+      "label": "Enable Prime Tower",
+      "description": "Print a tower next to the print which serves to prime the material after each nozzle switch.",
+      "type": "bool",
+      "category": "Dual Extrusion",
+      "default": false
+    },
+    {
+      "key": "prime_tower_mode",
+      "label": "Prime Tower Type",
+      "description": "<html>How to generate the prime tower:<ul><li><b>Normal:</b> create a bucket in which secondary materials are primed</li><li><b>Interleaved:</b> create a prime tower as sparse as possible. This will save time and filament, but is only possible if the used materials adhere to each other</li></ul></html>",
+      "type": "enum",
+      "category": "Dual Extrusion",
+      "default": "normal",
+      "options": {
+        "normal": "Normal",
+        "interleaved": "Interleaved"
+      }
+    },
+    {
+      "key": "prime_tower_size",
+      "label": "Prime Tower Size",
+      "description": "The width of the prime tower.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 20,
+      "unit": "mm",
+      "min": "0",
+      "max": "min(0.5 * machine_width, 0.5 * machine_depth)"
+    },
+    {
+      "key": "prime_tower_min_volume",
+      "label": "Prime Tower Minimum Volume",
+      "description": "The minimum volume for each layer of the prime tower in order to purge enough material.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 6,
+      "unit": "mm\u00b3",
+      "min": "0"
+    },
+    {
+      "key": "prime_tower_max_bridging_distance",
+      "label": "Prime Tower Maximum Bridging Distance",
+      "description": "The maximum length of the branches which may be printed over the air.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 5,
+      "unit": "mm",
+      "min": "line_width"
+    },
+    {
+      "key": "prime_tower_min_shell_thickness",
+      "label": "Prime Tower Minimum Shell Thickness",
+      "description": "The minimum thickness of the prime tower shell. You may increase it to make the prime tower stronger.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 0.4,
+      "unit": "mm",
+      "min": "max(extruderValues('prime_tower_line_width'))"
+    },
+    {
+      "key": "prime_tower_position_x",
+      "label": "Prime Tower X Position",
+      "description": "The x coordinate of the position of the prime tower.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 200,
+      "unit": "mm",
+      "min": "resolveOrValue('prime_tower_size') + (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0) - (machine_width / 2 if machine_center_is_zero else 0)",
+      "max": "(machine_width / 2 if machine_center_is_zero else machine_width) - (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0)"
+    },
+    {
+      "key": "prime_tower_position_y",
+      "label": "Prime Tower Y Position",
+      "description": "The y coordinate of the position of the prime tower.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 200,
+      "unit": "mm",
+      "min": "(machine_depth / -2 if machine_center_is_zero else 0) + (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0)",
+      "max": "(machine_depth / 2 - resolveOrValue('prime_tower_size') if machine_center_is_zero else machine_depth - resolveOrValue('prime_tower_size')) - (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0)"
+    },
+    {
+      "key": "prime_tower_wipe_enabled",
+      "label": "Wipe Inactive Nozzle on Prime Tower",
+      "description": "After printing the prime tower with one nozzle, wipe the oozed material from the other nozzle off on the prime tower.",
+      "type": "bool",
+      "category": "Dual Extrusion",
+      "default": true
+    },
+    {
+      "key": "prime_tower_brim_enable",
+      "label": "Prime Tower Base",
+      "description": "By enabling this setting, your prime-tower will get a brim, even if the model doesn't. If you want a sturdier base for a high tower, you can increase the base height.",
+      "type": "bool",
+      "category": "Dual Extrusion",
+      "default": false
+    },
+    {
+      "key": "prime_tower_base_size",
+      "label": "Prime Tower Base Size",
+      "description": "The width of the prime tower brim/base. A larger base enhances adhesion to the build plate, but also reduces the effective print area.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 1.2,
+      "unit": "mm",
+      "min": "0",
+      "max": "min(0.5 * machine_width, 0.5 * machine_depth)"
+    },
+    {
+      "key": "prime_tower_base_height",
+      "label": "Prime Tower Base Height",
+      "description": "The height of the prime tower base. Increasing this value will result in a more sturdy prime tower because the base will be wider. If this setting is too low, the prime tower will not have a sturdy base.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 0,
+      "unit": "mm",
+      "min": "0",
+      "max": "machine_height"
+    },
+    {
+      "key": "prime_tower_base_curve_magnitude",
+      "label": "Prime Tower Base Slope",
+      "description": "The magnitude factor used for the slope of the prime tower base. If you increase this value, the base will become slimmer. If you decrease it, the base will become thicker.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 4,
+      "min": "0",
+      "max": "10"
+    },
+    {
+      "key": "prime_tower_raft_base_line_spacing",
+      "label": "Prime Tower Raft Line Spacing",
+      "description": "The distance between the raft lines for the unique prime tower raft layer. Wide spacing makes for easy removal of the raft from the build plate.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 1.6,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "ooze_shield_enabled",
+      "label": "Enable Ooze Shield",
+      "description": "Enable exterior ooze shield. This will create a shell around the model which is likely to wipe a second nozzle if it's at the same height as the first nozzle.",
+      "type": "bool",
+      "category": "Dual Extrusion",
+      "default": false
+    },
+    {
+      "key": "ooze_shield_angle",
+      "label": "Ooze Shield Angle",
+      "description": "The maximum angle a part in the ooze shield will have. With 0 degrees being vertical, and 90 degrees being horizontal. A smaller angle leads to less failed ooze shields, but more material.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 60,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "ooze_shield_dist",
+      "label": "Ooze Shield Distance",
+      "description": "Distance of the ooze shield from the print, in the X/Y directions.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 2,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "switch_extruder_retraction_amount",
+      "label": "Nozzle Switch Retraction Distance",
+      "description": "The amount of retraction when switching extruders. Set to 0 for no retraction at all. This should generally be the same as the length of the heat zone.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 20,
+      "unit": "mm"
+    },
+    {
+      "key": "switch_extruder_retraction_speeds",
+      "label": "Nozzle Switch Retraction Speed",
+      "description": "The speed at which the filament is retracted. A higher retraction speed works better, but a very high retraction speed can lead to filament grinding.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "machine_max_feedrate_e if retraction_enable else float('inf')"
+    },
+    {
+      "key": "switch_extruder_retraction_speed",
+      "label": "Nozzle Switch Retract Speed",
+      "description": "The speed at which the filament is retracted during a nozzle switch retract.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "machine_max_feedrate_e if retraction_enable else float('inf')"
+    },
+    {
+      "key": "switch_extruder_prime_speed",
+      "label": "Nozzle Switch Prime Speed",
+      "description": "The speed at which the filament is pushed back after a nozzle switch retraction.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 20,
+      "unit": "mm/s",
+      "min": "0.1",
+      "max": "machine_max_feedrate_e if retraction_enable else float('inf')"
+    },
+    {
+      "key": "switch_extruder_extra_prime_amount",
+      "label": "Nozzle Switch Extra Prime Amount",
+      "description": "Extra material to prime after nozzle switching.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 0,
+      "unit": "mm\u00b3"
+    },
+    {
+      "key": "interlocking_enable",
+      "label": "Generate Interlocking Structure",
+      "description": "At the locations where models touch, generate an interlocking beam structure. This improves the adhesion between models, especially models printed in different materials.",
+      "type": "bool",
+      "category": "Dual Extrusion",
+      "default": false
+    },
+    {
+      "key": "interlocking_beam_width",
+      "label": "Interlocking Beam Width",
+      "description": "The width of the interlocking structure beams.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 0.8,
+      "unit": "mm",
+      "min": "min_odd_wall_line_width",
+      "max": "min(0.5 * machine_width, 0.5 * machine_depth)"
+    },
+    {
+      "key": "interlocking_orientation",
+      "label": "Interlocking Structure Orientation",
+      "description": "The height of the beams of the interlocking structure, measured in number of layers. Less layers is stronger, but more prone to defects.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 22.5,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "360"
+    },
+    {
+      "key": "interlocking_beam_layer_count",
+      "label": "Interlocking Beam Layer Count",
+      "description": "The height of the beams of the interlocking structure, measured in number of layers. Less layers is stronger, but more prone to defects.",
+      "type": "int",
+      "category": "Dual Extrusion",
+      "default": 2,
+      "min": "1"
+    },
+    {
+      "key": "interlocking_depth",
+      "label": "Interlocking Depth",
+      "description": "The distance from the boundary between models to generate interlocking structure, measured in cells. Too few cells will result in poor adhesion.",
+      "type": "int",
+      "category": "Dual Extrusion",
+      "default": 2,
+      "min": "1",
+      "max": "10"
+    },
+    {
+      "key": "interlocking_boundary_avoidance",
+      "label": "Interlocking Boundary Avoidance",
+      "description": "The distance from the outside of a model where interlocking structures will not be generated, measured in cells.",
+      "type": "int",
+      "category": "Dual Extrusion",
+      "default": 2,
+      "min": "0",
+      "max": "10"
+    },
+    {
+      "key": "multi_material_paint_resolution",
+      "label": "Multi-material Precision",
+      "description": "The precision of the details when generating multi-material shapes based on painting data. A lower precision will provide more details, but increase the slicing time and memory.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 0.2,
+      "unit": "mm",
+      "min": "0.05",
+      "max": "5"
+    },
+    {
+      "key": "multi_material_paint_depth",
+      "label": "Multi-material Depth",
+      "description": "The depth of the painted details inside the model. A higher depth will provide a better interlocking, but increase slicing time and memory. Set a very high value to go as deep as possible. The actually calculated depth may vary.",
+      "type": "float",
+      "category": "Dual Extrusion",
+      "default": 4,
+      "unit": "mm",
+      "min": "line_width"
+    },
+    {
+      "key": "meshfix_union_all",
+      "label": "Union Overlapping Volumes",
+      "description": "Ignore the internal geometry arising from overlapping volumes within a mesh and print the volumes as one. This may cause unintended internal cavities to disappear.",
+      "type": "bool",
+      "category": "Mesh Fixes",
+      "default": true
+    },
+    {
+      "key": "meshfix_union_all_remove_holes",
+      "label": "Remove All Holes",
+      "description": "Remove the holes in each layer and keep only the outside shape. This will ignore any invisible internal geometry. However, it also ignores layer holes which can be viewed from above or below.",
+      "type": "bool",
+      "category": "Mesh Fixes",
+      "default": false
+    },
+    {
+      "key": "meshfix_extensive_stitching",
+      "label": "Extensive Stitching",
+      "description": "Extensive stitching tries to stitch up open holes in the mesh by closing the hole with touching polygons. This option can introduce a lot of processing time.",
+      "type": "bool",
+      "category": "Mesh Fixes",
+      "default": false
+    },
+    {
+      "key": "meshfix_keep_open_polygons",
+      "label": "Keep Disconnected Faces",
+      "description": "Normally Cura tries to stitch up small holes in the mesh and remove parts of a layer with big holes. Enabling this option keeps those parts which cannot be stitched. This option should be used as a last resort option when everything else fails to produce proper g-code.",
+      "type": "bool",
+      "category": "Mesh Fixes",
+      "default": false
+    },
+    {
+      "key": "multiple_mesh_overlap",
+      "label": "Merged Meshes Overlap",
+      "description": "Make meshes which are touching each other overlap a bit. This makes them bond together better.",
+      "type": "float",
+      "category": "Mesh Fixes",
+      "default": 0.15,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "carve_multiple_volumes",
+      "label": "Remove Mesh Intersection",
+      "description": "Remove areas where multiple meshes are overlapping with each other. This may be used if merged dual material objects overlap with each other.",
+      "type": "bool",
+      "category": "Mesh Fixes",
+      "default": true
+    },
+    {
+      "key": "alternate_carve_order",
+      "label": "Alternate Mesh Removal",
+      "description": "Switch to which mesh intersecting volumes will belong with every layer, so that the overlapping meshes become interwoven. Turning this setting off will cause one of the meshes to obtain all of the volume in the overlap, while it is removed from the other meshes.",
+      "type": "bool",
+      "category": "Mesh Fixes",
+      "default": true
+    },
+    {
+      "key": "remove_empty_first_layers",
+      "label": "Remove Empty First Layers",
+      "description": "Remove empty layers beneath the first printed layer if they are present. Disabling this setting can cause empty first layers if the Slicing Tolerance setting is set to Exclusive or Middle.",
+      "type": "bool",
+      "category": "Mesh Fixes",
+      "default": true
+    },
+    {
+      "key": "meshfix_maximum_resolution",
+      "label": "Maximum Resolution",
+      "description": "The minimum size of a line segment after slicing. If you increase this, the mesh will have a lower resolution. This may allow the printer to keep up with the speed it has to process g-code and will increase slice speed by removing details of the mesh that it can't process anyway.",
+      "type": "float",
+      "category": "Mesh Fixes",
+      "default": 0.5,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "meshfix_maximum_travel_resolution",
+      "label": "Maximum Travel Resolution",
+      "description": "The minimum size of a travel line segment after slicing. If you increase this, the travel moves will have less smooth corners. This may allow the printer to keep up with the speed it has to process g-code, but it may cause model avoidance to become less accurate.",
+      "type": "float",
+      "category": "Mesh Fixes",
+      "default": 1.0,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "meshfix_maximum_deviation",
+      "label": "Maximum Deviation",
+      "description": "The maximum deviation allowed when reducing the resolution for the Maximum Resolution setting. If you increase this, the print will be less accurate, but the g-code will be smaller. Maximum Deviation is a limit for Maximum Resolution, so if the two conflict the Maximum Deviation will always be held true.",
+      "type": "float",
+      "category": "Mesh Fixes",
+      "default": 0.025,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "meshfix_maximum_extrusion_area_deviation",
+      "label": "Maximum Extrusion Area Deviation",
+      "description": "The maximum extrusion area deviation allowed when removing intermediate points from a straight line. An intermediate point may serve as width-changing point in a long straight line. Therefore, if it is removed, it will cause the line to have a uniform width and, as a result, lose (or gain) a bit of extrusion area. If you increase this you may notice slight under- (or over-) extrusion in between straight parallel walls, as more intermediate width-changing points will be allowed to be removed. Your print will be less accurate, but the g-code will be smaller.",
+      "type": "float",
+      "category": "Mesh Fixes",
+      "default": 50000,
+      "unit": "\u03bcm\u00b2",
+      "min": "0"
+    },
+    {
+      "key": "meshfix_fluid_motion_enabled",
+      "label": "Enable Fluid Motion",
+      "description": "When enabled tool paths are corrected for printers with smooth motion planners. Small movements that deviate from the general tool path direction are smoothed to improve fluid motions.",
+      "type": "bool",
+      "category": "Mesh Fixes",
+      "default": true
+    },
+    {
+      "key": "meshfix_fluid_motion_shift_distance",
+      "label": "Fluid Motion Shift Distance",
+      "description": "Distance points are shifted to smooth the path",
+      "type": "float",
+      "category": "Mesh Fixes",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0.01",
+      "max": "1"
+    },
+    {
+      "key": "meshfix_fluid_motion_small_distance",
+      "label": "Fluid Motion Small Distance",
+      "description": "Distance points are shifted to smooth the path",
+      "type": "float",
+      "category": "Mesh Fixes",
+      "default": 0.01,
+      "unit": "mm",
+      "min": "0.01",
+      "max": "0.1"
+    },
+    {
+      "key": "meshfix_fluid_motion_angle",
+      "label": "Fluid Motion Angle",
+      "description": "If a toolpath-segment deviates more than this angle from the general motion it is smoothed.",
+      "type": "float",
+      "category": "Mesh Fixes",
+      "default": 15,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "print_sequence",
+      "label": "Print Sequence",
+      "description": "Whether to print all models one layer at a time or to wait for one model to finish, before moving on to the next. One at a time mode is possible if a) only one extruder is enabled and b) all models are separated in such a way that the whole print head can move in between and all models are lower than the distance between the nozzle and the X/Y axes.",
+      "type": "enum",
+      "category": "Special Modes",
+      "default": "all_at_once",
+      "options": {
+        "all_at_once": "All at Once",
+        "one_at_a_time": "One at a Time"
+      }
+    },
+    {
+      "key": "user_defined_print_order_enabled",
+      "label": "Set Print Sequence Manually",
+      "description": "Allows you to order the object list to manually set the print sequence. First object from the list will be printed first.",
+      "type": "bool",
+      "category": "Special Modes",
+      "default": false
+    },
+    {
+      "key": "infill_mesh",
+      "label": "Infill Mesh",
+      "description": "Use this mesh to modify the infill of other meshes with which it overlaps. Replaces infill regions of other meshes with regions for this mesh. It's suggested to only print one Wall and no Top/Bottom Skin for this mesh.",
+      "type": "bool",
+      "category": "Special Modes",
+      "default": false
+    },
+    {
+      "key": "infill_mesh_order",
+      "label": "Mesh Processing Rank",
+      "description": "Determines the priority of this mesh when considering multiple overlapping infill meshes. Areas where multiple infill meshes overlap will take on the settings of the mesh with the highest rank. An infill mesh with a higher rank will modify the infill of infill meshes with lower rank and normal meshes.",
+      "type": "int",
+      "category": "Special Modes",
+      "default": 0
+    },
+    {
+      "key": "cutting_mesh",
+      "label": "Cutting Mesh",
+      "description": "Limit the volume of this mesh to within other meshes. You can use this to make certain areas of one mesh print with different settings and with a whole different extruder.",
+      "type": "bool",
+      "category": "Special Modes",
+      "default": false
+    },
+    {
+      "key": "mold_enabled",
+      "label": "Mold",
+      "description": "Print models as a mold, which can be cast in order to get a model which resembles the models on the build plate.",
+      "type": "bool",
+      "category": "Special Modes",
+      "default": false
+    },
+    {
+      "key": "mold_width",
+      "label": "Minimal Mold Width",
+      "description": "The minimal distance between the outside of the mold and the outside of the model.",
+      "type": "float",
+      "category": "Special Modes",
+      "default": 5,
+      "unit": "mm"
+    },
+    {
+      "key": "mold_roof_height",
+      "label": "Mold Roof Height",
+      "description": "The height above horizontal parts in your model which to print mold.",
+      "type": "float",
+      "category": "Special Modes",
+      "default": 0.5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "mold_angle",
+      "label": "Mold Angle",
+      "description": "The angle of overhang of the outer walls created for the mold. 0\u00b0 will make the outer shell of the mold vertical, while 90\u00b0 will make the outside of the model follow the contour of the model.",
+      "type": "float",
+      "category": "Special Modes",
+      "default": 40,
+      "unit": "\u00b0",
+      "min": "-89",
+      "max": "90"
+    },
+    {
+      "key": "support_mesh",
+      "label": "Support Mesh",
+      "description": "Use this mesh to specify support areas. This can be used to generate support structure.",
+      "type": "bool",
+      "category": "Special Modes",
+      "default": false
+    },
+    {
+      "key": "anti_overhang_mesh",
+      "label": "Anti Overhang Mesh",
+      "description": "Use this mesh to specify where no part of the model should be detected as overhang. This can be used to remove unwanted support structure.",
+      "type": "bool",
+      "category": "Special Modes",
+      "default": false
+    },
+    {
+      "key": "magic_mesh_surface_mode",
+      "label": "Surface Mode",
+      "description": "Treat the model as a surface only, a volume, or volumes with loose surfaces. The normal print mode only prints enclosed volumes. \"Surface\" prints a single wall tracing the mesh surface with no infill and no top/bottom skin. \"Both\" prints enclosed volumes like normal and any remaining polygons as surfaces.",
+      "type": "enum",
+      "category": "Special Modes",
+      "default": "normal",
+      "options": {
+        "normal": "Normal",
+        "surface": "Surface",
+        "both": "Both"
+      }
+    },
+    {
+      "key": "magic_spiralize",
+      "label": "Spiralize Outer Contour",
+      "description": "Spiralize smooths out the Z move of the outer edge. This will create a steady Z increase over the whole print. This feature turns a solid model into a single walled print with a solid bottom. This feature should only be enabled when each layer only contains a single part.",
+      "type": "bool",
+      "category": "Special Modes",
+      "default": false
+    },
+    {
+      "key": "smooth_spiralized_contours",
+      "label": "Smooth Spiralized Contours",
+      "description": "Smooth the spiralized contours to reduce the visibility of the Z seam (the Z seam should be barely visible on the print but will still be visible in the layer view). Note that smoothing will tend to blur fine surface details.",
+      "type": "bool",
+      "category": "Special Modes",
+      "default": true
+    },
+    {
+      "key": "relative_extrusion",
+      "label": "Relative Extrusion",
+      "description": "Use relative extrusion rather than absolute extrusion. Using relative E-steps makes for easier post-processing of the g-code. However, it's not supported by all printers and it may produce very slight deviations in the amount of deposited material compared to absolute E-steps. Irrespective of this setting, the extrusion mode will always be set to absolute before any g-code script is output.",
+      "type": "bool",
+      "category": "Special Modes",
+      "default": false
+    },
+    {
+      "key": "slicing_tolerance",
+      "label": "Slicing Tolerance",
+      "description": "Vertical tolerance in the sliced layers. The contours of a layer are normally generated by taking cross sections through the middle of each layer's thickness (Middle). Alternatively each layer can have the areas which fall inside of the volume throughout the entire thickness of the layer (Exclusive) or a layer has the areas which fall inside anywhere within the layer (Inclusive). Inclusive retains the most details, Exclusive makes for the best fit and Middle stays closest to the original surface.",
+      "type": "enum",
+      "category": "Experimental",
+      "default": "middle",
+      "options": {
+        "middle": "Middle",
+        "exclusive": "Exclusive",
+        "inclusive": "Inclusive"
+      }
+    },
+    {
+      "key": "infill_enable_travel_optimization",
+      "label": "Infill Travel Optimization",
+      "description": "When enabled, the order in which the infill lines are printed is optimized to reduce the distance travelled. The reduction in travel time achieved very much depends on the model being sliced, infill pattern, density, etc. Note that, for some models that have many small areas of infill, the time to slice the model may be greatly increased.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "material_flow_temp_graph",
+      "label": "Flow Temperature Graph",
+      "description": "Data linking material flow (in mm3 per second) to temperature (degrees Celsius).",
+      "type": "str",
+      "category": "Experimental",
+      "default": "[[3.5, 200],[7.0, 240]]",
+      "unit": "[[mm\u00b3,\u00b0C]]"
+    },
+    {
+      "key": "minimum_polygon_circumference",
+      "label": "Minimum Polygon Circumference",
+      "description": "Polygons in sliced layers that have a circumference smaller than this amount will be filtered out. Lower values lead to higher resolution mesh at the cost of slicing time. It is meant mostly for high resolution SLA printers and very tiny 3D models with a lot of details.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 1.0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_skip_some_zags",
+      "label": "Break Up Support In Chunks",
+      "description": "Skip some support line connections to make the support structure easier to break away. This setting is applicable to the Zig Zag support infill pattern.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "support_skip_zag_per_mm",
+      "label": "Support Chunk Size",
+      "description": "Leave out a connection between support lines once every N millimeter to make the support structure easier to break away.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 20,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "support_zag_skip_count",
+      "label": "Support Chunk Line Count",
+      "description": "Skip one in every N connection lines to make the support structure easier to break away.",
+      "type": "int",
+      "category": "Experimental",
+      "default": 5,
+      "min": "1"
+    },
+    {
+      "key": "draft_shield_enabled",
+      "label": "Enable Draft Shield",
+      "description": "This will create a wall around the model, which traps (hot) air and shields against exterior airflow. Especially useful for materials which warp easily.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "draft_shield_dist",
+      "label": "Draft Shield X/Y Distance",
+      "description": "Distance of the draft shield from the print, in the X/Y directions.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 10,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "draft_shield_height_limitation",
+      "label": "Draft Shield Limitation",
+      "description": "Set the height of the draft shield. Choose to print the draft shield at the full height of the model or at a limited height.",
+      "type": "enum",
+      "category": "Experimental",
+      "default": "full",
+      "options": {
+        "full": "Full",
+        "limited": "Limited"
+      }
+    },
+    {
+      "key": "draft_shield_height",
+      "label": "Draft Shield Height",
+      "description": "Height limitation of the draft shield. Above this height no draft shield will be printed.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 10,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "conical_overhang_enabled",
+      "label": "Make Overhang Printable",
+      "description": "Change the geometry of the printed model such that minimal support is required. Steep overhangs will become shallow overhangs. Overhanging areas will drop down to become more vertical.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "conical_overhang_angle",
+      "label": "Maximum Model Angle",
+      "description": "The maximum angle of overhangs after the they have been made printable. At a value of 0\u00b0 all overhangs are replaced by a piece of model connected to the build plate, 90\u00b0 will not change the model in any way.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 50,
+      "unit": "\u00b0",
+      "min": "-89",
+      "max": "89"
+    },
+    {
+      "key": "conical_overhang_hole_size",
+      "label": "Maximum Overhang Hole Area",
+      "description": "The maximum area of a hole in the base of the model before it's removed by Make Overhang Printable.  Holes smaller than this will be retained.  A value of 0 mm\u00b2 will fill all holes in the models base.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "mm\u00b2",
+      "min": "0"
+    },
+    {
+      "key": "coasting_enable",
+      "label": "Enable Coasting",
+      "description": "Coasting replaces the last part of an extrusion path with a travel path. The oozed material is used to print the last piece of the extrusion path in order to reduce stringing.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "coasting_volume",
+      "label": "Coasting Volume",
+      "description": "The volume otherwise oozed. This value should generally be close to the nozzle diameter cubed.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0.064,
+      "unit": "mm\u00b3",
+      "min": "0"
+    },
+    {
+      "key": "coasting_min_volume",
+      "label": "Minimum Volume Before Coasting",
+      "description": "The smallest volume an extrusion path should have before allowing coasting. For smaller extrusion paths, less pressure has been built up in the bowden tube and so the coasted volume is scaled linearly. This value should always be larger than the Coasting Volume.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0.8,
+      "unit": "mm\u00b3",
+      "min": "0"
+    },
+    {
+      "key": "coasting_speed",
+      "label": "Coasting Speed",
+      "description": "The speed by which to move during coasting, relative to the speed of the extrusion path. A value slightly under 100% is advised, since during the coasting move the pressure in the bowden tube drops.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 90,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "cross_infill_pocket_size",
+      "label": "Cross 3D Pocket Size",
+      "description": "The size of pockets at four-way crossings in the cross 3D pattern at heights where the pattern is touching itself.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 2.0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "cross_infill_density_image",
+      "label": "Cross Infill Density Image",
+      "description": "The file location of an image of which the brightness values determine the minimal density at the corresponding location in the infill of the print.",
+      "type": "str",
+      "category": "Experimental",
+      "default": ""
+    },
+    {
+      "key": "cross_support_density_image",
+      "label": "Cross Fill Density Image for Support",
+      "description": "The file location of an image of which the brightness values determine the minimal density at the corresponding location in the support.",
+      "type": "str",
+      "category": "Experimental",
+      "default": ""
+    },
+    {
+      "key": "support_conical_enabled",
+      "label": "Enable Conical Support",
+      "description": "Make support areas smaller at the bottom than at the overhang.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "support_conical_angle",
+      "label": "Conical Support Angle",
+      "description": "The angle of the tilt of conical support. With 0 degrees being vertical, and 90 degrees being horizontal. Smaller angles cause the support to be more sturdy, but consist of more material. Negative angles cause the base of the support to be wider than the top.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 30,
+      "unit": "\u00b0",
+      "min": "-90",
+      "max": "90"
+    },
+    {
+      "key": "support_conical_min_width",
+      "label": "Conical Support Minimum Width",
+      "description": "Minimum width to which the base of the conical support area is reduced. Small widths can lead to unstable support structures.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 5.0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "magic_fuzzy_skin_enabled",
+      "label": "Fuzzy Skin",
+      "description": "Randomly jitter while printing the outer wall, so that the surface has a rough and fuzzy look.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "magic_fuzzy_skin_outside_only",
+      "label": "Fuzzy Skin Outside Only",
+      "description": "Jitter only the parts' outlines and not the parts' holes.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "magic_fuzzy_skin_thickness",
+      "label": "Fuzzy Skin Thickness",
+      "description": "The width within which to jitter. It's advised to keep this below the outer wall width, since the inner walls are unaltered.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0.3,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "magic_fuzzy_skin_point_density",
+      "label": "Fuzzy Skin Density",
+      "description": "The average density of points introduced on each polygon in a layer. Note that the original points of the polygon are discarded, so a low density results in a reduction of the resolution.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 1.25,
+      "unit": "1/mm",
+      "min": "0.008",
+      "max": "2 / magic_fuzzy_skin_thickness"
+    },
+    {
+      "key": "magic_fuzzy_skin_point_dist",
+      "label": "Fuzzy Skin Point Distance",
+      "description": "The average distance between the random points introduced on each line segment. Note that the original points of the polygon are discarded, so a high smoothness results in a reduction of the resolution. This value must be higher than half the Fuzzy Skin Thickness.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0.8,
+      "unit": "mm",
+      "min": "magic_fuzzy_skin_thickness / 2"
+    },
+    {
+      "key": "flow_rate_max_extrusion_offset",
+      "label": "Flow Rate Compensation Max Extrusion Offset",
+      "description": "The maximum distance in mm to move the filament to compensate for changes in flow rate.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "flow_rate_extrusion_offset_factor",
+      "label": "Flow Rate Compensation Factor",
+      "description": "How far to move the filament in order to compensate for changes in flow rate, as a percentage of how far the filament would move in one second of extrusion.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 100,
+      "unit": "%",
+      "min": "0"
+    },
+    {
+      "key": "adaptive_layer_height_enabled",
+      "label": "Use Adaptive Layers",
+      "description": "Adaptive layers computes the layer heights depending on the shape of the model.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "adaptive_layer_height_variation",
+      "label": "Adaptive Layers Maximum Variation",
+      "description": "The maximum allowed height different from the base layer height.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0.1,
+      "unit": "mm",
+      "min": "0.0"
+    },
+    {
+      "key": "adaptive_layer_height_variation_step",
+      "label": "Adaptive Layers Variation Step Size",
+      "description": "The difference in height of the next layer height compared to the previous one.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0.01,
+      "unit": "mm",
+      "min": "0.001"
+    },
+    {
+      "key": "adaptive_layer_height_threshold",
+      "label": "Adaptive Layers Topography Size",
+      "description": "Target horizontal distance between two adjacent layers. Reducing this setting causes thinner layers to be used to bring the edges of the layers closer together.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0.2,
+      "unit": "mm"
+    },
+    {
+      "key": "wall_overhang_angle",
+      "label": "Overhanging Wall Angle",
+      "description": "Walls that overhang more than this angle will be printed using overhanging wall settings. When the value is 90, no walls will be treated as overhanging. Overhang that gets supported by support will not be treated as overhang either. Furthermore, any line that's less than half overhanging will also not be treated as overhang.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 90,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "cool_min_layer_time_overhang",
+      "label": "Minimum Layer Time with Overhang",
+      "description": "The minimum time spent in a layer that contains overhanging extrusions. This forces the printer to slow down, to at least spend the time set here in one layer. This allows the printed material to cool down properly before printing the next layer. Layers may still take shorter than the minimal layer time if Lift Head is disabled and if the Minimum Speed would otherwise be violated.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 5,
+      "unit": "s",
+      "min": "0"
+    },
+    {
+      "key": "cool_min_layer_time_overhang_min_segment_length",
+      "label": "Minimum Overhang Segment Length",
+      "description": "When trying to apply the minimum layer time specific for overhanging layers, it will be applied only if at least one consecutive overhanging extrusion move is longer than this value.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "seam_overhang_angle",
+      "label": "Seam Overhanging Wall Angle",
+      "description": "Try to prevent seams on walls that overhang more than this angle. When the value is 90, no walls will be treated as overhanging.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 90,
+      "unit": "\u00b0",
+      "min": "0",
+      "max": "90"
+    },
+    {
+      "key": "wall_overhang_speed_factors",
+      "label": "Overhanging Wall Speeds",
+      "description": "Overhanging walls will be printed at a percentage of their normal print speed. You can specify multiple values, so that even more overhanging walls will be printed even slower, e.g. by setting [75, 50, 25]",
+      "type": "[int]",
+      "category": "Experimental",
+      "default": "[100]",
+      "unit": "%"
+    },
+    {
+      "key": "bridge_settings_enabled",
+      "label": "Enable Bridge Settings",
+      "description": "Detect bridges and modify print speed, flow and fan settings while bridges are printed.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "bridge_wall_min_length",
+      "label": "Minimum Bridge Wall Length",
+      "description": "Unsupported walls shorter than this will be printed using the normal wall settings. Longer unsupported walls will be printed using the bridge wall settings.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 5,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "bridge_skin_support_threshold",
+      "label": "Bridge Skin Support Threshold",
+      "description": "If a skin region is supported for less than this percentage of its area, print it using the bridge settings. Otherwise it is printed using the normal skin settings.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 50,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "bridge_wall_coast",
+      "label": "Bridge Wall Coasting",
+      "description": "This controls the distance the extruder should coast immediately before a bridge wall begins. Coasting before the bridge starts can reduce the pressure in the nozzle and may produce a flatter bridge.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "500"
+    },
+    {
+      "key": "bridge_wall_speed",
+      "label": "Bridge Wall Speed",
+      "description": "The speed at which the bridge walls are printed.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 15,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "bridge_wall_material_flow",
+      "label": "Bridge Wall Flow",
+      "description": "When printing bridge walls, the amount of material extruded is multiplied by this value.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 50,
+      "unit": "%",
+      "min": "5"
+    },
+    {
+      "key": "bridge_skin_speed",
+      "label": "Bridge Skin Speed",
+      "description": "The speed at which bridge skin regions are printed.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 15,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "bridge_skin_material_flow",
+      "label": "Bridge Skin Flow",
+      "description": "When printing bridge skin regions, the amount of material extruded is multiplied by this value.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 60,
+      "unit": "%",
+      "min": "5"
+    },
+    {
+      "key": "bridge_skin_density",
+      "label": "Bridge Skin Density",
+      "description": "The density of the bridge skin layer. Values less than 100 will increase the gaps between the skin lines.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 100,
+      "unit": "%",
+      "min": "5"
+    },
+    {
+      "key": "bridge_fan_speed",
+      "label": "Bridge Fan Speed",
+      "description": "Percentage fan speed to use when printing bridge walls and skin.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 100,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "bridge_interlace_lines",
+      "label": "Interlace Bridge Lines",
+      "description": "When enabled, bridging lines will be printed interlaced, i.e. in 2 monotonic passes so that adjacent lines won't be printed just after each other. The lines of the first pass then have more time to cool down and are stronger when the second pass is added.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "bridge_enable_more_layers",
+      "label": "Bridge Has Multiple Layers",
+      "description": "If enabled, the second and third layers above the air are printed using the following settings. Otherwise, those layers are printed using the normal settings.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": true
+    },
+    {
+      "key": "bridge_skin_speed_2",
+      "label": "Bridge Second Skin Speed",
+      "description": "Print speed to use when printing the second bridge skin layer.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 25,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "bridge_skin_material_flow_2",
+      "label": "Bridge Second Skin Flow",
+      "description": "When printing the second bridge skin layer, the amount of material extruded is multiplied by this value.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 100,
+      "unit": "%",
+      "min": "0.0001"
+    },
+    {
+      "key": "bridge_skin_density_2",
+      "label": "Bridge Second Skin Density",
+      "description": "The density of the second bridge skin layer. Values less than 100 will increase the gaps between the skin lines.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 75,
+      "unit": "%",
+      "min": "0"
+    },
+    {
+      "key": "bridge_fan_speed_2",
+      "label": "Bridge Second Skin Fan Speed",
+      "description": "Percentage fan speed to use when printing the second bridge skin layer.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "bridge_skin_speed_3",
+      "label": "Bridge Third Skin Speed",
+      "description": "Print speed to use when printing the third bridge skin layer.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 15,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)"
+    },
+    {
+      "key": "bridge_skin_material_flow_3",
+      "label": "Bridge Third Skin Flow",
+      "description": "When printing the third bridge skin layer, the amount of material extruded is multiplied by this value.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 110,
+      "unit": "%",
+      "min": "0.001"
+    },
+    {
+      "key": "bridge_skin_density_3",
+      "label": "Bridge Third Skin Density",
+      "description": "The density of the third bridge skin layer. Values less than 100 will increase the gaps between the skin lines.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 80,
+      "unit": "%",
+      "min": "0"
+    },
+    {
+      "key": "bridge_fan_speed_3",
+      "label": "Bridge Third Skin Fan Speed",
+      "description": "Percentage fan speed to use when printing the third bridge skin layer.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "%",
+      "min": "0",
+      "max": "100"
+    },
+    {
+      "key": "clean_between_layers",
+      "label": "Wipe Nozzle Between Layers",
+      "description": "Whether to include nozzle wipe G-Code between layers (maximum 1 per layer). Enabling this setting could influence behavior of retract at layer change. Please use Wipe Retraction settings to control retraction at layers where the wipe script will be working.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "max_extrusion_before_wipe",
+      "label": "Material Volume Between Wipes",
+      "description": "Maximum material that can be extruded before another nozzle wipe is initiated. If this value is less than the volume of material required in a layer, the setting has no effect in this layer, i.e. it is limited to one wipe per layer.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 10,
+      "unit": "mm\u00b3"
+    },
+    {
+      "key": "wipe_retraction_enable",
+      "label": "Wipe Retraction Enable",
+      "description": "Retract the filament when the nozzle is moving over a non-printed area.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": true
+    },
+    {
+      "key": "wipe_retraction_amount",
+      "label": "Wipe Retraction Distance",
+      "description": "Amount to retract the filament so it does not ooze during the wipe sequence.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 1,
+      "unit": "mm"
+    },
+    {
+      "key": "wipe_retraction_extra_prime_amount",
+      "label": "Wipe Retraction Extra Prime Amount",
+      "description": "Some material can ooze away during a wipe travel moves, which can be compensated for here.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "mm\u00b3"
+    },
+    {
+      "key": "wipe_retraction_speed",
+      "label": "Wipe Retraction Speed",
+      "description": "The speed at which the filament is retracted and primed during a wipe retraction move.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 5,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "machine_max_feedrate_e"
+    },
+    {
+      "key": "wipe_retraction_retract_speed",
+      "label": "Wipe Retraction Retract Speed",
+      "description": "The speed at which the filament is retracted during a wipe retraction move.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 3,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "machine_max_feedrate_e"
+    },
+    {
+      "key": "wipe_retraction_prime_speed",
+      "label": "Wipe Retraction Prime Speed",
+      "description": "The speed at which the filament is primed during a wipe retraction move.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 2,
+      "unit": "mm/s",
+      "min": "0",
+      "max": "machine_max_feedrate_e"
+    },
+    {
+      "key": "wipe_pause",
+      "label": "Wipe Pause",
+      "description": "Pause after the unretract.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "s",
+      "min": "0"
+    },
+    {
+      "key": "wipe_hop_enable",
+      "label": "Wipe Z Hop",
+      "description": "When wiping, the build plate is lowered to create clearance between the nozzle and the print. It prevents the nozzle from hitting the print during travel moves, reducing the chance to knock the print from the build plate.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": true
+    },
+    {
+      "key": "wipe_hop_amount",
+      "label": "Wipe Z Hop Height",
+      "description": "The height difference when performing a Z Hop.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 1,
+      "unit": "mm"
+    },
+    {
+      "key": "wipe_hop_speed",
+      "label": "Wipe Hop Speed",
+      "description": "Speed to move the z-axis during the hop.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 10,
+      "unit": "mm/s",
+      "min": "0"
+    },
+    {
+      "key": "wipe_brush_pos_x",
+      "label": "Wipe Brush X Position",
+      "description": "X location where wipe script will start.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 100,
+      "unit": "mm"
+    },
+    {
+      "key": "wipe_repeat_count",
+      "label": "Wipe Repeat Count",
+      "description": "Number of times to move the nozzle across the brush.",
+      "type": "int",
+      "category": "Experimental",
+      "default": 5,
+      "min": "0"
+    },
+    {
+      "key": "wipe_move_distance",
+      "label": "Wipe Move Distance",
+      "description": "The distance to move the head back and forth across the brush.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 20,
+      "unit": "mm"
+    },
+    {
+      "key": "small_hole_max_size",
+      "label": "Small Hole Max Size",
+      "description": "Holes and part outlines with a diameter smaller than this will be printed using Small Feature Speed.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "small_feature_max_length",
+      "label": "Small Feature Max Length",
+      "description": "Feature outlines that are shorter than this length will be printed using Small Feature Speed.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "small_feature_speed_factor",
+      "label": "Small Feature Speed",
+      "description": "Small features will be printed at this percentage of their normal print speed. Slower printing can help with adhesion and accuracy.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 50,
+      "unit": "%",
+      "min": "1"
+    },
+    {
+      "key": "small_feature_speed_factor_0",
+      "label": "Small Feature Initial Layer Speed",
+      "description": "Small features on the first layer will be printed at this percentage of their normal print speed. Slower printing can help with adhesion and accuracy.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 50,
+      "unit": "%",
+      "min": "1"
+    },
+    {
+      "key": "material_alternate_walls",
+      "label": "Alternate Wall Directions",
+      "description": "Alternate wall directions every other layer and inset. Useful for materials that can build up stress, like for metal printing.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "group_outer_walls",
+      "label": "Group Outer Walls",
+      "description": "Outer walls of different islands in the same layer are printed in sequence. When enabled the amount of flow changes is limited because walls are printed one type at a time, when disabled the number of travels between islands is reduced because walls in the same islands are grouped.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": true
+    },
+    {
+      "key": "retraction_during_travel_ratio",
+      "label": "Retraction During Travel Move",
+      "description": "<html>The ratio of retraction performed during the travel move, with the remainder completed while the nozzle is stationary, before traveling<ul><li>When 0, the entire retraction is performed while stationary, before the travel begins</li><li>When 100, the entire retraction is performed during the travel move, bypassing the stationary phase</li></ul></html>",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "%",
+      "min": 0,
+      "max": 100
+    },
+    {
+      "key": "keep_retracting_during_travel",
+      "label": "Keep Retracting During Travel",
+      "description": "When retraction during travel is enabled, and there is more than enough time to perform a full retract during a travel move, spread the retraction over the whole travel move with a lower retraction speed, so that we do not travel with a non-retracting nozzle. This can help reducing oozing.",
+      "type": "bool",
+      "category": "Experimental",
+      "default": false
+    },
+    {
+      "key": "prime_during_travel_ratio",
+      "label": "Prime During Travel Move",
+      "description": "<html>The ratio of priming performed during the travel move, with the remainder completed while the nozzle is stationary, after traveling<ul><li>When 0, the entire priming is performed while stationary, after the travel ends</li><li>When 100, the entire priming is performed during the travel move, allowing the print to start immediately</li></ul></html>",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "%",
+      "min": 0,
+      "max": 100
+    },
+    {
+      "key": "scarf_joint_seam_length",
+      "label": "Scarf Seam Length",
+      "description": "Determines the length of the scarf seam, a seam type that should make the Z seam less visible. Must be higher than 0 to be effective.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "mm",
+      "min": "0"
+    },
+    {
+      "key": "scarf_joint_seam_start_height_ratio",
+      "label": "Scarf Seam Start Height",
+      "description": "The ratio of the selected layer height at which the scarf seam will begin. A lower number will result in a larger seam height. Must be lower than 100 to be effective.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 0,
+      "unit": "%",
+      "min": 0,
+      "max": 100.0
+    },
+    {
+      "key": "scarf_split_distance",
+      "label": "Scarf Seam Step Length",
+      "description": "Determines the length of each step in the flow change when extruding along the scarf seam. A smaller distance will result in a more precise but also more complex G-code.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 1.0,
+      "unit": "mm",
+      "min": 0.1,
+      "max": 100.0
+    },
+    {
+      "key": "wall_0_start_speed_ratio",
+      "label": "Outer Wall Start Speed Ratio",
+      "description": "This is the ratio of the top speed to start with when printing an outer wall.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 100.0,
+      "unit": "%",
+      "min": 0.0,
+      "max": 100.0
+    },
+    {
+      "key": "wall_0_acceleration",
+      "label": "Outer Wall Start Acceleration",
+      "description": "This is the acceleration with which to reach the top speed when printing an outer wall.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 20.0,
+      "unit": "mm/s\u00b2",
+      "min": 1.0,
+      "max": 100000.0
+    },
+    {
+      "key": "wall_0_end_speed_ratio",
+      "label": "Outer Wall End Speed Ratio",
+      "description": "This is the ratio of the top speed to end with when printing an outer wall.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 100.0,
+      "unit": "%",
+      "min": 0.0,
+      "max": 100.0
+    },
+    {
+      "key": "wall_0_deceleration",
+      "label": "Outer Wall End Deceleration",
+      "description": "This is the deceleration with which to end printing an outer wall.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 20.0,
+      "unit": "mm/s\u00b2",
+      "min": 1.0,
+      "max": 100000.0
+    },
+    {
+      "key": "wall_0_speed_split_distance",
+      "label": "Outer Wall Speed Split Distance",
+      "description": "This is the maximum length of an extrusion path when splitting a longer path to apply the outer wall acceleration/deceleration. A smaller distance will create a more precise but also more verbose G-Code.",
+      "type": "float",
+      "category": "Experimental",
+      "default": 1.0,
+      "unit": "mm",
+      "min": 0.1,
+      "max": 100.0
+    },
+    {
+      "key": "ppr_enable",
+      "label": "Enable Print Process Reporting",
+      "description": "Enable print process reporting for setting threshold values for possible fault detection.",
+      "type": "bool",
+      "category": "Print Process Reporting",
+      "default": false
+    },
+    {
+      "key": "flow_warn_limit",
+      "label": "Flow Warning",
+      "description": "Limit on the flow warning for detection.",
+      "type": "float",
+      "category": "Print Process Reporting",
+      "default": 15.0,
+      "unit": "%"
+    },
+    {
+      "key": "flow_anomaly_limit",
+      "label": "Flow Limit",
+      "description": "Limit on flow anomaly for detection.",
+      "type": "float",
+      "category": "Print Process Reporting",
+      "default": 25.0,
+      "unit": "%"
+    },
+    {
+      "key": "print_temp_warn_limit",
+      "label": "Print temperature Warning",
+      "description": "Limit on Print temperature warning for detection.",
+      "type": "float",
+      "category": "Print Process Reporting",
+      "default": 3.0,
+      "unit": "\u00b0C"
+    },
+    {
+      "key": "print_temp_anomaly_limit",
+      "label": "Print temperature Limit",
+      "description": "Limit on Print Temperature anomaly for detection.",
+      "type": "float",
+      "category": "Print Process Reporting",
+      "default": 7.0,
+      "unit": "\u00b0C"
+    },
+    {
+      "key": "bv_temp_warn_limit",
+      "label": "Build Volume temperature Warning",
+      "description": "Limit on Build Volume Temperature warning for detection.",
+      "type": "float",
+      "category": "Print Process Reporting",
+      "default": 7.5,
+      "unit": "\u00b0C"
+    },
+    {
+      "key": "bv_temp_anomaly_limit",
+      "label": "Build Volume temperature Limit",
+      "description": "Limit on Build Volume temperature Anomaly for detection.",
+      "type": "float",
+      "category": "Print Process Reporting",
+      "default": 10.0,
+      "unit": "\u00b0C"
+    },
+    {
+      "key": "center_object",
+      "label": "Center Object",
+      "description": "Whether to center the object on the middle of the build platform (0,0), instead of using the coordinate system in which the object was saved.",
+      "type": "bool",
+      "category": "Command Line Settings",
+      "default": false
+    },
+    {
+      "key": "mesh_position_x",
+      "label": "Mesh Position X",
+      "description": "Offset applied to the object in the x direction.",
+      "type": "float",
+      "category": "Command Line Settings",
+      "default": 0
+    },
+    {
+      "key": "mesh_position_y",
+      "label": "Mesh Position Y",
+      "description": "Offset applied to the object in the y direction.",
+      "type": "float",
+      "category": "Command Line Settings",
+      "default": 0
+    },
+    {
+      "key": "mesh_position_z",
+      "label": "Mesh Position Z",
+      "description": "Offset applied to the object in the z direction. With this you can perform what was used to be called 'Object Sink'.",
+      "type": "float",
+      "category": "Command Line Settings",
+      "default": 0
+    },
+    {
+      "key": "mesh_rotation_matrix",
+      "label": "Mesh Rotation Matrix",
+      "description": "Transformation matrix to be applied to the model when loading it from file.",
+      "type": "str",
+      "category": "Command Line Settings",
+      "default": "[[1,0,0], [0,1,0], [0,0,1]]"
+    }
+  ]
+}

--- a/src/estampo/data/orca-settings.json
+++ b/src/estampo/data/orca-settings.json
@@ -1,0 +1,2953 @@
+{
+  "engine": "orca",
+  "version": "2.3.1",
+  "source": "OrcaSlicer BBL profiles extracted from Docker image",
+  "note": "Process settings go in [slicer.orca.overrides], machine settings in [slicer.orca.machine_overrides], filament settings in [slicer.orca.filament_overrides]. Use the 'key' field as the override key.",
+  "settings_count": 263,
+  "process_count": 113,
+  "machine_count": 84,
+  "filament_count": 66,
+  "settings": [
+    {
+      "key": "description",
+      "category": "process",
+      "example_values": [
+        "Compared with the default profile of a 0.4 mm nozzle, it has a bigger layer height, and results in more apparent layer lines and lower printing quality, but shorter printing time.",
+        "Compared with the default profile of a 0.2 mm nozzle, it has a bigger layer height, and results in slightly visible layer lines, but shorter printing time.",
+        "Compared with the default profile of a 0.4 mm nozzle, it has a smaller layer height, and results in less apparent layer lines and higher printing quality, but longer printing time."
+      ],
+      "profiles_count": 118
+    },
+    {
+      "key": "default_acceleration",
+      "category": "process",
+      "example_values": [
+        "6000",
+        "5000",
+        "4000"
+      ],
+      "profiles_count": 75
+    },
+    {
+      "key": "elefant_foot_compensation",
+      "category": "process",
+      "example_values": [
+        "0",
+        "0.15",
+        "0.075"
+      ],
+      "profiles_count": 91
+    },
+    {
+      "key": "travel_speed",
+      "category": "process",
+      "example_values": [
+        "700",
+        "400",
+        "500"
+      ],
+      "profiles_count": 60
+    },
+    {
+      "key": "compatible_printers",
+      "category": "process",
+      "example_values": [
+        [
+          "Bambu Lab A1 mini 0.4 nozzle"
+        ],
+        [
+          "Bambu Lab P1P 0.2 nozzle"
+        ],
+        [
+          "Bambu Lab X1 Carbon 0.6 nozzle",
+          "Bambu Lab X1 0.6 nozzle",
+          "Bambu Lab P1S 0.6 nozzle",
+          "Bambu Lab X1E 0.6 nozzle"
+        ]
+      ],
+      "profiles_count": 121
+    },
+    {
+      "key": "outer_wall_acceleration",
+      "category": "process",
+      "example_values": [
+        "2500",
+        "2000",
+        "5000"
+      ],
+      "profiles_count": 29
+    },
+    {
+      "key": "smooth_coefficient",
+      "category": "process",
+      "example_values": [
+        "150",
+        "80"
+      ],
+      "profiles_count": 30
+    },
+    {
+      "key": "overhang_totally_speed",
+      "category": "process",
+      "example_values": [
+        "50",
+        "19"
+      ],
+      "profiles_count": 30
+    },
+    {
+      "key": "sparse_infill_density",
+      "category": "process",
+      "example_values": [
+        "25%",
+        "15%"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "wall_loops",
+      "category": "process",
+      "example_values": [
+        "4",
+        "2",
+        "6"
+      ],
+      "profiles_count": 12
+    },
+    {
+      "key": "initial_layer_infill_speed",
+      "category": "process",
+      "example_values": [
+        "28",
+        "70",
+        "105"
+      ],
+      "profiles_count": 38
+    },
+    {
+      "key": "initial_layer_speed",
+      "category": "process",
+      "example_values": [
+        "16",
+        "40",
+        "20"
+      ],
+      "profiles_count": 39
+    },
+    {
+      "key": "gap_infill_speed",
+      "category": "process",
+      "example_values": [
+        "250",
+        "230",
+        "210"
+      ],
+      "profiles_count": 20
+    },
+    {
+      "key": "inner_wall_speed",
+      "category": "process",
+      "example_values": [
+        "150",
+        "120",
+        "40"
+      ],
+      "profiles_count": 20
+    },
+    {
+      "key": "internal_solid_infill_speed",
+      "category": "process",
+      "example_values": [
+        "200",
+        "180",
+        "150"
+      ],
+      "profiles_count": 20
+    },
+    {
+      "key": "outer_wall_speed",
+      "category": "process",
+      "example_values": [
+        "60",
+        "120",
+        "200"
+      ],
+      "profiles_count": 34
+    },
+    {
+      "key": "sparse_infill_pattern",
+      "category": "process",
+      "example_values": [
+        "gyroid",
+        "crosshatch"
+      ],
+      "profiles_count": 25
+    },
+    {
+      "key": "sparse_infill_speed",
+      "category": "process",
+      "example_values": [
+        "200",
+        "180",
+        "150"
+      ],
+      "profiles_count": 35
+    },
+    {
+      "key": "top_surface_speed",
+      "category": "process",
+      "example_values": [
+        "150",
+        "30",
+        "200"
+      ],
+      "profiles_count": 29
+    },
+    {
+      "key": "layer_height",
+      "category": "process",
+      "example_values": [
+        "0.08",
+        "0.2",
+        "0.28"
+      ],
+      "profiles_count": 21
+    },
+    {
+      "key": "initial_layer_print_height",
+      "category": "process",
+      "example_values": [
+        "0.1",
+        "0.2",
+        "0.4"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "bottom_shell_layers",
+      "category": "process",
+      "example_values": [
+        "5",
+        "3",
+        "4"
+      ],
+      "profiles_count": 9
+    },
+    {
+      "key": "top_shell_layers",
+      "category": "process",
+      "example_values": [
+        "7",
+        "3",
+        "4"
+      ],
+      "profiles_count": 12
+    },
+    {
+      "key": "bridge_flow",
+      "category": "process",
+      "example_values": [
+        "1",
+        "0.95"
+      ],
+      "profiles_count": 22
+    },
+    {
+      "key": "line_width",
+      "category": "process",
+      "example_values": [
+        "0.22",
+        "0.42",
+        "0.82"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "outer_wall_line_width",
+      "category": "process",
+      "example_values": [
+        "0.22",
+        "0.42",
+        "0.82"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "ironing_inset",
+      "category": "process",
+      "example_values": [
+        "0.11",
+        "0.21",
+        "0.41"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "initial_layer_line_width",
+      "category": "process",
+      "example_values": [
+        "0.25",
+        "0.5",
+        "0.82"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "sparse_infill_line_width",
+      "category": "process",
+      "example_values": [
+        "0.22",
+        "0.45",
+        "0.82"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "inner_wall_line_width",
+      "category": "process",
+      "example_values": [
+        "0.22",
+        "0.45",
+        "0.82"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "internal_solid_infill_line_width",
+      "category": "process",
+      "example_values": [
+        "0.22",
+        "0.42",
+        "0.82"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "support_line_width",
+      "category": "process",
+      "example_values": [
+        "0.22",
+        "0.42",
+        "0.82"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "top_surface_line_width",
+      "category": "process",
+      "example_values": [
+        "0.22",
+        "0.42",
+        "0.45"
+      ],
+      "profiles_count": 18
+    },
+    {
+      "key": "support_top_z_distance",
+      "category": "process",
+      "example_values": [
+        "0.08",
+        "0.2",
+        "0.06"
+      ],
+      "profiles_count": 11
+    },
+    {
+      "key": "support_bottom_z_distance",
+      "category": "process",
+      "example_values": [
+        "0.08",
+        "0.2",
+        "0.06"
+      ],
+      "profiles_count": 10
+    },
+    {
+      "key": "adaptive_layer_height",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "bottom_shell_thickness",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "bottom_surface_pattern",
+      "category": "process",
+      "example_values": [
+        "monotonic"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "bridge_no_support",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "bridge_speed",
+      "category": "process",
+      "example_values": [
+        "25",
+        "30",
+        "50"
+      ],
+      "profiles_count": 12
+    },
+    {
+      "key": "brim_object_gap",
+      "category": "process",
+      "example_values": [
+        "0.1"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "brim_width",
+      "category": "process",
+      "example_values": [
+        "5"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "compatible_printers_condition",
+      "category": "process",
+      "example_values": [
+        ""
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "detect_overhang_wall",
+      "category": "process",
+      "example_values": [
+        "1"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "detect_thin_wall",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "draft_shield",
+      "category": "process",
+      "example_values": [
+        "disabled"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "enable_arc_fitting",
+      "category": "process",
+      "example_values": [
+        "1"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "enable_prime_tower",
+      "category": "process",
+      "example_values": [
+        "1"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "enable_support",
+      "category": "process",
+      "example_values": [
+        "0",
+        "1"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "filename_format",
+      "category": "process",
+      "example_values": [
+        "{input_filename_base}_{filament_type[0]}_{print_time}.gcode"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "infill_combination",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "infill_direction",
+      "category": "process",
+      "example_values": [
+        "45"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "infill_wall_overlap",
+      "category": "process",
+      "example_values": [
+        "15%"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "interface_shells",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "internal_bridge_support_thickness",
+      "category": "process",
+      "example_values": [
+        "0.8"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "ironing_flow",
+      "category": "process",
+      "example_values": [
+        "10%",
+        "8%"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "ironing_spacing",
+      "category": "process",
+      "example_values": [
+        "0.15"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "ironing_speed",
+      "category": "process",
+      "example_values": [
+        "30"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "ironing_type",
+      "category": "process",
+      "example_values": [
+        "no ironing"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "max_bridge_length",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "max_travel_detour_distance",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "minimum_sparse_infill_area",
+      "category": "process",
+      "example_values": [
+        "15"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "only_one_wall_top",
+      "category": "process",
+      "example_values": [
+        "1"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "prime_tower_width",
+      "category": "process",
+      "example_values": [
+        "35"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "print_sequence",
+      "category": "process",
+      "example_values": [
+        "by layer"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "print_settings_id",
+      "category": "process",
+      "example_values": [
+        ""
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "raft_layers",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "reduce_crossing_wall",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "reduce_infill_retraction",
+      "category": "process",
+      "example_values": [
+        "1"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "resolution",
+      "category": "process",
+      "example_values": [
+        "0.012"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "scarf_angle_threshold",
+      "category": "process",
+      "example_values": [
+        "155"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "seam_position",
+      "category": "process",
+      "example_values": [
+        "aligned"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "skirt_distance",
+      "category": "process",
+      "example_values": [
+        "2"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "skirt_height",
+      "category": "process",
+      "example_values": [
+        "1"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "skirt_loops",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "spiral_mode",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "standby_temperature_delta",
+      "category": "process",
+      "example_values": [
+        "-5"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "support_base_pattern",
+      "category": "process",
+      "example_values": [
+        "default"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "support_base_pattern_spacing",
+      "category": "process",
+      "example_values": [
+        "2.5"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "support_expansion",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "support_filament",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "support_interface_bottom_layers",
+      "category": "process",
+      "example_values": [
+        "2"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "support_interface_filament",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "support_interface_loop_pattern",
+      "category": "process",
+      "example_values": [
+        "0",
+        "1"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "support_interface_pattern",
+      "category": "process",
+      "example_values": [
+        "auto"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "support_interface_spacing",
+      "category": "process",
+      "example_values": [
+        "0.5",
+        "0"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "support_interface_speed",
+      "category": "process",
+      "example_values": [
+        "80"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "support_interface_top_layers",
+      "category": "process",
+      "example_values": [
+        "2",
+        "3"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "support_object_xy_distance",
+      "category": "process",
+      "example_values": [
+        "0.35"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "support_on_build_plate_only",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "support_speed",
+      "category": "process",
+      "example_values": [
+        "40",
+        "150"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "support_style",
+      "category": "process",
+      "example_values": [
+        "default"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "support_threshold_angle",
+      "category": "process",
+      "example_values": [
+        "30",
+        "40",
+        "35"
+      ],
+      "profiles_count": 6
+    },
+    {
+      "key": "support_type",
+      "category": "process",
+      "example_values": [
+        "normal(auto)"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "top_shell_thickness",
+      "category": "process",
+      "example_values": [
+        "0.8",
+        "1.0",
+        "0.6"
+      ],
+      "profiles_count": 6
+    },
+    {
+      "key": "top_surface_pattern",
+      "category": "process",
+      "example_values": [
+        "monotonicline",
+        "monotonic"
+      ],
+      "profiles_count": 6
+    },
+    {
+      "key": "tree_support_branch_angle",
+      "category": "process",
+      "example_values": [
+        "45"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "tree_support_branch_diameter",
+      "category": "process",
+      "example_values": [
+        "2"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "tree_support_wall_count",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "wall_generator",
+      "category": "process",
+      "example_values": [
+        "classic"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "wall_infill_order",
+      "category": "process",
+      "example_values": [
+        "inner wall/outer wall/infill"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "wipe_tower_no_sparse_layers",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "xy_contour_compensation",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "xy_hole_compensation",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "infill_shift_step",
+      "category": "process",
+      "example_values": [
+        "0.4"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "infill_rotate_step",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "symmetric_infill_y_axis",
+      "category": "process",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "overhang_3_4_speed",
+      "category": "process",
+      "example_values": [
+        "25",
+        "15",
+        "10"
+      ],
+      "profiles_count": 14
+    },
+    {
+      "key": "overhang_4_4_speed",
+      "category": "process",
+      "example_values": [
+        "5",
+        "10"
+      ],
+      "profiles_count": 6
+    },
+    {
+      "key": "overhang_1_4_speed",
+      "category": "process",
+      "example_values": [
+        "60",
+        "0"
+      ],
+      "profiles_count": 4
+    },
+    {
+      "key": "overhang_2_4_speed",
+      "category": "process",
+      "example_values": [
+        "30",
+        "50"
+      ],
+      "profiles_count": 4
+    },
+    {
+      "key": "initial_layer_acceleration",
+      "category": "process",
+      "example_values": [
+        "500"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "top_surface_acceleration",
+      "category": "process",
+      "example_values": [
+        "2000"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "nozzle_diameter",
+      "category": "machine",
+      "example_values": [
+        [
+          "0.6"
+        ],
+        [
+          "0.2"
+        ],
+        "0.4;0.2;0.6;0.8"
+      ],
+      "profiles_count": 37
+    },
+    {
+      "key": "printer_model",
+      "category": "machine",
+      "example_values": [
+        "Bambu Lab P1S",
+        "Bambu Lab A1 mini",
+        "Bambu Lab X1E"
+      ],
+      "profiles_count": 28
+    },
+    {
+      "key": "printer_variant",
+      "category": "machine",
+      "example_values": [
+        "0.6",
+        "0.2",
+        "0.8"
+      ],
+      "profiles_count": 30
+    },
+    {
+      "key": "default_filament_profile",
+      "category": "machine",
+      "example_values": [
+        [
+          "Bambu PLA Basic @BBL X1C"
+        ],
+        [
+          "Bambu PLA Basic @BBL A1M 0.2 nozzle"
+        ],
+        [
+          "Bambu PLA Basic @BBL X1C 0.2 nozzle"
+        ]
+      ],
+      "profiles_count": 30
+    },
+    {
+      "key": "default_print_profile",
+      "category": "machine",
+      "example_values": [
+        "0.30mm Standard @BBL X1C 0.6 nozzle",
+        "0.10mm Standard @BBL A1M 0.2 nozzle",
+        "0.10mm Standard @BBL P1P 0.2 nozzle"
+      ],
+      "profiles_count": 30
+    },
+    {
+      "key": "max_layer_height",
+      "category": "machine",
+      "example_values": [
+        [
+          "0.42"
+        ],
+        [
+          "0.14"
+        ],
+        [
+          "0.14"
+        ]
+      ],
+      "profiles_count": 22
+    },
+    {
+      "key": "min_layer_height",
+      "category": "machine",
+      "example_values": [
+        [
+          "0.12"
+        ],
+        [
+          "0.04"
+        ],
+        [
+          "0.04"
+        ]
+      ],
+      "profiles_count": 22
+    },
+    {
+      "key": "nozzle_type",
+      "category": "machine",
+      "example_values": [
+        "hardened_steel",
+        "stainless_steel"
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "retraction_length",
+      "category": "machine",
+      "example_values": [
+        [
+          "1.4"
+        ],
+        [
+          "0.4"
+        ],
+        [
+          "0.4"
+        ]
+      ],
+      "profiles_count": 20
+    },
+    {
+      "key": "retraction_minimum_travel",
+      "category": "machine",
+      "example_values": [
+        [
+          "3"
+        ],
+        [
+          "3"
+        ],
+        [
+          "3"
+        ]
+      ],
+      "profiles_count": 8
+    },
+    {
+      "key": "upward_compatible_machine",
+      "category": "machine",
+      "example_values": [
+        [
+          "Bambu Lab P1P 0.6 nozzle",
+          "Bambu Lab X1 0.6 nozzle",
+          "Bambu Lab X1 Carbon 0.6 nozzle",
+          "Bambu Lab X1E 0.6 nozzle",
+          "Bambu Lab A1 0.6 nozzle"
+        ],
+        [
+          "Bambu Lab P1S 0.2 nozzle",
+          "Bambu Lab P1P 0.2 nozzle",
+          "Bambu Lab X1 0.2 nozzle",
+          "Bambu Lab X1 Carbon 0.2 nozzle",
+          "Bambu Lab X1E 0.2 nozzle",
+          "Bambu Lab A1 0.2 nozzle"
+        ],
+        [
+          "Bambu Lab P1P 0.2 nozzle",
+          "Bambu Lab X1 0.2 nozzle",
+          "Bambu Lab X1 Carbon 0.2 nozzle",
+          "Bambu Lab X1E 0.2 nozzle",
+          "Bambu Lab A1 0.2 nozzle"
+        ]
+      ],
+      "profiles_count": 28
+    },
+    {
+      "key": "machine_start_gcode",
+      "category": "machine",
+      "example_values": [],
+      "profiles_count": 23
+    },
+    {
+      "key": "url",
+      "category": "machine",
+      "example_values": [
+        "http://www.bambulab.com/Parameters/printer_model/Bambu Lab X1.json",
+        "http://www.bambulab.com/Parameters/printer_model/Bambu Lab X1 Carbon.json"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "bed_model",
+      "category": "machine",
+      "example_values": [
+        "bbl-3dp-X1.stl",
+        "bbl-3dp-A1M.stl"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "bed_texture",
+      "category": "machine",
+      "example_values": [
+        "bbl-3dp-logo.svg"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "default_bed_type",
+      "category": "machine",
+      "example_values": [
+        "Textured PEI Plate"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "family",
+      "category": "machine",
+      "example_values": [
+        "BBL-3DP"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "machine_tech",
+      "category": "machine",
+      "example_values": [
+        "FFF"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "model_id",
+      "category": "machine",
+      "example_values": [
+        "C11",
+        "C12",
+        "C13"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "default_materials",
+      "category": "machine",
+      "example_values": [],
+      "profiles_count": 7
+    },
+    {
+      "key": "auxiliary_fan",
+      "category": "machine",
+      "example_values": [
+        "0",
+        "1"
+      ],
+      "profiles_count": 5
+    },
+    {
+      "key": "bed_exclude_area",
+      "category": "machine",
+      "example_values": [
+        [
+          "0x0",
+          "18x0",
+          "18x28",
+          "0x28"
+        ],
+        [],
+        [
+          "0x0",
+          "28x0",
+          "28x28",
+          "0x28",
+          "0x28",
+          "8x28",
+          "8x256",
+          "0x256"
+        ]
+      ],
+      "profiles_count": 8
+    },
+    {
+      "key": "enable_long_retraction_when_cut",
+      "category": "machine",
+      "example_values": [
+        "2",
+        "0",
+        "1"
+      ],
+      "profiles_count": 8
+    },
+    {
+      "key": "extruder_offset",
+      "category": "machine",
+      "example_values": [
+        [
+          "0x2"
+        ],
+        [
+          "0x0"
+        ],
+        [
+          "0x2"
+        ]
+      ],
+      "profiles_count": 6
+    },
+    {
+      "key": "machine_load_filament_time",
+      "category": "machine",
+      "example_values": [
+        "29",
+        "28",
+        "25"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "machine_unload_filament_time",
+      "category": "machine",
+      "example_values": [
+        "28",
+        "34",
+        "29"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "nozzle_height",
+      "category": "machine",
+      "example_values": [
+        "4.2",
+        "4.76"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "scan_first_layer",
+      "category": "machine",
+      "example_values": [
+        "1",
+        "0"
+      ],
+      "profiles_count": 7
+    },
+    {
+      "key": "machine_end_gcode",
+      "category": "machine",
+      "example_values": [],
+      "profiles_count": 9
+    },
+    {
+      "key": "change_filament_gcode",
+      "category": "machine",
+      "example_values": [
+        ""
+      ],
+      "profiles_count": 9
+    },
+    {
+      "key": "retract_length_toolchange",
+      "category": "machine",
+      "example_values": [
+        [
+          "3"
+        ],
+        [
+          "3"
+        ],
+        [
+          "1"
+        ]
+      ],
+      "profiles_count": 8
+    },
+    {
+      "key": "support_chamber_temp_control",
+      "category": "machine",
+      "example_values": [
+        "0",
+        "1"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "printer_technology",
+      "category": "machine",
+      "example_values": [
+        "FFF"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "deretraction_speed",
+      "category": "machine",
+      "example_values": [
+        [
+          "40"
+        ],
+        [
+          "30"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "extruder_colour",
+      "category": "machine",
+      "example_values": [
+        [
+          "#FCE94F"
+        ],
+        [
+          "#018001"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "gcode_flavor",
+      "category": "machine",
+      "example_values": [
+        "marlin"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "silent_mode",
+      "category": "machine",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "long_retractions_when_cut",
+      "category": "machine",
+      "example_values": [
+        [
+          "0"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "machine_max_acceleration_e",
+      "category": "machine",
+      "example_values": [
+        [
+          "5000"
+        ],
+        [
+          "5000",
+          "5000"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "machine_max_acceleration_extruding",
+      "category": "machine",
+      "example_values": [
+        [
+          "10000"
+        ],
+        [
+          "12000",
+          "12000"
+        ],
+        [
+          "20000",
+          "20000"
+        ]
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "machine_max_acceleration_retracting",
+      "category": "machine",
+      "example_values": [
+        [
+          "1000"
+        ],
+        [
+          "5000",
+          "5000"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "machine_max_acceleration_x",
+      "category": "machine",
+      "example_values": [
+        [
+          "10000"
+        ],
+        [
+          "12000",
+          "12000"
+        ],
+        [
+          "20000",
+          "20000"
+        ]
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "machine_max_acceleration_y",
+      "category": "machine",
+      "example_values": [
+        [
+          "10000"
+        ],
+        [
+          "12000",
+          "12000"
+        ],
+        [
+          "20000",
+          "20000"
+        ]
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "machine_max_acceleration_z",
+      "category": "machine",
+      "example_values": [
+        [
+          "100"
+        ],
+        [
+          "1500",
+          "1500"
+        ],
+        [
+          "1500",
+          "1500"
+        ]
+      ],
+      "profiles_count": 4
+    },
+    {
+      "key": "machine_max_speed_e",
+      "category": "machine",
+      "example_values": [
+        [
+          "60"
+        ],
+        [
+          "30",
+          "30"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "machine_max_speed_x",
+      "category": "machine",
+      "example_values": [
+        [
+          "500"
+        ],
+        [
+          "500",
+          "200"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "machine_max_speed_y",
+      "category": "machine",
+      "example_values": [
+        [
+          "500"
+        ],
+        [
+          "500",
+          "200"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "machine_max_speed_z",
+      "category": "machine",
+      "example_values": [
+        [
+          "10"
+        ],
+        [
+          "30",
+          "30"
+        ],
+        [
+          "30",
+          "30"
+        ]
+      ],
+      "profiles_count": 4
+    },
+    {
+      "key": "machine_max_jerk_e",
+      "category": "machine",
+      "example_values": [
+        [
+          "5"
+        ],
+        [
+          "3",
+          "3"
+        ],
+        [
+          "3",
+          "3"
+        ]
+      ],
+      "profiles_count": 4
+    },
+    {
+      "key": "machine_max_jerk_x",
+      "category": "machine",
+      "example_values": [
+        [
+          "8"
+        ],
+        [
+          "9",
+          "9"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "machine_max_jerk_y",
+      "category": "machine",
+      "example_values": [
+        [
+          "8"
+        ],
+        [
+          "9",
+          "9"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "machine_max_jerk_z",
+      "category": "machine",
+      "example_values": [
+        [
+          "3"
+        ],
+        [
+          "5",
+          "5"
+        ],
+        [
+          "3",
+          "3"
+        ]
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "machine_min_extruding_rate",
+      "category": "machine",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "0",
+          "0"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "machine_min_travel_rate",
+      "category": "machine",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "0",
+          "0"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "printable_height",
+      "category": "machine",
+      "example_values": [
+        "250",
+        "180",
+        "256"
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "extruder_clearance_radius",
+      "category": "machine",
+      "example_values": [
+        "65",
+        "57"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "extruder_clearance_height_to_rod",
+      "category": "machine",
+      "example_values": [
+        "34",
+        "25"
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "extruder_clearance_height_to_lid",
+      "category": "machine",
+      "example_values": [
+        "140",
+        "180",
+        "256"
+      ],
+      "profiles_count": 4
+    },
+    {
+      "key": "printer_settings_id",
+      "category": "machine",
+      "example_values": [
+        ""
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "retract_before_wipe",
+      "category": "machine",
+      "example_values": [
+        [
+          "70%"
+        ],
+        [
+          "0%"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "retract_when_changing_layer",
+      "category": "machine",
+      "example_values": [
+        [
+          "1"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "retraction_distances_when_cut",
+      "category": "machine",
+      "example_values": [
+        [
+          "18"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "z_hop",
+      "category": "machine",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "0.4"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "retract_restart_extra",
+      "category": "machine",
+      "example_values": [
+        [
+          "0"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "retract_restart_extra_toolchange",
+      "category": "machine",
+      "example_values": [
+        [
+          "0"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "retraction_speed",
+      "category": "machine",
+      "example_values": [
+        [
+          "60"
+        ],
+        [
+          "30"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "single_extruder_multi_material",
+      "category": "machine",
+      "example_values": [
+        "0",
+        "1"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "support_air_filtration",
+      "category": "machine",
+      "example_values": [
+        "0",
+        "1"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "wipe",
+      "category": "machine",
+      "example_values": [
+        [
+          "1"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "purge_in_prime_tower",
+      "category": "machine",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "enable_filament_ramming",
+      "category": "machine",
+      "example_values": [
+        "0"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "best_object_pos",
+      "category": "machine",
+      "example_values": [
+        "0.7x0.5",
+        "0.5x0.5"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "extruder_clearance_max_radius",
+      "category": "machine",
+      "example_values": [
+        "73",
+        "68"
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "extruder_clearance_dist_to_rod",
+      "category": "machine",
+      "example_values": [
+        "56.5"
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "head_wrap_detect_zone",
+      "category": "machine",
+      "example_values": [
+        [
+          "156x152",
+          "180x152",
+          "180x180",
+          "156x180"
+        ],
+        [
+          "226x224",
+          "256x224",
+          "256x256",
+          "226x256"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "nozzle_volume",
+      "category": "machine",
+      "example_values": [
+        "92",
+        "107"
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "printable_area",
+      "category": "machine",
+      "example_values": [
+        [
+          "0x0",
+          "180x0",
+          "180x180",
+          "0x180"
+        ],
+        [
+          "0x0",
+          "256x0",
+          "256x256",
+          "0x256"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "retract_lift_below",
+      "category": "machine",
+      "example_values": [
+        [
+          "179"
+        ],
+        [
+          "255"
+        ],
+        [
+          "249"
+        ]
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "printer_structure",
+      "category": "machine",
+      "example_values": [
+        "i3",
+        "corexy"
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "layer_change_gcode",
+      "category": "machine",
+      "example_values": [
+        "; layer num/total_layer_count: {layer_num+1}/[total_layer_count]\n; update layer progress\nM73 L{layer_num+1}\nM991 S0 P{layer_num} ;notify layer change\n",
+        "; layer num/total_layer_count: {layer_num+1}/[total_layer_count]\n; update layer progress\nM73 L{layer_num+1}\nM991 S0 P{layer_num} ;notify layer change"
+      ],
+      "profiles_count": 5
+    },
+    {
+      "key": "time_lapse_gcode",
+      "category": "machine",
+      "example_values": [],
+      "profiles_count": 2
+    },
+    {
+      "key": "machine_max_acceleration_travel",
+      "category": "machine",
+      "example_values": [
+        [
+          "9000",
+          "9000"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "z_hop_types",
+      "category": "machine",
+      "example_values": [
+        [
+          "Auto Lift"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "machine_pause_gcode",
+      "category": "machine",
+      "example_values": [
+        "M400 U1"
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_max_volumetric_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "3.6"
+        ],
+        [
+          "1"
+        ],
+        [
+          "2"
+        ]
+      ],
+      "profiles_count": 217
+    },
+    {
+      "key": "compatible_printers",
+      "category": "filament",
+      "example_values": [
+        [
+          "Bambu Lab X1 Carbon 0.4 nozzle",
+          "Bambu Lab X1 Carbon 0.6 nozzle",
+          "Bambu Lab X1 Carbon 0.8 nozzle",
+          "Bambu Lab P1S 0.4 nozzle",
+          "Bambu Lab P1S 0.6 nozzle",
+          "Bambu Lab P1S 0.8 nozzle",
+          "Bambu Lab X1E 0.4 nozzle",
+          "Bambu Lab X1E 0.6 nozzle",
+          "Bambu Lab X1E 0.8 nozzle"
+        ],
+        [
+          "Bambu Lab P1P 0.8 nozzle",
+          "Bambu Lab P1P 0.6 nozzle",
+          "Bambu Lab P1P 0.4 nozzle"
+        ],
+        [
+          "Bambu Lab P1S 0.8 nozzle"
+        ]
+      ],
+      "profiles_count": 375
+    },
+    {
+      "key": "filament_long_retractions_when_cut",
+      "category": "filament",
+      "example_values": [
+        [
+          "1"
+        ],
+        [
+          "1"
+        ],
+        [
+          "1"
+        ]
+      ],
+      "profiles_count": 98
+    },
+    {
+      "key": "filament_retraction_distances_when_cut",
+      "category": "filament",
+      "example_values": [
+        [
+          "18"
+        ],
+        [
+          "18"
+        ],
+        [
+          "18"
+        ]
+      ],
+      "profiles_count": 98
+    },
+    {
+      "key": "eng_plate_temp",
+      "category": "filament",
+      "example_values": [
+        [
+          "100"
+        ],
+        [
+          "100"
+        ],
+        [
+          "30"
+        ]
+      ],
+      "profiles_count": 63
+    },
+    {
+      "key": "eng_plate_temp_initial_layer",
+      "category": "filament",
+      "example_values": [
+        [
+          "100"
+        ],
+        [
+          "100"
+        ],
+        [
+          "30"
+        ]
+      ],
+      "profiles_count": 63
+    },
+    {
+      "key": "fan_max_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "40"
+        ],
+        [
+          "40"
+        ],
+        [
+          "20"
+        ]
+      ],
+      "profiles_count": 162
+    },
+    {
+      "key": "hot_plate_temp",
+      "category": "filament",
+      "example_values": [
+        [
+          "100"
+        ],
+        [
+          "65"
+        ],
+        [
+          "100"
+        ]
+      ],
+      "profiles_count": 160
+    },
+    {
+      "key": "hot_plate_temp_initial_layer",
+      "category": "filament",
+      "example_values": [
+        [
+          "100"
+        ],
+        [
+          "65"
+        ],
+        [
+          "100"
+        ]
+      ],
+      "profiles_count": 160
+    },
+    {
+      "key": "nozzle_temperature",
+      "category": "filament",
+      "example_values": [
+        [
+          "260"
+        ],
+        [
+          "280"
+        ],
+        [
+          "260"
+        ]
+      ],
+      "profiles_count": 87
+    },
+    {
+      "key": "slow_down_layer_time",
+      "category": "filament",
+      "example_values": [
+        [
+          "12"
+        ],
+        [
+          "12"
+        ],
+        [
+          "12"
+        ]
+      ],
+      "profiles_count": 170
+    },
+    {
+      "key": "textured_plate_temp",
+      "category": "filament",
+      "example_values": [
+        [
+          "100"
+        ],
+        [
+          "65"
+        ],
+        [
+          "100"
+        ]
+      ],
+      "profiles_count": 160
+    },
+    {
+      "key": "textured_plate_temp_initial_layer",
+      "category": "filament",
+      "example_values": [
+        [
+          "100"
+        ],
+        [
+          "65"
+        ],
+        [
+          "100"
+        ]
+      ],
+      "profiles_count": 161
+    },
+    {
+      "key": "chamber_temperatures",
+      "category": "filament",
+      "example_values": [
+        [
+          "60"
+        ],
+        [
+          "60"
+        ],
+        [
+          "60"
+        ]
+      ],
+      "profiles_count": 28
+    },
+    {
+      "key": "filament_id",
+      "category": "filament",
+      "example_values": [
+        "GFN03",
+        "GFA11",
+        "GFU99"
+      ],
+      "profiles_count": 74
+    },
+    {
+      "key": "description",
+      "category": "filament",
+      "example_values": [
+        "This filament is too soft and not compatible with the AMS. Printing it is of many requirements, and to get better printing quality, please refer to this wiki: TPU printing guide.",
+        "To make the prints get higher gloss, please dry the filament before use, and set the outer wall speed to be 40 to 60 mm/s when slicing.",
+        "When printing this filament, there's a risk of warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials."
+      ],
+      "profiles_count": 57
+    },
+    {
+      "key": "filament_cost",
+      "category": "filament",
+      "example_values": [
+        [
+          "84.99"
+        ],
+        [
+          "20"
+        ],
+        [
+          "44.99"
+        ]
+      ],
+      "profiles_count": 69
+    },
+    {
+      "key": "filament_density",
+      "category": "filament",
+      "example_values": [
+        [
+          "1.09"
+        ],
+        [
+          "1.24"
+        ],
+        [
+          "1.21"
+        ]
+      ],
+      "profiles_count": 66
+    },
+    {
+      "key": "filament_flow_ratio",
+      "category": "filament",
+      "example_values": [
+        [
+          "0.96"
+        ],
+        [
+          "0.6"
+        ],
+        [
+          "0.98"
+        ]
+      ],
+      "profiles_count": 68
+    },
+    {
+      "key": "filament_type",
+      "category": "filament",
+      "example_values": [
+        [
+          "PA-CF"
+        ],
+        [
+          "TPU"
+        ],
+        [
+          "PLA-AERO"
+        ]
+      ],
+      "profiles_count": 40
+    },
+    {
+      "key": "filament_vendor",
+      "category": "filament",
+      "example_values": [
+        [
+          "Bambu Lab"
+        ],
+        [
+          "Bambu Lab"
+        ],
+        [
+          "Bambu Lab"
+        ]
+      ],
+      "profiles_count": 55
+    },
+    {
+      "key": "nozzle_temperature_initial_layer",
+      "category": "filament",
+      "example_values": [
+        [
+          "280"
+        ],
+        [
+          "240"
+        ],
+        [
+          "240"
+        ]
+      ],
+      "profiles_count": 65
+    },
+    {
+      "key": "overhang_fan_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "40"
+        ],
+        [
+          "40"
+        ],
+        [
+          "100"
+        ]
+      ],
+      "profiles_count": 40
+    },
+    {
+      "key": "overhang_fan_threshold",
+      "category": "filament",
+      "example_values": [
+        [
+          "0%"
+        ],
+        [
+          "50%"
+        ],
+        [
+          "0%"
+        ]
+      ],
+      "profiles_count": 39
+    },
+    {
+      "key": "temperature_vitrification",
+      "category": "filament",
+      "example_values": [
+        [
+          "170"
+        ],
+        [
+          "30"
+        ],
+        [
+          "45"
+        ]
+      ],
+      "profiles_count": 32
+    },
+    {
+      "key": "fan_cooling_layer_time",
+      "category": "filament",
+      "example_values": [
+        [
+          "80"
+        ],
+        [
+          "80"
+        ],
+        [
+          "100"
+        ]
+      ],
+      "profiles_count": 140
+    },
+    {
+      "key": "fan_min_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "50"
+        ],
+        [
+          "60"
+        ],
+        [
+          "100"
+        ]
+      ],
+      "profiles_count": 147
+    },
+    {
+      "key": "reduce_fan_stop_start_freq",
+      "category": "filament",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "1"
+        ],
+        [
+          "1"
+        ]
+      ],
+      "profiles_count": 30
+    },
+    {
+      "key": "additional_cooling_fan_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "70"
+        ],
+        [
+          "70"
+        ],
+        [
+          "0"
+        ]
+      ],
+      "profiles_count": 16
+    },
+    {
+      "key": "close_fan_the_first_x_layers",
+      "category": "filament",
+      "example_values": [
+        [
+          "1"
+        ],
+        [
+          "1"
+        ],
+        [
+          "3"
+        ]
+      ],
+      "profiles_count": 10
+    },
+    {
+      "key": "supertack_plate_temp",
+      "category": "filament",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "0"
+        ],
+        [
+          "80"
+        ]
+      ],
+      "profiles_count": 32
+    },
+    {
+      "key": "supertack_plate_temp_initial_layer",
+      "category": "filament",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "0"
+        ],
+        [
+          "80"
+        ]
+      ],
+      "profiles_count": 33
+    },
+    {
+      "key": "cool_plate_temp",
+      "category": "filament",
+      "example_values": [
+        [
+          "30"
+        ],
+        [
+          "35"
+        ],
+        [
+          "0"
+        ]
+      ],
+      "profiles_count": 30
+    },
+    {
+      "key": "cool_plate_temp_initial_layer",
+      "category": "filament",
+      "example_values": [
+        [
+          "30"
+        ],
+        [
+          "35"
+        ],
+        [
+          "0"
+        ]
+      ],
+      "profiles_count": 30
+    },
+    {
+      "key": "filament_retraction_length",
+      "category": "filament",
+      "example_values": [
+        [
+          "0.4"
+        ],
+        [
+          "0.3"
+        ],
+        [
+          "0.2"
+        ]
+      ],
+      "profiles_count": 17
+    },
+    {
+      "key": "nozzle_temperature_range_high",
+      "category": "filament",
+      "example_values": [
+        [
+          "250"
+        ],
+        [
+          "260"
+        ],
+        [
+          "240"
+        ]
+      ],
+      "profiles_count": 35
+    },
+    {
+      "key": "nozzle_temperature_range_low",
+      "category": "filament",
+      "example_values": [
+        [
+          "200"
+        ],
+        [
+          "210"
+        ],
+        [
+          "190"
+        ]
+      ],
+      "profiles_count": 35
+    },
+    {
+      "key": "filament_start_gcode",
+      "category": "filament",
+      "example_values": [
+        [
+          "; filament start gcode\n{if  (bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >30)||(bed_temperature_initial_layer[current_extruder] >30)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+        ],
+        [
+          "; filament start gcode\n{if  (bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >30)||(bed_temperature_initial_layer[current_extruder] >30)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+        ],
+        [
+          "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+        ]
+      ],
+      "profiles_count": 86
+    },
+    {
+      "key": "filament_scarf_seam_type",
+      "category": "filament",
+      "example_values": [
+        [
+          "none"
+        ],
+        [
+          "none"
+        ],
+        [
+          "none"
+        ]
+      ],
+      "profiles_count": 15
+    },
+    {
+      "key": "filament_scarf_gap",
+      "category": "filament",
+      "example_values": [
+        [
+          "15%"
+        ],
+        [
+          "0%"
+        ],
+        [
+          "0%"
+        ]
+      ],
+      "profiles_count": 5
+    },
+    {
+      "key": "slow_down_min_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "20"
+        ],
+        [
+          "10"
+        ],
+        [
+          "20"
+        ]
+      ],
+      "profiles_count": 25
+    },
+    {
+      "key": "required_nozzle_HRC",
+      "category": "filament",
+      "example_values": [
+        [
+          "40"
+        ],
+        [
+          "40"
+        ],
+        [
+          "3"
+        ]
+      ],
+      "profiles_count": 13
+    },
+    {
+      "key": "activate_air_filtration",
+      "category": "filament",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "1"
+        ],
+        [
+          "1"
+        ]
+      ],
+      "profiles_count": 5
+    },
+    {
+      "key": "complete_print_exhaust_fan_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "70"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "during_print_exhaust_fan_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "70"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_deretraction_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_diameter",
+      "category": "filament",
+      "example_values": [
+        [
+          "1.75"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_is_support",
+      "category": "filament",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "1"
+        ],
+        [
+          "1"
+        ]
+      ],
+      "profiles_count": 10
+    },
+    {
+      "key": "filament_minimal_purge_on_wipe_tower",
+      "category": "filament",
+      "example_values": [
+        [
+          "15"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_retract_before_wipe",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_retract_restart_extra",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_retract_when_changing_layer",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_retraction_minimum_travel",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_retraction_speed",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ],
+        [
+          "0.4"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "filament_settings_id",
+      "category": "filament",
+      "example_values": [
+        [
+          ""
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_soluble",
+      "category": "filament",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "1"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "filament_wipe",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_wipe_distance",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ],
+        [
+          "5"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "filament_z_hop",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_z_hop_types",
+      "category": "filament",
+      "example_values": [
+        [
+          "nil"
+        ],
+        [
+          "Normal Lift"
+        ]
+      ],
+      "profiles_count": 2
+    },
+    {
+      "key": "full_fan_speed_layer",
+      "category": "filament",
+      "example_values": [
+        [
+          "0"
+        ],
+        [
+          "2"
+        ],
+        [
+          "2"
+        ]
+      ],
+      "profiles_count": 6
+    },
+    {
+      "key": "filament_scarf_height",
+      "category": "filament",
+      "example_values": [
+        [
+          "10%"
+        ],
+        [
+          "5%"
+        ],
+        [
+          "5%"
+        ]
+      ],
+      "profiles_count": 5
+    },
+    {
+      "key": "filament_scarf_length",
+      "category": "filament",
+      "example_values": [
+        [
+          "10"
+        ],
+        [
+          "10"
+        ],
+        [
+          "10"
+        ]
+      ],
+      "profiles_count": 3
+    },
+    {
+      "key": "filament_shrink",
+      "category": "filament",
+      "example_values": [
+        [
+          "100%"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "slow_down_for_layer_cooling",
+      "category": "filament",
+      "example_values": [
+        [
+          "1"
+        ]
+      ],
+      "profiles_count": 1
+    },
+    {
+      "key": "filament_end_gcode",
+      "category": "filament",
+      "example_values": [
+        [
+          "; filament end gcode \nM106 P3 S0\n"
+        ]
+      ],
+      "profiles_count": 1
+    }
+  ]
+}

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -350,23 +350,123 @@ def validate_override_keys(
 ) -> list[str]:
     """Check that override keys exist in the resolved process profile.
 
-    Returns a list of warning strings for unknown keys.
+    Returns a list of warning strings for unknown keys, including
+    cross-engine detection (e.g. OrcaSlicer key used in CuraEngine config)
+    and "did you mean?" suggestions.
     """
-    if not overrides or not process:
+    if not overrides:
         return []
 
+    profile_keys: set[str] = set()
+    if process:
+        try:
+            data = resolve_profile_data(process, engine, "process", project_dir)
+            profile_keys = set(data.keys())
+        except (EstampoError, FileNotFoundError, OSError):
+            log.debug("Cannot resolve process profile for override validation", exc_info=True)
+
+    # Load known settings from bundled settings JSON files
+    engine_keys = _load_engine_settings(engine)
+    other_engine = "cura" if engine == "orca" else "orca"
+    other_keys = _load_engine_settings(other_engine)
+    cross_map = _cross_engine_map()
+
+    all_valid = profile_keys | engine_keys
+    warnings: list[str] = []
+
+    for key in overrides:
+        if key in all_valid:
+            continue
+
+        # Cross-engine detection: key belongs to the other engine
+        if key in other_keys:
+            suggestion = cross_map.get(key)
+            if suggestion and suggestion in all_valid:
+                warnings.append(
+                    f"slicer.overrides key '{key}' is an {other_engine} setting "
+                    f"— did you mean '{suggestion}'?"
+                )
+            else:
+                warnings.append(
+                    f"slicer.overrides key '{key}' is an {other_engine} setting, "
+                    f"not a valid {engine} key"
+                )
+        else:
+            # Unknown key — try fuzzy match against engine keys
+            hint = _closest_setting(key, all_valid)
+            msg = f"slicer.overrides key '{key}' not found in {engine} settings"
+            if hint:
+                msg += f" — did you mean '{hint}'?"
+            warnings.append(msg)
+
+    return warnings
+
+
+def _load_engine_settings(engine: str) -> set[str]:
+    """Load known setting keys from bundled settings JSON."""
+    settings_file = Path(__file__).parent / "data" / f"{engine}-settings.json"
+    if not settings_file.exists():
+        return set()
     try:
-        data = resolve_profile_data(process, engine, "process", project_dir)
-    except (EstampoError, FileNotFoundError, OSError):
-        log.debug("Cannot resolve process profile for override validation", exc_info=True)
-        return []
+        data = json.loads(settings_file.read_text())
+        return {s["key"] for s in data.get("settings", [])}
+    except (json.JSONDecodeError, KeyError, OSError):
+        return set()
 
-    unknown = [k for k in overrides if k not in data]
-    return [
-        f"slicer.overrides key '{k}' not found in process profile '{process}' "
-        f"— it will be injected but may be ignored by the slicer"
-        for k in unknown
-    ]
+
+def _cross_engine_map() -> dict[str, str]:
+    """Bidirectional mapping between OrcaSlicer and CuraEngine setting names."""
+    orca_to_cura = {
+        "wall_loops": "wall_line_count",
+        "top_shell_layers": "top_layers",
+        "bottom_shell_layers": "bottom_layers",
+        "sparse_infill_density": "infill_sparse_density",
+        "sparse_infill_pattern": "infill_pattern",
+        "initial_layer_print_height": "layer_height_0",
+        "enable_support": "support_enable",
+        "support_threshold_angle": "support_angle",
+        "nozzle_temperature": "material_print_temperature",
+        "bed_temperature": "material_bed_temperature",
+        "outer_wall_speed": "speed_wall_0",
+        "inner_wall_speed": "speed_wall_x",
+        "sparse_infill_speed": "speed_infill",
+        "travel_speed": "speed_travel",
+        "retraction_length": "retraction_amount",
+        "brim_type": "adhesion_type",
+        "seam_position": "z_seam_type",
+        "fan_min_speed": "cool_fan_speed_min",
+        "fan_max_speed": "cool_fan_speed_max",
+        "ironing_type": "ironing_enabled",
+        "xy_hole_compensation": "hole_xy_offset",
+        "xy_contour_compensation": "xy_offset",
+    }
+    # Build bidirectional map
+    cross: dict[str, str] = {}
+    cross.update(orca_to_cura)
+    cross.update({v: k for k, v in orca_to_cura.items()})
+    return cross
+
+
+def _closest_setting(name: str, candidates: set[str]) -> str | None:
+    """Find the closest matching setting key."""
+    if not candidates:
+        return None
+    name_lower = name.lower()
+    # Substring match
+    for c in sorted(candidates):
+        if name_lower in c.lower() or c.lower() in name_lower:
+            return c
+    # Common word overlap (split on underscores)
+    name_parts = set(name_lower.split("_"))
+    best = None
+    best_score = 0
+    for c in candidates:
+        c_parts = set(c.lower().split("_"))
+        overlap = len(name_parts & c_parts)
+        if overlap > best_score:
+            best_score = overlap
+            best = c
+    return best if best_score >= 2 else None
 
 
 def pin_profiles(

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -981,9 +981,16 @@ def test_validate_override_keys_unknown(tmp_path):
     assert "bogus_key" in warnings[0]
 
 
-def test_validate_override_keys_no_process():
-    """No process profile means no warnings (nothing to check against)."""
-    assert validate_override_keys({"k": "v"}, engine="orca", process=None) == []
+def test_validate_override_keys_no_process_valid_key():
+    """No process profile but valid engine key produces no warnings."""
+    assert validate_override_keys({"layer_height": "0.2"}, engine="orca", process=None) == []
+
+
+def test_validate_override_keys_no_process_unknown_key():
+    """No process profile with unknown key still warns (checked against engine settings)."""
+    warnings = validate_override_keys({"bogus_xyz": "v"}, engine="orca", process=None)
+    assert len(warnings) == 1
+    assert "bogus_xyz" in warnings[0]
 
 
 def test_validate_override_keys_no_overrides():
@@ -992,7 +999,7 @@ def test_validate_override_keys_no_overrides():
 
 
 def test_validate_override_keys_unresolvable_profile():
-    """Unresolvable profile is silently skipped (no crash)."""
+    """Unresolvable profile with valid engine key still passes."""
     warnings = validate_override_keys(
         {"layer_height": "0.2"},
         engine="orca",
@@ -1000,6 +1007,41 @@ def test_validate_override_keys_unresolvable_profile():
         project_dir=None,
     )
     assert warnings == []
+
+
+def test_validate_override_keys_cross_engine_orca_in_cura():
+    """Using OrcaSlicer key in CuraEngine config should suggest the CuraEngine equivalent."""
+    warnings = validate_override_keys(
+        {"wall_loops": "3"},
+        engine="cura",
+        process=None,
+    )
+    assert len(warnings) == 1
+    assert "orca" in warnings[0].lower()
+    assert "wall_line_count" in warnings[0]
+
+
+def test_validate_override_keys_cross_engine_cura_in_orca():
+    """Using CuraEngine key in OrcaSlicer config should suggest the OrcaSlicer equivalent."""
+    warnings = validate_override_keys(
+        {"infill_sparse_density": 20},
+        engine="orca",
+        process=None,
+    )
+    assert len(warnings) == 1
+    assert "cura" in warnings[0].lower()
+    assert "sparse_infill_density" in warnings[0]
+
+
+def test_validate_override_keys_did_you_mean():
+    """Typo in override key should suggest closest match."""
+    warnings = validate_override_keys(
+        {"wall_loop": "3"},  # missing 's'
+        engine="orca",
+        process=None,
+    )
+    assert len(warnings) == 1
+    assert "wall_loops" in warnings[0]
 
 
 # --- pinned_profiles_version ---


### PR DESCRIPTION
## Summary

- Override keys are now validated against the full bundled settings lists (263 OrcaSlicer + 711 CuraEngine settings)
- **Cross-engine detection**: using `wall_loops` in a CuraEngine config warns and suggests `wall_line_count` (and vice versa for all 22 mapped setting pairs)
- **"Did you mean?"** suggestions for typos: `wall_loop` → `wall_loops`
- Works even without a process profile (CuraEngine has no process profiles)
- Settings JSON files bundled in package data so validation works for installed users too

Example warnings:
```
⚠ slicer.overrides key 'wall_loops' is an orca setting — did you mean 'wall_line_count'?
⚠ slicer.overrides key 'wall_loop' not found in orca settings — did you mean 'wall_loops'?
```

Closes #503

## Test plan
- [x] Cross-engine: OrcaSlicer key in CuraEngine config detects and suggests equivalent
- [x] Cross-engine: CuraEngine key in OrcaSlicer config detects and suggests equivalent
- [x] Typo detection with "did you mean?" suggestions
- [x] Valid keys produce no warnings (with and without process profile)
- [x] Unknown keys without close match still warn
- [x] All 567 tests pass, mypy/ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)