### PR TITLE
Release v0.4.0a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to this project are documented here.
 
 <!-- towncrier release notes start -->
 
+## 0.4.0a1 — 2026-04-17
+
+### Features
+
+- Remove G-code template post-processing from CuraEngine backend; write ``cura_settings.json`` for external resolvers via command stages ([#485](https://github.com/estampo/estampo/pull/485))
+- Validate slicer override keys against full settings lists with cross-engine detection and "did you mean?" suggestions ([#503](https://github.com/estampo/estampo/pull/503))
+- Add AI setup prompt template (``docs/ai-setup-prompt.md``) for assisted estampo adoption in new projects ([#506](https://github.com/estampo/estampo/pull/506))
+- Support PEP 440 pre-release versions (``0.4.0a1``, ``0.4.0b1``, ``0.4.0rc1``) in the release pipeline ([#508](https://github.com/estampo/estampo/pull/508))
+- Add JSON Schema for ``estampo.toml`` and ``llm.md`` reference document for humans and AI assistants
+- Add ``--json`` flag to ``validate`` and ``run`` commands for structured output
+- Add ``SlicerEngine`` protocol in ``engine.py`` formalizing the contract every slicer module must implement
+- Add ``estampo info --json``, ``profiles list --json``, ``profiles pin --yes``, and non-interactive ``estampo init --engine --printer --filament --part``
+- Add ``{filament}`` and ``{filaments}`` template variables for command stages
+- Bundle bambox, bambox-bridge, and cura-p1s into Docker images; add ``docker`` flag for command stages; fix action image reference and stale workflow paths
+- ``estampo init`` offers pack/repack command stages for Bambu Lab printers
+
+### Bugfixes
+
+- Fix ``pin_cura_definitions()`` to also copy extruder definitions referenced by the machine definition ([#455](https://github.com/estampo/estampo/pull/455))
+- Fix ``profiles pin`` showing unnecessary overwrite prompt after ``profiles add`` on a fresh project ([#457](https://github.com/estampo/estampo/pull/457))
+- Extract CuraEngine extruder definitions from Docker image and copy them automatically on ``profiles add`` ([#459](https://github.com/estampo/estampo/pull/459))
+- Fix Docker command wrapping producing backslash paths on Windows ([#497](https://github.com/estampo/estampo/pull/497))
+- Auto-generated profile and definition update PRs now trigger CI and reuse a stable branch name, so they can actually merge.
+- Fix example pack commands and CuraEngine local definition search path
+- Include towncrier changelog fragments in auto-generated profile update PRs
+
+### Misc
+
+- Remove trivial wrapper functions in ``init.py`` — call ``ui.*`` and engine modules directly ([#447](https://github.com/estampo/estampo/pull/447))
+- Refresh examples: add quickstart config, validate all examples in CI ([#465](https://github.com/estampo/estampo/pull/465))
+- Add multi-part example demonstrating arrangement, orientation, scaling, and slicer overrides ([#466](https://github.com/estampo/estampo/pull/466))
+- Add multi-filament example demonstrating OrcaSlicer AMS slot assignment ([#467](https://github.com/estampo/estampo/pull/467))
+- Add CuraEngine example with Ultimaker 2; add bambox repack stage to OrcaSlicer examples ([#468](https://github.com/estampo/estampo/pull/468))
+- Add CuraEngine + Bambu P1S example with bambox printer definition and pack stage
+- Add printing instructions and print stage docs to P1S examples
+- Consolidate duplicated filament conversion logic in ``gcode.py`` and remove duplicate ``_load_bundled_manifest()`` from ``cura.py``
+- Decouple progress adapter from hardcoded Hamilton node names using ``@tag`` decorators
+- Delete C++ cloud bridge source and remove bridge jobs from all CI/CD workflows
+- Delete printer, auth, credentials, cloud, and thumbnails modules — estampo is now fully printer-agnostic. Default CuraEngine printer changed from Bambu Lab P1S to Ultimaker 2.
+- Extract shared Docker utilities into ``docker.py`` module, removing duplication from engine modules
+- Pin profiles in all examples and add richer slicer overrides
+- Release-readiness tests now run full pipeline inside Docker (including pack/repack) and verify ``.gcode.3mf`` output
+- Remove unused ``bambulabs-api`` and ``bambu-lab-cloud-api`` dependencies, and remove ``_find_in_bambox()`` from ``cura.py`` per ADR-005
+- Replace raw ``print()`` with ANSI escape codes with ``ui.*`` functions throughout CLI and engine modules
+- Update bundled CuraEngine 5.12.0 definitions
+
+
 ## 0.3.1 — 2026-04-11
 
 ### Features

--- a/changes/+ai-cli-500.feature
+++ b/changes/+ai-cli-500.feature
@@ -1,1 +1,0 @@
-Add ``estampo info --json``, ``profiles list --json``, ``profiles pin --yes``, and non-interactive ``estampo init --engine --printer --filament --part``

--- a/changes/+consolidate-duplication.misc
+++ b/changes/+consolidate-duplication.misc
@@ -1,1 +1,0 @@
-Consolidate duplicated filament conversion logic in ``gcode.py`` and remove duplicate ``_load_bundled_manifest()`` from ``cura.py``

--- a/changes/+cura-p1s-example.misc
+++ b/changes/+cura-p1s-example.misc
@@ -1,1 +1,0 @@
-Add CuraEngine + Bambu P1S example with bambox printer definition and pack stage

--- a/changes/+decouple-progress-adapter.misc
+++ b/changes/+decouple-progress-adapter.misc
@@ -1,1 +1,0 @@
-Decouple progress adapter from hardcoded Hamilton node names using ``@tag`` decorators

--- a/changes/+delete-cloud-bridge.misc
+++ b/changes/+delete-cloud-bridge.misc
@@ -1,1 +1,0 @@
-Delete C++ cloud bridge source and remove bridge jobs from all CI/CD workflows

--- a/changes/+docker-bundle-fixes.feature
+++ b/changes/+docker-bundle-fixes.feature
@@ -1,1 +1,0 @@
-Bundle bambox, bambox-bridge, and cura-p1s into Docker images; add ``docker`` flag for command stages; fix action image reference and stale workflow paths

--- a/changes/+e2e-pack-readiness.misc
+++ b/changes/+e2e-pack-readiness.misc
@@ -1,1 +1,0 @@
-Release-readiness tests now run full pipeline inside Docker (including pack/repack) and verify ``.gcode.3mf`` output

--- a/changes/+filament-command-variable.feature
+++ b/changes/+filament-command-variable.feature
@@ -1,1 +1,0 @@
-Add ``{filament}`` and ``{filaments}`` template variables for command stages

--- a/changes/+fix-auto-pr-token.bugfix
+++ b/changes/+fix-auto-pr-token.bugfix
@@ -1,1 +1,0 @@
-Auto-generated profile and definition update PRs now trigger CI and reuse a stable branch name, so they can actually merge.

--- a/changes/+fix-pack-commands.bugfix
+++ b/changes/+fix-pack-commands.bugfix
@@ -1,1 +1,0 @@
-Fix example pack commands and CuraEngine local definition search path

--- a/changes/+init-command-stages.feature
+++ b/changes/+init-command-stages.feature
@@ -1,1 +1,0 @@
-``estampo init`` offers pack/repack command stages for Bambu Lab printers

--- a/changes/+json-output-500.feature
+++ b/changes/+json-output-500.feature
@@ -1,1 +1,0 @@
-Add ``--json`` flag to ``validate`` and ``run`` commands for structured output

--- a/changes/+json-schema-llm-docs.feature
+++ b/changes/+json-schema-llm-docs.feature
@@ -1,1 +1,0 @@
-Add JSON Schema for ``estampo.toml`` and ``llm.md`` reference document for humans and AI assistants

--- a/changes/+pin-profiles-overrides.misc
+++ b/changes/+pin-profiles-overrides.misc
@@ -1,1 +1,0 @@
-Pin profiles in all examples and add richer slicer overrides

--- a/changes/+print-docs.misc
+++ b/changes/+print-docs.misc
@@ -1,1 +1,0 @@
-Add printing instructions and print stage docs to P1S examples

--- a/changes/+profile-pr-changelog.bugfix
+++ b/changes/+profile-pr-changelog.bugfix
@@ -1,1 +1,0 @@
-Include towncrier changelog fragments in auto-generated profile update PRs

--- a/changes/+remove-bambu-deps.misc
+++ b/changes/+remove-bambu-deps.misc
@@ -1,1 +1,0 @@
-Remove unused ``bambulabs-api`` and ``bambu-lab-cloud-api`` dependencies, and remove ``_find_in_bambox()`` from ``cura.py`` per ADR-005

--- a/changes/+shared-docker-logic.misc
+++ b/changes/+shared-docker-logic.misc
@@ -1,1 +1,0 @@
-Extract shared Docker utilities into ``docker.py`` module, removing duplication from engine modules

--- a/changes/+slicer-engine-protocol.feature
+++ b/changes/+slicer-engine-protocol.feature
@@ -1,1 +1,0 @@
-Add ``SlicerEngine`` protocol in ``engine.py`` formalizing the contract every slicer module must implement

--- a/changes/+standardize-output.misc
+++ b/changes/+standardize-output.misc
@@ -1,1 +1,0 @@
-Replace raw ``print()`` with ANSI escape codes with ``ui.*`` functions throughout CLI and engine modules

--- a/changes/+update-cura-definitions.misc
+++ b/changes/+update-cura-definitions.misc
@@ -1,1 +1,0 @@
-Update bundled CuraEngine 5.12.0 definitions

--- a/changes/+vendor-agnostic-sweep.misc
+++ b/changes/+vendor-agnostic-sweep.misc
@@ -1,1 +1,0 @@
-Delete printer, auth, credentials, cloud, and thumbnails modules — estampo is now fully printer-agnostic. Default CuraEngine printer changed from Bambu Lab P1S to Ultimaker 2.

--- a/changes/447.misc
+++ b/changes/447.misc
@@ -1,1 +1,0 @@
-Remove trivial wrapper functions in ``init.py`` — call ``ui.*`` and engine modules directly

--- a/changes/455.bugfix
+++ b/changes/455.bugfix
@@ -1,1 +1,0 @@
-Fix ``pin_cura_definitions()`` to also copy extruder definitions referenced by the machine definition

--- a/changes/457.bugfix
+++ b/changes/457.bugfix
@@ -1,1 +1,0 @@
-Fix ``profiles pin`` showing unnecessary overwrite prompt after ``profiles add`` on a fresh project

--- a/changes/459.bugfix
+++ b/changes/459.bugfix
@@ -1,1 +1,0 @@
-Extract CuraEngine extruder definitions from Docker image and copy them automatically on ``profiles add``

--- a/changes/465.misc
+++ b/changes/465.misc
@@ -1,1 +1,0 @@
-Refresh examples: add quickstart config, validate all examples in CI

--- a/changes/466.misc
+++ b/changes/466.misc
@@ -1,1 +1,0 @@
-Add multi-part example demonstrating arrangement, orientation, scaling, and slicer overrides

--- a/changes/467.misc
+++ b/changes/467.misc
@@ -1,1 +1,0 @@
-Add multi-filament example demonstrating OrcaSlicer AMS slot assignment

--- a/changes/468.misc
+++ b/changes/468.misc
@@ -1,1 +1,0 @@
-Add CuraEngine example with Ultimaker 2; add bambox repack stage to OrcaSlicer examples

--- a/changes/485.feature
+++ b/changes/485.feature
@@ -1,1 +1,0 @@
-Remove G-code template post-processing from CuraEngine backend; write ``cura_settings.json`` for external resolvers via command stages

--- a/changes/497.bugfix
+++ b/changes/497.bugfix
@@ -1,1 +1,0 @@
-Fix Docker command wrapping producing backslash paths on Windows

--- a/changes/503.feature
+++ b/changes/503.feature
@@ -1,1 +1,0 @@
-Validate slicer override keys against full settings lists with cross-engine detection and "did you mean?" suggestions

--- a/changes/506.feature
+++ b/changes/506.feature
@@ -1,1 +1,0 @@
-Add AI setup prompt template (``docs/ai-setup-prompt.md``) for assisted estampo adoption in new projects

--- a/changes/508.feature
+++ b/changes/508.feature
@@ -1,1 +1,0 @@
-Support PEP 440 pre-release versions (``0.4.0a1``, ``0.4.0b1``, ``0.4.0rc1``) in the release pipeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estampo"
-version = "0.3.1"
+version = "0.4.0a1"
 description = "The build system for reproducible 3D prints. Define parts, slicer settings, and printer targets in code."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release v0.4.0a1


### Features

- Remove G-code template post-processing from CuraEngine backend; write ``cura_settings.json`` for external resolvers via command stages ([#485](https://github.com/estampo/estampo/pull/485))
- Validate slicer override keys against full settings lists with cross-engine detection and "did you mean?" suggestions ([#503](https://github.com/estampo/estampo/pull/503))
- Add AI setup prompt template (``docs/ai-setup-prompt.md``) for assisted estampo adoption in new projects ([#506](https://github.com/estampo/estampo/pull/506))
- Support PEP 440 pre-release versions (``0.4.0a1``, ``0.4.0b1``, ``0.4.0rc1``) in the release pipeline ([#508](https://github.com/estampo/estampo/pull/508))
- Add JSON Schema for ``estampo.toml`` and ``llm.md`` reference document for humans and AI assistants
- Add ``--json`` flag to ``validate`` and ``run`` commands for structured output
- Add ``SlicerEngine`` protocol in ``engine.py`` formalizing the contract every slicer module must implement
- Add ``estampo info --json``, ``profiles list --json``, ``profiles pin --yes``, and non-interactive ``estampo init --engine --printer --filament --part``
- Add ``{filament}`` and ``{filaments}`` template variables for command stages
- Bundle bambox, bambox-bridge, and cura-p1s into Docker images; add ``docker`` flag for command stages; fix action image reference and stale workflow paths
- ``estampo init`` offers pack/repack command stages for Bambu Lab printers

### Bugfixes

- Fix ``pin_cura_definitions()`` to also copy extruder definitions referenced by the machine definition ([#455](https://github.com/estampo/estampo/pull/455))
- Fix ``profiles pin`` showing unnecessary overwrite prompt after ``profiles add`` on a fresh project ([#457](https://github.com/estampo/estampo/pull/457))
- Extract CuraEngine extruder definitions from Docker image and copy them automatically on ``profiles add`` ([#459](https://github.com/estampo/estampo/pull/459))
- Fix Docker command wrapping producing backslash paths on Windows ([#497](https://github.com/estampo/estampo/pull/497))
- Auto-generated profile and definition update PRs now trigger CI and reuse a stable branch name, so they can actually merge.
- Fix example pack commands and CuraEngine local definition search path
- Include towncrier changelog fragments in auto-generated profile update PRs

### Misc

- Remove trivial wrapper functions in ``init.py`` — call ``ui.*`` and engine modules directly ([#447](https://github.com/estampo/estampo/pull/447))
- Refresh examples: add quickstart config, validate all examples in CI ([#465](https://github.com/estampo/estampo/pull/465))
- Add multi-part example demonstrating arrangement, orientation, scaling, and slicer overrides ([#466](https://github.com/estampo/estampo/pull/466))
- Add multi-filament example demonstrating OrcaSlicer AMS slot assignment ([#467](https://github.com/estampo/estampo/pull/467))
- Add CuraEngine example with Ultimaker 2; add bambox repack stage to OrcaSlicer examples ([#468](https://github.com/estampo/estampo/pull/468))
- Add CuraEngine + Bambu P1S example with bambox printer definition and pack stage
- Add printing instructions and print stage docs to P1S examples
- Consolidate duplicated filament conversion logic in ``gcode.py`` and remove duplicate ``_load_bundled_manifest()`` from ``cura.py``
- Decouple progress adapter from hardcoded Hamilton node names using ``@tag`` decorators
- Delete C++ cloud bridge source and remove bridge jobs from all CI/CD workflows
- Delete printer, auth, credentials, cloud, and thumbnails modules — estampo is now fully printer-agnostic. Default CuraEngine printer changed from Bambu Lab P1S to Ultimaker 2.
- Extract shared Docker utilities into ``docker.py`` module, removing duplication from engine modules
- Pin profiles in all examples and add richer slicer overrides
- Release-readiness tests now run full pipeline inside Docker (including pack/repack) and verify ``.gcode.3mf`` output
- Remove unused ``bambulabs-api`` and ``bambu-lab-cloud-api`` dependencies, and remove ``_find_in_bambox()`` from ``cura.py`` per ADR-005
- Replace raw ``print()`` with ANSI escape codes with ``ui.*`` functions throughout CLI and engine modules
- Update bundled CuraEngine 5.12.0 definitions

---
**Merge this PR to trigger the release pipeline.**
The release workflow will auto-tag `v0.4.0a1`, build all artifacts, validate on TestPyPI, then publish to PyPI + Docker Hub + GHCR.