### PR TITLE
Support PEP 440 pre-release versions in release pipeline

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. 0.2.3)"
+        description: "Release version (e.g. 0.2.3, 0.4.0a1, 0.4.0rc1)"
         required: true
 
 jobs:
@@ -21,8 +21,9 @@ jobs:
       - name: Validate version format
         run: |
           VERSION="${{ inputs.version }}"
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version format: $VERSION (expected X.Y.Z)"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]] && \
+             [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected X.Y.Z or X.Y.ZaN/X.Y.ZbN/X.Y.ZrcN)"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.2.3) — use only as fallback"
+        description: "Release tag (e.g. v0.2.3, v0.4.0a1) — use only as fallback"
         required: true
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
           echo "Associated PR branches: ${BRANCHES:-<none>}"
 
           VERSION=$(echo "$BRANCHES" \
-            | grep -oP '^release/v\K\d+\.\d+\.\d+$' \
+            | grep -oP '^release/v\K\d+\.\d+\.\d+((a|b|rc)\d+)?$' \
             | head -1 || true)
 
           if [[ -n "$VERSION" ]]; then
@@ -447,6 +447,10 @@ jobs:
           VERSION="${{ needs.version.outputs.version }}"
           WHEEL=$(ls dist/*.whl 2>/dev/null | head -1)
           ARGS=(gh release create "v${VERSION}" --title "v${VERSION}" --notes-file /tmp/release-body.md)
+          # Mark alpha/beta/rc versions as pre-release
+          if [[ "$VERSION" =~ (a|b|rc)[0-9]+$ ]]; then
+            ARGS+=(--prerelease)
+          fi
           if [[ -n "$WHEEL" ]]; then
             ARGS+=("$WHEEL")
           fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,6 +43,17 @@ This creates a `release/v0.3.0` branch with:
 - `CHANGELOG.md` updated by towncrier (fragments compiled and deleted)
 - A PR titled "Release v0.3.0"
 
+**Pre-release versions** follow [PEP 440](https://peps.python.org/pep-0440/):
+
+```bash
+gh workflow run prepare-release.yml -f version=0.4.0a1   # alpha
+gh workflow run prepare-release.yml -f version=0.4.0b1   # beta
+gh workflow run prepare-release.yml -f version=0.4.0rc1  # release candidate
+```
+
+Pre-releases create GitHub Releases marked as "Pre-release" and are not
+installed by `pip install estampo` unless the user opts in with `--pre`.
+
 ### 2. Review
 
 Open the PR, review the changelog, edit if needed, then merge.

--- a/changes/508.feature
+++ b/changes/508.feature
@@ -1,0 +1,1 @@
+Support PEP 440 pre-release versions (``0.4.0a1``, ``0.4.0b1``, ``0.4.0rc1``) in the release pipeline


### PR DESCRIPTION
## Summary

- Update version validation in `prepare-release.yml` to accept PEP 440 pre-release suffixes: `0.4.0a1`, `0.4.0b1`, `0.4.0rc1`
- Update release branch detection in `release.yml` to match `release/v0.4.0a1` style branches
- Mark pre-release GitHub Releases with `--prerelease` flag
- Document pre-release workflow in `RELEASE.md`

## Changes

| File | What changed |
|------|-------------|
| `prepare-release.yml` | Version regex accepts optional `(a\|b\|rc)N` suffix |
| `release.yml` | Branch detection regex, tag description, `--prerelease` flag on GitHub Release |
| `RELEASE.md` | Document pre-release version support with examples |

## Test plan

- [ ] Verify regex accepts: `0.4.0`, `0.4.0a1`, `0.4.0b1`, `0.4.0rc1`
- [ ] Verify regex rejects: `0.4.0alpha1`, `0.4.0-rc1`, `0.4.0.a1`
- [ ] Test with `gh workflow run prepare-release.yml -f version=0.4.0a1` when ready

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)