### PR TITLE
Fix {sliced_3mf} variable to resolve to file, not directory

### DIFF
--- a/changes/516.bugfix
+++ b/changes/516.bugfix
@@ -1,0 +1,1 @@
+Fix ``{sliced_3mf}`` command variable to resolve to the sliced output file instead of the directory

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -334,6 +334,29 @@ To set up the secret: run `bambox login` locally, then copy the contents of
 - **Pin the slicer version** for reproducibility.
 - estampo runs slicers inside Docker by default. GitHub Actions runners have
   Docker available, so `estampo run` works out of the box in CI.
+
+### Command stage variables
+
+Command stages use `{variable}` placeholders that are substituted at runtime.
+Only use these exact variable names — estampo will error on unknown variables.
+
+| Variable | Available after | Description |
+|----------|----------------|-------------|
+| `{name}` | always | Project name from TOML config (empty if unset) |
+| `{output_dir}` | always | Output directory path |
+| `{engine}` | always | Slicer engine name (`orca` or `cura`) |
+| `{machine}` | always | Printer/machine profile name (empty if unset) |
+| `{filament}` | always | First filament profile name (empty if unset) |
+| `{filaments}` | always | All filament profiles, comma-separated |
+| `{slicer_image}` | always | Docker image tag for the active slicer |
+| `{input_3mf}` | `plate` | Plate 3MF file path |
+| `{sliced_3mf}` | `slice` | Sliced output file (`.gcode.3mf` for OrcaSlicer, `.gcode` for CuraEngine) |
+| `{sliced_dir}` | `slice` | Slicer output directory |
+| `{cura_settings}` | `slice` | CuraEngine settings JSON path (CuraEngine only, empty for OrcaSlicer) |
+
+Command stage outputs are also available as variables to downstream stages.
+For example, if a `resolve_templates` stage has `output = "..."`, the next
+stage can reference `{resolve_templates}`.
 ````
 
 ---

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -285,7 +285,7 @@ output = "{output_dir}/plate.gcode.3mf"
 | `{filament}` | First filament profile | Always |
 | `{filaments}` | All filaments, comma-separated | Always |
 | `{input_3mf}` | Plate 3MF path | After `plate` |
-| `{sliced_3mf}` | Packaged 3MF after slicing | After `slice` |
+| `{sliced_3mf}` | Sliced output file (`.gcode.3mf` or `.gcode`) | After `slice` |
 | `{sliced_dir}` | Slicer output directory | After `slice` |
 | `{cura_settings}` | CuraEngine settings JSON | After `slice` (cura only) |
 | `{slicer_image}` | Docker image tag | Always |

--- a/src/estampo/commands.py
+++ b/src/estampo/commands.py
@@ -37,8 +37,8 @@ COMMAND_VARIABLES: dict[str, str] = {
     "filament": "First filament profile name (empty string if unset)",
     "filaments": "All filament profiles, comma-separated (empty string if unset)",
     "input_3mf": "Plate 3MF path (available after plate stage)",
-    "sliced_3mf": "Packaged 3MF after slicing (available after slice stage)",
-    "sliced_dir": "Slicer output directory (available after slice stage)",
+    "sliced_3mf": "Sliced output file — .gcode.3mf or .gcode (after slice)",
+    "sliced_dir": "Slicer output directory (after slice)",
     "cura_settings": "CuraEngine settings JSON path (after slice, cura only)",
     "slicer_image": "Docker image tag for the active slicer engine",
 }
@@ -71,6 +71,17 @@ def build_command_context(
 
         slicer_image = cura_docker_image(config.slicer.version)
 
+    # Resolve {sliced_3mf} to the actual deliverable file, not the directory
+    sliced_3mf = ""
+    packaged_dir = stage_results.get("packaged_output")
+    if packaged_dir:
+        from estampo.slicer import find_deliverable
+
+        try:
+            sliced_3mf = str(find_deliverable(Path(str(packaged_dir))))
+        except FileNotFoundError:
+            sliced_3mf = str(packaged_dir)
+
     ctx: dict[str, str] = {
         "name": config.name or "",
         "output_dir": str(output_dir),
@@ -79,7 +90,7 @@ def build_command_context(
         "filament": fils[0] if fils else "",
         "filaments": ",".join(fils) if fils else "",
         "input_3mf": str(stage_results.get("plate_3mf_path", "")),
-        "sliced_3mf": str(stage_results.get("packaged_output", "")),
+        "sliced_3mf": sliced_3mf,
         "sliced_dir": str(stage_results.get("sliced_output_dir", "")),
         "cura_settings": "",
         "slicer_image": slicer_image,

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -779,8 +779,8 @@ def _wizard_pick_command_stages(
         else:
             stages.append("pack")
             command_stages["pack"] = {
-                "command": "bambox repack {output_dir}/plate_sliced.gcode.3mf",
-                "output": "{output_dir}/plate_sliced.gcode.3mf",
+                "command": "bambox repack {sliced_3mf}",
+                "output": "{sliced_3mf}",
             }
     ui.console.print()
     return command_stages

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -101,6 +101,10 @@ class TestBuildCommandContext:
         cfg = _make_config(tmp_path)
         plate = tmp_path / "plate.3mf"
         sliced = tmp_path / "sliced"
+        sliced.mkdir()
+        # Create a deliverable file so find_deliverable resolves it
+        deliverable = sliced / "plate_sliced.gcode.3mf"
+        deliverable.write_bytes(b"fake")
         results = {
             "plate_3mf_path": plate,
             "packaged_output": sliced,
@@ -108,7 +112,7 @@ class TestBuildCommandContext:
         }
         ctx = build_command_context(cfg, tmp_path / "out", results)
         assert ctx["input_3mf"] == str(plate)
-        assert ctx["sliced_3mf"] == str(sliced)
+        assert ctx["sliced_3mf"] == str(deliverable)
         assert ctx["sliced_dir"] == str(sliced)
 
     def test_missing_results_default_to_empty(self, tmp_path):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -649,15 +649,15 @@ class TestBuildToml:
             stages=["load", "arrange", "plate", "slice", "pack"],
             command_stages={
                 "pack": {
-                    "command": "bambox repack {output_dir}/plate_sliced.gcode.3mf",
-                    "output": "{output_dir}/plate_sliced.gcode.3mf",
+                    "command": "bambox repack {sliced_3mf}",
+                    "output": "{sliced_3mf}",
                 },
             },
         )
         assert '"pack"' in toml
         assert "[pack]" in toml
         assert "bambox repack" in toml
-        assert 'output = "{output_dir}/plate_sliced.gcode.3mf"' in toml
+        assert 'output = "{sliced_3mf}"' in toml
 
     def test_cura_resolve_and_pack_stages(self):
         toml = _build_toml(


### PR DESCRIPTION
## Summary

- **Fix `{sliced_3mf}` variable** — was resolving to the slicer output directory (same as `{sliced_dir}`). Now uses `find_deliverable()` to resolve to the actual output file (`.gcode.3mf` for OrcaSlicer, `.gcode` for CuraEngine)
- **Document all command stage variables** — added reference table to AI setup prompt showing every `{variable}`, when it's available, and what it contains
- **Update wizard** — `bambox repack` command now uses `{sliced_3mf}` instead of hardcoded `{output_dir}/plate_sliced.gcode.3mf`

Closes #516

## Test plan

- [ ] All 568 tests pass (updated test verifies `{sliced_3mf}` resolves to file not directory)
- [ ] `ruff check`, `ruff format`, `mypy` all pass
- [ ] Verify `bambox repack {sliced_3mf}` works in real OrcaSlicer pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)