### PR TITLE
Fix AI setup prompt missing bambox pack for Bambu printers

### DIFF
--- a/changes/511.bugfix
+++ b/changes/511.bugfix
@@ -1,0 +1,1 @@
+Fix AI setup prompt to include engine-specific bambox pack commands for Bambu printers

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -210,25 +210,46 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uv tool install estampo
       - run: estampo validate
-      - run: estampo run --local -v
+      - run: estampo run -v
       - uses: actions/upload-artifact@v4
         with:
           name: sliced
-          path: output/
+          path: estampo_output/
 ```
 
 ### Post-processing for Bambu Lab printers
 
-If sending to a Bambu Lab printer, add a `pack` stage using
-[bambox](https://github.com/estampo/bambox):
+If the printer is a Bambu Lab printer (P1S, X1C, A1, etc.), you **must** add a
+`pack` stage to produce the `.gcode.3mf` file that Bambu printers require. Use
+[bambox](https://github.com/estampo/bambox) for this. **The pack stage is not
+optional** — without it, the output is plain G-code that Bambu printers cannot
+use.
 
+The command differs by slicer engine:
+
+**CuraEngine** (creates `.gcode.3mf` from plain G-code):
 ```toml
 [pipeline]
 stages = ["load", "arrange", "plate", "slice", "pack"]
 
 [pack]
-command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
-output = "{output_dir}/plate_sliced.gcode.3mf"
+command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
+output = "{output_dir}/plate.gcode.3mf"
+```
+
+**OrcaSlicer** (patches the existing `.gcode.3mf` for Bambu Connect compatibility):
+```toml
+[pipeline]
+stages = ["load", "arrange", "plate", "slice", "pack"]
+
+[pack]
+command = "bambox repack {sliced_3mf}"
+output = "{sliced_3mf}"
+```
+
+When adding a GitHub Actions workflow for a Bambu printer, also install bambox:
+```yaml
+- run: uv tool install bambox
 ```
 
 ### Important rules
@@ -241,9 +262,8 @@ output = "{output_dir}/plate_sliced.gcode.3mf"
 - **Use string values** for OrcaSlicer overrides (they are passed as CLI
   arguments): `layer_height = "0.2"`, not `layer_height = 0.2`.
 - **Pin the slicer version** for reproducibility.
-- estampo runs slicers inside Docker by default. In CI (GitHub Actions), use
-  `--local` since the runner already has the slicer installed via the Docker
-  image.
+- estampo runs slicers inside Docker by default. GitHub Actions runners have
+  Docker available, so `estampo run` works out of the box in CI.
 ````
 
 ---

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -252,6 +252,33 @@ When adding a GitHub Actions workflow for a Bambu printer, also install bambox:
 - run: uv tool install bambox
 ```
 
+### Cloud printing for Bambu Lab printers (optional)
+
+To send the `.gcode.3mf` directly to a Bambu printer after packing, add a
+`print` stage. This uses `bambox print` which communicates with Bambu Cloud.
+
+```toml
+[pipeline]
+stages = ["load", "arrange", "plate", "slice", "pack", "print"]
+
+[print]
+command = "bambox print {output_dir}/plate.gcode.3mf -d {DEVICE_SERIAL} -y"
+```
+
+Replace `{DEVICE_SERIAL}` with the printer's serial number (found in Bambu
+Handy or the printer's display under Network > Device Info).
+
+**Setup requirements:**
+1. Run `bambox login` once to authenticate with Bambu Cloud — credentials are
+   saved to `~/.config/estampo/credentials.toml`
+2. The bridge is required: native binary on Linux x86_64, Docker on all other
+   platforms (macOS, Windows, Linux ARM64)
+
+**For CI (GitHub Actions):** cloud printing from CI requires storing the
+credentials file as a GitHub secret and writing it before the print step.
+This is an advanced setup — most users should print locally with
+`estampo run` after the CI workflow produces the `.gcode.3mf` artifact.
+
 ### Important rules
 
 - **Do not invent setting names.** Only use keys from the setting lists above

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -254,19 +254,18 @@ When adding a GitHub Actions workflow for a Bambu printer, also install bambox:
 
 ### Cloud printing for Bambu Lab printers (optional)
 
-To send the `.gcode.3mf` directly to a Bambu printer after packing, add a
-`print` stage. This uses `bambox print` which communicates with Bambu Cloud.
+To send the `.gcode.3mf` directly to a Bambu printer, use `bambox print`.
+**Do not add a print stage to `estampo.toml`** — printing should be an
+explicit manual action, not something that runs on every `estampo run` or
+CI push.
 
-```toml
-[pipeline]
-stages = ["load", "arrange", "plate", "slice", "pack", "print"]
-
-[print]
-command = "bambox print {output_dir}/plate.gcode.3mf -d {DEVICE_SERIAL} -y"
+**Local printing** (after `estampo run` produces the `.gcode.3mf`):
+```bash
+bambox print estampo_output/plate.gcode.3mf -y
 ```
 
-Replace `{DEVICE_SERIAL}` with the printer's serial number (found in Bambu
-Handy or the printer's display under Network > Device Info).
+If only one printer is configured, bambox uses it automatically — no
+`-d DEVICE_SERIAL` needed.
 
 **Setup requirements:**
 1. Run `bambox login` once to authenticate with Bambu Cloud — credentials are
@@ -274,10 +273,36 @@ Handy or the printer's display under Network > Device Info).
 2. The bridge is required: native binary on Linux x86_64, Docker on all other
    platforms (macOS, Windows, Linux ARM64)
 
-**For CI (GitHub Actions):** cloud printing from CI requires storing the
-credentials file as a GitHub secret and writing it before the print step.
-This is an advanced setup — most users should print locally with
-`estampo run` after the CI workflow produces the `.gcode.3mf` artifact.
+**For CI:** add a separate manually-triggered workflow (not the slice
+workflow) so printing only happens when explicitly requested:
+
+```yaml
+# .github/workflows/print.yml
+name: Print
+
+on:
+  workflow_dispatch:
+
+jobs:
+  print:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv tool install estampo
+      - run: uv tool install bambox
+      - run: |
+          mkdir -p ~/.config/estampo
+          echo "$BAMBOX_CREDENTIALS" > ~/.config/estampo/credentials.toml
+        env:
+          BAMBOX_CREDENTIALS: ${{ secrets.BAMBOX_CREDENTIALS }}
+      - run: estampo run -v
+      - run: bambox print estampo_output/plate.gcode.3mf -y
+```
+
+To set up the secret: run `bambox login` locally, then copy the contents of
+`~/.config/estampo/credentials.toml` into a GitHub repository secret named
+`BAMBOX_CREDENTIALS`.
 
 ### Important rules
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -260,13 +260,18 @@ filament = "decorative"
 Custom pipeline stages that run external CLI tools. Add the stage name to
 `[pipeline].stages` and define a matching TOML section with a `command` key.
 
+**OrcaSlicer** (patches existing `.gcode.3mf`):
 ```toml
-[pipeline]
-stages = ["load", "arrange", "plate", "slice", "pack"]
-
 [pack]
-command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
-output = "{output_dir}/plate_sliced.gcode.3mf"
+command = "bambox repack {sliced_3mf}"
+output = "{sliced_3mf}"
+```
+
+**CuraEngine** (creates `.gcode.3mf` from plain G-code):
+```toml
+[pack]
+command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
+output = "{output_dir}/plate.gcode.3mf"
 ```
 
 ### Available variables

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -35,8 +35,8 @@ filaments = ["Generic PLA @base"]
 file = "model.stl"
 
 [pack]
-command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
-output = "{output_dir}/plate_sliced.gcode.3mf"
+command = "bambox repack {sliced_3mf}"
+output = "{sliced_3mf}"
 ```
 
 ## Config structure
@@ -326,8 +326,8 @@ filaments = ["Generic PLA @base"]
 file = "model.stl"
 
 [pack]
-command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
-output = "{output_dir}/plate_sliced.gcode.3mf"
+command = "bambox repack {sliced_3mf}"
+output = "{sliced_3mf}"
 ```
 
 ### CuraEngine + Bambu Lab


### PR DESCRIPTION
## Summary

- Add engine-specific bambox pack commands to `ai-setup-prompt.md` — CuraEngine needs `bambox pack` (creates `.gcode.3mf` from plain G-code), OrcaSlicer needs `bambox repack` (patches existing `.gcode.3mf`)
- Make the pack section more prominent with bold "not optional" language so AIs don't skip it for Bambu printers
- Fix CI workflow template: remove unnecessary `--local` flag, correct output path to `estampo_output/`
- Update `llm.md` command stages section to show both engine variants

Discovered testing with `pzfreo/test3d` — the AI generated a working CuraEngine config but skipped the pack stage, producing plain G-code instead of `.gcode.3mf`.

Closes #511

## Test plan

- [ ] Verify AI setup prompt renders correctly in markdown
- [ ] Test with a fresh AI conversation using the updated prompt for a CuraEngine + Bambu setup
- [ ] Confirm `llm.md` examples are consistent with `ai-setup-prompt.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)