### PR TITLE
Decompose monster functions in orca.py, config.py, init.py

### DIFF
--- a/changes/442.misc
+++ b/changes/442.misc
@@ -1,0 +1,1 @@
+Decompose ``orca_slice_plate``, ``load_config``, and ``run_wizard`` into smaller focused functions

--- a/src/estampo/config.py
+++ b/src/estampo/config.py
@@ -261,6 +261,124 @@ def _parse_cura_config(raw: dict) -> CuraSlicerConfig:
     )
 
 
+def _parse_parts(
+    parts_raw: list[dict],
+    base_dir: Path,
+) -> tuple[list[PartConfig], list[int | str], list[dict[str, int | str]]]:
+    """Parse [[parts]] entries into PartConfig objects.
+
+    Returns (parts, raw_filaments, raw_obj_filaments) — filament indices are
+    placeholders until resolved by ``_resolve_filaments()``.
+    """
+    if not parts_raw:
+        raise EstampoError("At least one [[parts]] entry is required")
+
+    parts: list[PartConfig] = []
+    raw_filaments: list[int | str] = []
+    raw_obj_filaments: list[dict[str, int | str]] = []
+
+    for i, p in enumerate(parts_raw):
+        if "file" not in p:
+            raise EstampoError(f"parts[{i}]: 'file' is required")
+        orient = p.get("orient", "flat")
+        if orient not in VALID_ORIENTS:
+            raise EstampoError(f"parts[{i}]: orient must be one of {VALID_ORIENTS}, got '{orient}'")
+        file_path = base_dir / p["file"]
+        if not file_path.exists():
+            raise EstampoError(f"parts[{i}]: file not found: {file_path}")
+        copies = int(p.get("copies", 1))
+        if copies < 1:
+            raise EstampoError(f"parts[{i}]: copies must be >= 1, got {copies}")
+        raw_fil = p.get("filament", 1)
+        if isinstance(raw_fil, str):
+            if not raw_fil.strip():
+                raise EstampoError(f"parts[{i}]: filament name must not be empty")
+        else:
+            raw_fil = int(raw_fil)
+            if raw_fil < 1:
+                raise EstampoError(f"parts[{i}]: filament must be >= 1, got {raw_fil}")
+        raw_filaments.append(raw_fil)
+
+        # Per-object filament overrides for multi-object 3MF files
+        obj_fils_raw: dict[str, int | str] = {}
+        for obj_name, obj_fil in p.get("filaments", {}).items():
+            if isinstance(obj_fil, str):
+                if not obj_fil.strip():
+                    raise EstampoError(
+                        f"parts[{i}].filaments.{obj_name}: filament name must not be empty"
+                    )
+            else:
+                obj_fil = int(obj_fil)
+                if obj_fil < 1:
+                    raise EstampoError(
+                        f"parts[{i}].filaments.{obj_name}: filament must be >= 1, got {obj_fil}"
+                    )
+            obj_fils_raw[obj_name] = obj_fil
+        raw_obj_filaments.append(obj_fils_raw)
+
+        rotate = p.get("rotate")
+        if rotate is not None:
+            if not isinstance(rotate, list) or len(rotate) != 3:
+                raise EstampoError(f"parts[{i}]: rotate must be [rx, ry, rz], got {rotate}")
+            rotate = [float(r) for r in rotate]
+        scale = float(p.get("scale", 1.0))
+        if scale <= 0:
+            raise EstampoError(f"parts[{i}]: scale must be > 0, got {scale}")
+        obj_name = p.get("object")
+        if obj_name is not None:
+            if not isinstance(obj_name, str) or not obj_name.strip():
+                raise EstampoError(f"parts[{i}]: object must be a non-empty string")
+            if obj_fils_raw:
+                raise EstampoError(f"parts[{i}]: cannot use both 'object' and [parts.filaments]")
+        sequence = int(p.get("sequence", 1))
+        if sequence < 1:
+            raise EstampoError(f"parts[{i}]: sequence must be >= 1, got {sequence}")
+        material_name = raw_fil if isinstance(raw_fil, str) else None
+
+        parts.append(
+            PartConfig(
+                file=file_path,
+                copies=copies,
+                orient=orient,
+                rotate=rotate,
+                filament=1,  # placeholder, resolved below
+                material=material_name,
+                scale=scale,
+                object=obj_name,
+                sequence=sequence,
+            )
+        )
+
+    return parts, raw_filaments, raw_obj_filaments
+
+
+def _parse_pipeline(raw: dict) -> PipelineConfig:
+    """Parse [pipeline] and command stage sections from raw TOML data."""
+    from estampo.pipeline import STAGE_OUTPUTS
+
+    pipeline_raw = raw.get("pipeline", {})
+    pipeline_stages = pipeline_raw.get("stages", list(DEFAULT_STAGES))
+    if not isinstance(pipeline_stages, list):
+        raise EstampoError("pipeline.stages must be a list of stage names")
+
+    command_stages: dict[str, CommandStageConfig] = {}
+    for s in pipeline_stages:
+        if not isinstance(s, str) or not s.strip():
+            raise EstampoError(f"pipeline.stages: each stage must be a non-empty string, got {s!r}")
+        if s in STAGE_OUTPUTS:
+            continue
+        stage_raw = raw.get(s)
+        if stage_raw is None or not isinstance(stage_raw, dict) or "command" not in stage_raw:
+            raise EstampoError(
+                f"pipeline.stages: unknown stage '{s}'. "
+                f"Either use a built-in stage ({sorted(STAGE_OUTPUTS)}) "
+                f"or define a [{s}] section with a 'command' key."
+            )
+        command_stages[s] = parse_command_stage(s, stage_raw)
+
+    return PipelineConfig(stages=pipeline_stages, command_stages=command_stages)
+
+
 def load_config(path: Path) -> EstampoConfig:
     """Load and validate an estampo.toml file."""
     path = path.resolve()
@@ -334,122 +452,17 @@ def load_config(path: Path) -> EstampoConfig:
                 )
             filament_aliases[alias] = profile
 
-    # Parts — first pass: parse everything except filament resolution
-    parts_raw = raw.get("parts", [])
-    if not parts_raw:
-        raise EstampoError("At least one [[parts]] entry is required")
-
-    parts = []
-    raw_filaments: list[int | str] = []  # preserve raw filament values for resolution
-    raw_obj_filaments: list[dict[str, int | str]] = []  # per-part object filament overrides
-    for i, p in enumerate(parts_raw):
-        if "file" not in p:
-            raise EstampoError(f"parts[{i}]: 'file' is required")
-        orient = p.get("orient", "flat")
-        if orient not in VALID_ORIENTS:
-            raise EstampoError(f"parts[{i}]: orient must be one of {VALID_ORIENTS}, got '{orient}'")
-        file_path = base_dir / p["file"]
-        if not file_path.exists():
-            raise EstampoError(f"parts[{i}]: file not found: {file_path}")
-        copies = int(p.get("copies", 1))
-        if copies < 1:
-            raise EstampoError(f"parts[{i}]: copies must be >= 1, got {copies}")
-        raw_fil = p.get("filament", 1)
-        if isinstance(raw_fil, str):
-            if not raw_fil.strip():
-                raise EstampoError(f"parts[{i}]: filament name must not be empty")
-        else:
-            raw_fil = int(raw_fil)
-            if raw_fil < 1:
-                raise EstampoError(f"parts[{i}]: filament must be >= 1, got {raw_fil}")
-        raw_filaments.append(raw_fil)
-
-        # Per-object filament overrides for multi-object 3MF files
-        obj_fils_raw: dict[str, int | str] = {}
-        for obj_name, obj_fil in p.get("filaments", {}).items():
-            if isinstance(obj_fil, str):
-                if not obj_fil.strip():
-                    raise EstampoError(
-                        f"parts[{i}].filaments.{obj_name}: filament name must not be empty"
-                    )
-            else:
-                obj_fil = int(obj_fil)
-                if obj_fil < 1:
-                    raise EstampoError(
-                        f"parts[{i}].filaments.{obj_name}: filament must be >= 1, got {obj_fil}"
-                    )
-            obj_fils_raw[obj_name] = obj_fil
-        raw_obj_filaments.append(obj_fils_raw)
-
-        rotate = p.get("rotate")
-        if rotate is not None:
-            if not isinstance(rotate, list) or len(rotate) != 3:
-                raise EstampoError(f"parts[{i}]: rotate must be [rx, ry, rz], got {rotate}")
-            rotate = [float(r) for r in rotate]
-        scale = float(p.get("scale", 1.0))
-        if scale <= 0:
-            raise EstampoError(f"parts[{i}]: scale must be > 0, got {scale}")
-        obj_name = p.get("object")
-        if obj_name is not None:
-            if not isinstance(obj_name, str) or not obj_name.strip():
-                raise EstampoError(f"parts[{i}]: object must be a non-empty string")
-            if obj_fils_raw:
-                raise EstampoError(f"parts[{i}]: cannot use both 'object' and [parts.filaments]")
-        sequence = int(p.get("sequence", 1))
-        if sequence < 1:
-            raise EstampoError(f"parts[{i}]: sequence must be >= 1, got {sequence}")
-        # Preserve original material name for logging/display
-        material_name = raw_fil if isinstance(raw_fil, str) else None
-
-        parts.append(
-            PartConfig(
-                file=file_path,
-                copies=copies,
-                orient=orient,
-                rotate=rotate,
-                filament=1,  # placeholder, resolved below
-                material=material_name,
-                scale=scale,
-                object=obj_name,
-                sequence=sequence,
-            )
-        )
+    parts, raw_filaments, raw_obj_filaments = _parse_parts(raw.get("parts", []), base_dir)
 
     # Filament resolution (OrcaSlicer only — CuraEngine has no multi-filament slots)
     if engine == "orca":
         _resolve_filaments(parts, orca_cfg, raw_filaments, raw_obj_filaments, filament_aliases)
     else:
-        # CuraEngine: just set integer filament values directly
         for i, raw_fil in enumerate(raw_filaments):
             if isinstance(raw_fil, int):
                 parts[i].filament = raw_fil
 
-    # Pipeline config (optional)
-    from estampo.pipeline import STAGE_OUTPUTS
-
-    pipeline_raw = raw.get("pipeline", {})
-    pipeline_stages = pipeline_raw.get("stages", list(DEFAULT_STAGES))
-    if not isinstance(pipeline_stages, list):
-        raise EstampoError("pipeline.stages must be a list of stage names")
-
-    # Parse command stages: top-level TOML sections with a "command" key
-    command_stages: dict[str, CommandStageConfig] = {}
-    for s in pipeline_stages:
-        if not isinstance(s, str) or not s.strip():
-            raise EstampoError(f"pipeline.stages: each stage must be a non-empty string, got {s!r}")
-        if s in STAGE_OUTPUTS:
-            continue  # built-in stage
-        # Check for a matching TOML section with a command key
-        stage_raw = raw.get(s)
-        if stage_raw is None or not isinstance(stage_raw, dict) or "command" not in stage_raw:
-            raise EstampoError(
-                f"pipeline.stages: unknown stage '{s}'. "
-                f"Either use a built-in stage ({sorted(STAGE_OUTPUTS)}) "
-                f"or define a [{s}] section with a 'command' key."
-            )
-        command_stages[s] = parse_command_stage(s, stage_raw)
-
-    pipeline = PipelineConfig(stages=pipeline_stages, command_stages=command_stages)
+    pipeline = _parse_pipeline(raw)
 
     # Top-level project name (optional)
     project_name: str | None = raw.get("name")

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -701,6 +701,95 @@ def _wizard_pick_filaments(
     return filament_names
 
 
+def _wizard_pick_bed_type(existing_bed: str | None) -> str | None:
+    """Prompt for bed/plate type selection."""
+    from estampo import ui
+
+    ui.heading("Bed Type")
+    ui.info("Select bed/plate type (affects filament compatibility):")
+    bed_default = ""
+    for i, bt in enumerate(BED_TYPES, 1):
+        marker = " ←" if bt == existing_bed else ""
+        ui.info(f"  {i}. {bt}{marker}")
+        if bt == existing_bed:
+            bed_default = str(i)
+    bed_pick = ui.prompt_str("Pick bed type (or Enter to skip)", bed_default).strip()
+    bed_type: str | None = None
+    if bed_pick.isdigit() and 1 <= int(bed_pick) <= len(BED_TYPES):
+        bed_type = BED_TYPES[int(bed_pick) - 1]
+        ui.info(f"  → {bed_type}")
+    ui.console.print()
+    return bed_type
+
+
+def _wizard_pick_nozzle_type(existing_nozzle: str) -> dict[str, str]:
+    """Prompt for nozzle type selection.  Returns machine_overrides dict."""
+    from estampo import ui
+
+    ui.heading("Nozzle Type")
+    nozzle_types = ["stainless_steel", "hardened_steel", "brass"]
+    nozzle_default = "1"
+    ui.info("Select your physical nozzle type:")
+    for i, nt in enumerate(nozzle_types, 1):
+        marker = " ←" if nt == existing_nozzle else ""
+        ui.info(f"  {i}. {nt}{marker}")
+        if nt == existing_nozzle:
+            nozzle_default = str(i)
+    nozzle_prompt = f"Pick nozzle type (default: {existing_nozzle})"
+    nozzle_pick = ui.prompt_str(nozzle_prompt, nozzle_default).strip()
+    if nozzle_pick.isdigit() and 1 <= int(nozzle_pick) <= len(nozzle_types):
+        picked_nozzle = nozzle_types[int(nozzle_pick) - 1]
+    elif nozzle_pick in nozzle_types:
+        picked_nozzle = nozzle_pick
+    else:
+        picked_nozzle = "stainless_steel"
+    ui.info(f"  → {picked_nozzle}")
+    ui.console.print()
+    machine_overrides: dict[str, str] = {}
+    if picked_nozzle != "stainless_steel":
+        machine_overrides["nozzle_type"] = picked_nozzle
+    return machine_overrides
+
+
+def _wizard_pick_command_stages(
+    engine: str,
+    printer_profile: str,
+    stages: list[str],
+) -> dict[str, dict[str, str | bool]]:
+    """Prompt for Bambu Lab pack/resolve command stages.  Mutates ``stages`` in place."""
+    from estampo import ui
+
+    command_stages: dict[str, dict[str, str | bool]] = {}
+    if not _is_bambu_printer(printer_profile):
+        return command_stages
+
+    ui.heading("Packaging")
+    ui.info("This printer needs bambox to produce printable .gcode.3mf files.")
+    if ui.prompt_yn("Add a pack stage? (requires: pipx install bambox)", default=True):
+        if engine == "cura":
+            stages.append("resolve_templates")
+            command_stages["resolve_templates"] = {
+                "command": (
+                    "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"
+                ),
+            }
+            stages.append("pack")
+            command_stages["pack"] = {
+                "command": (
+                    "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
+                ),
+                "output": "{output_dir}/plate.gcode.3mf",
+            }
+        else:
+            stages.append("pack")
+            command_stages["pack"] = {
+                "command": "bambox repack {output_dir}/plate_sliced.gcode.3mf",
+                "output": "{output_dir}/plate_sliced.gcode.3mf",
+            }
+    ui.console.print()
+    return command_stages
+
+
 def _wizard_pick_parts(
     existing_parts: list[dict] | None = None,
 ) -> list[dict]:
@@ -948,46 +1037,12 @@ def run_wizard(output: Path | None = None) -> str:
     _wizard_assign_filament_slots(parts_config, filament_names)
 
     # --- Step 8: Bed type ---
-    ui.heading("Bed Type")
-    ui.info("Select bed/plate type (affects filament compatibility):")
-    existing_bed = existing.bed_type if existing else None
-    bed_default = ""
-    for i, bt in enumerate(BED_TYPES, 1):
-        marker = " ←" if bt == existing_bed else ""
-        ui.info(f"  {i}. {bt}{marker}")
-        if bt == existing_bed:
-            bed_default = str(i)
-    bed_pick = ui.prompt_str("Pick bed type (or Enter to skip)", bed_default).strip()
-    bed_type: str | None = None
-    if bed_pick.isdigit() and 1 <= int(bed_pick) <= len(BED_TYPES):
-        bed_type = BED_TYPES[int(bed_pick) - 1]
-        ui.info(f"  → {bed_type}")
-    ui.console.print()
+    bed_type = _wizard_pick_bed_type(existing.bed_type if existing else None)
 
     # --- Step 9: Nozzle type ---
-    ui.heading("Nozzle Type")
-    NOZZLE_TYPES = ["stainless_steel", "hardened_steel", "brass"]
-    existing_nozzle = (existing and existing.nozzle_type) or "stainless_steel"
-    nozzle_default = "1"
-    ui.info("Select your physical nozzle type:")
-    for i, nt in enumerate(NOZZLE_TYPES, 1):
-        marker = " ←" if nt == existing_nozzle else ""
-        ui.info(f"  {i}. {nt}{marker}")
-        if nt == existing_nozzle:
-            nozzle_default = str(i)
-    nozzle_prompt = f"Pick nozzle type (default: {existing_nozzle})"
-    nozzle_pick = ui.prompt_str(nozzle_prompt, nozzle_default).strip()
-    machine_overrides: dict[str, str] = {}
-    if nozzle_pick.isdigit() and 1 <= int(nozzle_pick) <= len(NOZZLE_TYPES):
-        picked_nozzle = NOZZLE_TYPES[int(nozzle_pick) - 1]
-    elif nozzle_pick in NOZZLE_TYPES:
-        picked_nozzle = nozzle_pick
-    else:
-        picked_nozzle = "stainless_steel"
-    if picked_nozzle != "stainless_steel":
-        machine_overrides["nozzle_type"] = picked_nozzle
-    ui.info(f"  → {picked_nozzle}")
-    ui.console.print()
+    machine_overrides = _wizard_pick_nozzle_type(
+        (existing and existing.nozzle_type) or "stainless_steel"
+    )
 
     # --- Step 10: Slicer overrides ---
     ui.heading("Slicer Overrides")
@@ -995,35 +1050,9 @@ def run_wizard(output: Path | None = None) -> str:
     ui.console.print()
 
     # --- Step 11: Command stages (pack/resolve) ---
-    command_stages: dict[str, dict[str, str | bool]] = {}
-    is_bambu = _is_bambu_printer(printer_profile or "")
-    if is_bambu:
-        ui.heading("Packaging")
-        ui.info("This printer needs bambox to produce printable .gcode.3mf files.")
-        if ui.prompt_yn("Add a pack stage? (requires: pipx install bambox)", default=True):
-            if engine == "cura":
-                # CuraEngine needs resolve_templates before pack
-                stages.append("resolve_templates")
-                command_stages["resolve_templates"] = {
-                    "command": (
-                        "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"
-                    ),
-                }
-                stages.append("pack")
-                command_stages["pack"] = {
-                    "command": (
-                        "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
-                    ),
-                    "output": "{output_dir}/plate.gcode.3mf",
-                }
-            else:
-                # OrcaSlicer — repack the existing .3mf
-                stages.append("pack")
-                command_stages["pack"] = {
-                    "command": "bambox repack {output_dir}/plate_sliced.gcode.3mf",
-                    "output": "{output_dir}/plate_sliced.gcode.3mf",
-                }
-        ui.console.print()
+    command_stages = _wizard_pick_command_stages(
+        engine, printer_profile or "", stages
+    )
 
     # --- Build TOML ---
     toml = _build_toml(

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -769,15 +769,11 @@ def _wizard_pick_command_stages(
         if engine == "cura":
             stages.append("resolve_templates")
             command_stages["resolve_templates"] = {
-                "command": (
-                    "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"
-                ),
+                "command": ("cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"),
             }
             stages.append("pack")
             command_stages["pack"] = {
-                "command": (
-                    "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
-                ),
+                "command": ("bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"),
                 "output": "{output_dir}/plate.gcode.3mf",
             }
         else:
@@ -1050,9 +1046,7 @@ def run_wizard(output: Path | None = None) -> str:
     ui.console.print()
 
     # --- Step 11: Command stages (pack/resolve) ---
-    command_stages = _wizard_pick_command_stages(
-        engine, printer_profile or "", stages
-    )
+    command_stages = _wizard_pick_command_stages(engine, printer_profile or "", stages)
 
     # --- Build TOML ---
     toml = _build_toml(

--- a/src/estampo/orca.py
+++ b/src/estampo/orca.py
@@ -481,9 +481,7 @@ def _slice_local(
 
     if result.returncode != 0:
         log.error("Slicer stderr:\n%s", result.stderr)
-        raise RuntimeError(
-            f"Slicer failed (exit code {result.returncode}):\n{result.stderr[:500]}"
-        )
+        raise RuntimeError(f"Slicer failed (exit code {result.returncode}):\n{result.stderr[:500]}")
 
     log.info("Slicer stdout:\n%s", result.stdout)
     log.info("Slicing complete. Output in %s", output_dir)

--- a/src/estampo/orca.py
+++ b/src/estampo/orca.py
@@ -346,6 +346,150 @@ def _resolve_profiles(
 # ---------------------------------------------------------------------------
 
 
+def _select_slicer(
+    local: bool,
+    docker_version: str | None,
+    image: str,
+) -> tuple[bool, Path | None]:
+    """Decide whether to use Docker or a local slicer binary.
+
+    Returns (use_docker, slicer_path).  slicer_path is None when use_docker is True.
+    """
+    from estampo.docker import ensure_image as _ensure_docker_image
+    from estampo.slicer import find_slicer
+
+    if local:
+        return False, find_slicer("orca")
+
+    if docker_version is not None:
+        if _ensure_docker_image(image):
+            return True, None
+        try:
+            slicer = find_slicer("orca")
+            from estampo import ui
+
+            ui.warn(f"Docker image '{image}' not available, using local slicer.")
+            return False, slicer
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"Docker image '{image}' not found locally or on Docker Hub, "
+                f"and no local slicer installed. Either:\n"
+                f"  docker pull {image}\n"
+                f"  or install the slicer locally"
+            )
+
+    # Default: try Docker first, fall back to local
+    if _ensure_docker_image(image):
+        return True, None
+    try:
+        slicer = find_slicer("orca")
+        from estampo import ui
+
+        ui.warn(
+            "Docker not available, using local slicer. "
+            "Builds may not be reproducible across machines."
+        )
+        return False, slicer
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f"No slicer available. Pull the Docker image:\n  docker pull {image}"
+        )
+
+
+def _check_pinned_profiles(
+    project_dir: Path,
+    profiles_dir: str,
+    docker_version: str,
+) -> None:
+    """Raise EstampoError if pinned profiles are stale for the target slicer version."""
+    from estampo.profiles import pinned_profiles_version
+
+    engine_pinned = project_dir / profiles_dir / "orca"
+    has_pinned = engine_pinned.is_dir() and any(engine_pinned.rglob("*.json"))
+    if not has_pinned:
+        return
+
+    pinned_ver = pinned_profiles_version(project_dir, profiles_dir, "orca")
+    if pinned_ver and pinned_ver != docker_version:
+        raise EstampoError(
+            f"Pinned profiles were created for slicer {pinned_ver} but "
+            f"slicer.version is {docker_version}. Profile schemas change "
+            f"between slicer versions and loading stale profiles can crash "
+            f"the slicer.\n\n"
+            f"  Run 'estampo profiles pin' to update your pinned profiles "
+            f"for {docker_version}."
+        )
+    elif pinned_ver is None:
+        raise EstampoError(
+            f"Pinned profiles in '{profiles_dir}/' have no version marker "
+            f"and may be incompatible with slicer {docker_version}. Profile "
+            f"schemas change between slicer versions and loading stale "
+            f"profiles can crash the slicer.\n\n"
+            f"  Run 'estampo profiles pin' to update your pinned profiles "
+            f"for {docker_version}."
+        )
+
+
+def _slice_local(
+    slicer: Path,
+    input_3mf: Path,
+    output_dir: Path,
+    settings_arg: str | None,
+    filament_arg: str | None,
+    filament_ids: list[int] | None,
+    allow_mix_temp: bool,
+) -> Path:
+    """Run OrcaSlicer locally via subprocess.  Returns output_dir."""
+    cmd = [str(slicer)]
+    if settings_arg:
+        cmd.extend(["--load-settings", settings_arg])
+    if filament_arg:
+        cmd.extend(["--load-filaments", filament_arg])
+
+    if allow_mix_temp:
+        cmd.append("--allow-mix-temp")
+
+    # --load-filament-ids only works with STL inputs, not 3MF
+    if filament_ids and not str(input_3mf).endswith(".3mf"):
+        cmd.extend(["--load-filament-ids", ",".join(str(i) for i in filament_ids)])
+
+    sliced_3mf_name = input_3mf.stem + "_sliced.gcode.3mf"
+    cmd.extend(
+        [
+            "--slice",
+            "0",
+            "--export-3mf",
+            sliced_3mf_name,
+            "--min-save",
+            "--outputdir",
+            str(output_dir),
+            str(input_3mf),
+        ]
+    )
+
+    log.info("Slicing with OrcaSlicer: %s", " ".join(cmd))
+
+    from estampo import ui
+
+    with ui.status("Slicing"):
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+    if result.returncode != 0:
+        log.error("Slicer stderr:\n%s", result.stderr)
+        raise RuntimeError(
+            f"Slicer failed (exit code {result.returncode}):\n{result.stderr[:500]}"
+        )
+
+    log.info("Slicer stdout:\n%s", result.stdout)
+    log.info("Slicing complete. Output in %s", output_dir)
+    return output_dir
+
+
 def orca_slice_plate(
     input_3mf: Path,
     output_dir: Path | None = None,
@@ -380,12 +524,6 @@ def orca_slice_plate(
 
     Returns the output directory containing the sliced gcode.
     """
-    from estampo.docker import ensure_image as _ensure_docker_image
-    from estampo.profiles import pinned_profiles_version
-    from estampo.slicer import find_slicer
-
-    # If config specifies a version and no explicit docker_version was given,
-    # use it as the docker_version for Docker-based slicing.
     if required_version and not docker_version:
         docker_version = required_version
 
@@ -398,59 +536,14 @@ def orca_slice_plate(
         )
 
     image = docker_image(docker_version)
-
-    if local:
-        # Force local — no Docker fallback
-        use_docker = False
-        slicer = find_slicer("orca")
-    elif docker_version is not None:
-        # Explicit Docker version requested — try Docker, fall back to local
-        if _ensure_docker_image(image):
-            use_docker = True
-        else:
-            try:
-                slicer = find_slicer("orca")
-                use_docker = False
-                from estampo import ui
-
-                ui.warn(f"Docker image '{image}' not available, using local slicer.")
-            except FileNotFoundError:
-                raise FileNotFoundError(
-                    f"Docker image '{image}' not found locally or on Docker Hub, "
-                    f"and no local slicer installed. Either:\n"
-                    f"  docker pull {image}\n"
-                    f"  or install the slicer locally"
-                )
-    else:
-        # Default: try Docker first, fall back to local
-        if _ensure_docker_image(image):
-            use_docker = True
-        else:
-            try:
-                slicer = find_slicer("orca")
-                use_docker = False
-                from estampo import ui
-
-                ui.warn(
-                    "Docker not available, using local slicer. "
-                    "Builds may not be reproducible across machines."
-                )
-            except FileNotFoundError:
-                raise FileNotFoundError(
-                    f"No slicer available. Pull the Docker image:\n  docker pull {image}"
-                )
+    use_docker, slicer = _select_slicer(local, docker_version, image)
 
     # Detect and verify slicer version
-    if use_docker:
-        detected_version = docker_version
-    else:
-        detected_version = _detect_slicer_version(slicer)
-
+    detected_version = docker_version if use_docker else _detect_slicer_version(slicer)  # type: ignore[arg-type]
     if required_version:
         _check_slicer_version(
             detected_version, required_version, "Docker" if use_docker else "local"
         )
-
     docker_str = " (Docker)" if use_docker else ""
     log.debug("Slicer: OrcaSlicer %s%s", detected_version or "unknown", docker_str)
 
@@ -472,45 +565,16 @@ def orca_slice_plate(
     else:
         tmp_dir = Path(tempfile.mkdtemp(prefix="estampo_"))
 
-    # Detect stale pinned profiles early, before extracting Docker profiles.
-    # Profiles pinned for one slicer version can crash a different version due
-    # to schema changes (array sizes, removed/added keys).
     if project_dir and docker_version:
-        engine_pinned = project_dir / profiles_dir / "orca"
-        has_pinned = engine_pinned.is_dir() and any(engine_pinned.rglob("*.json"))
-        if has_pinned:
-            pinned_ver = pinned_profiles_version(project_dir, profiles_dir, "orca")
-            if pinned_ver and pinned_ver != docker_version:
-                raise EstampoError(
-                    f"Pinned profiles were created for slicer {pinned_ver} but "
-                    f"slicer.version is {docker_version}. Profile schemas change "
-                    f"between slicer versions and loading stale profiles can crash "
-                    f"the slicer.\n\n"
-                    f"  Run 'estampo profiles pin' to update your pinned profiles "
-                    f"for {docker_version}."
-                )
-            elif pinned_ver is None:
-                raise EstampoError(
-                    f"Pinned profiles in '{profiles_dir}/' have no version marker "
-                    f"and may be incompatible with slicer {docker_version}. Profile "
-                    f"schemas change between slicer versions and loading stale "
-                    f"profiles can crash the slicer.\n\n"
-                    f"  Run 'estampo profiles pin' to update your pinned profiles "
-                    f"for {docker_version}."
-                )
+        _check_pinned_profiles(project_dir, profiles_dir, docker_version)
 
-    # When slicing via Docker, extract profiles from the Docker image so we
-    # use version-matched profiles instead of the local system install (which
-    # may be a different OrcaSlicer version with incompatible gcode templates).
+    # Extract version-matched profiles from Docker image
     docker_profile_dir = None
     if use_docker and docker_version:
         docker_profile_dir = extract_docker_profiles(version=docker_version)
         log.info("Extracted Docker image profiles to %s", docker_profile_dir)
 
-    # OrcaSlicer 2.3.2+ has stricter filament-grouping validation that
-    # rejects filaments even in single-filament configs.  Pass
-    # --allow-mix-temp unconditionally on 2.3.2+ to disable the check.
-    # The flag was added in 2.3.2 — older versions reject it as unknown.
+    # OrcaSlicer 2.3.2+ needs --allow-mix-temp for AMS filament validation
     allow_mix_temp = bool(detected_version and detected_version >= "2.3.2")
 
     try:
@@ -530,7 +594,7 @@ def orca_slice_plate(
         )
 
         if use_docker:
-            result_dir = _slice_via_docker(
+            return _slice_via_docker(
                 input_3mf,
                 output_dir,
                 tmp_dir,
@@ -539,59 +603,16 @@ def orca_slice_plate(
                 image,
                 allow_mix_temp,
             )
-            return result_dir
 
-        # Local slicer path
-        cmd = [str(slicer)]
-        if settings_arg:
-            cmd.extend(["--load-settings", settings_arg])
-        if filament_arg:
-            cmd.extend(["--load-filaments", filament_arg])
-
-        # AMS printers load multiple filament types through a single nozzle.
-        if allow_mix_temp:
-            cmd.append("--allow-mix-temp")
-
-        # --load-filament-ids only works with STL inputs, not 3MF
-        if filament_ids and not str(input_3mf).endswith(".3mf"):
-            cmd.extend(["--load-filament-ids", ",".join(str(i) for i in filament_ids)])
-
-        sliced_3mf_name = input_3mf.stem + "_sliced.gcode.3mf"
-        cmd.extend(
-            [
-                "--slice",
-                "0",
-                "--export-3mf",
-                sliced_3mf_name,
-                "--min-save",
-                "--outputdir",
-                str(output_dir),
-                str(input_3mf),
-            ]
+        return _slice_local(
+            slicer,  # type: ignore[arg-type]
+            input_3mf,
+            output_dir,
+            settings_arg,
+            filament_arg,
+            filament_ids,
+            allow_mix_temp,
         )
-
-        log.info("Slicing with OrcaSlicer: %s", " ".join(cmd))
-
-        from estampo import ui
-
-        with ui.status("Slicing"):
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=300,
-            )
-
-        if result.returncode != 0:
-            log.error("Slicer stderr:\n%s", result.stderr)
-            raise RuntimeError(
-                f"Slicer failed (exit code {result.returncode}):\n{result.stderr[:500]}"
-            )
-
-        log.info("Slicer stdout:\n%s", result.stdout)
-        log.info("Slicing complete. Output in %s", output_dir)
-        return output_dir
-
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
         if docker_profile_dir:


### PR DESCRIPTION
## Summary

- **`orca_slice_plate`** (261 → 138 lines): Extract `_select_slicer()`, `_check_pinned_profiles()`, `_slice_local()`
- **`load_config`** (212 → ~110 lines): Extract `_parse_parts()`, `_parse_pipeline()`
- **`run_wizard`** (232 → 172 lines): Extract `_wizard_pick_bed_type()`, `_wizard_pick_nozzle_type()`, `_wizard_pick_command_stages()`

Pure refactor — no behavioral changes. Each extracted function has a single concern and clean parameter boundary.

Closes #442

## Test plan

- [ ] All 568 existing tests pass (no new tests needed — pure refactor)
- [ ] `ruff check`, `ruff format`, `mypy` all pass
- [ ] Verify no public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)