### PR TITLE
Hide untested watch command from CLI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,14 +251,9 @@ estampo run                         # full pipeline
 estampo run --until plate           # stop after plating
 estampo run --only slice            # run just one stage
 estampo run --dry-run               # everything except sending to printer
-estampo watch                       # re-run pipeline when input files change
-estampo status                      # query printer status
-estampo status -w                   # live printer dashboard
 estampo profiles list               # list available slicer profiles
 estampo profiles pin                # pin profiles for reproducible builds
 ```
-
-![estampo status --watch](https://raw.githubusercontent.com/estampo/estampo/main/docs/images/watch.png)
 
 ## Credentials
 

--- a/changes/+hide-watch.misc
+++ b/changes/+hide-watch.misc
@@ -1,0 +1,1 @@
+Hide untested ``estampo watch`` command from CLI help and remove from docs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -206,28 +206,6 @@ estampo status --printer workshop --resume # resume paused print
 estampo status --printer workshop --clear  # clear FAILED state
 ```
 
-## `estampo watch`
-
-Watch input files and re-run the pipeline when they change. Useful for iterating on code-CAD models (OpenSCAD, build123d, CadQuery).
-
-```
-estampo watch [config] [--until STAGE] [--local] [-v]
-```
-
-| Option        | Description                                      |
-|---------------|--------------------------------------------------|
-| `--until`     | Run pipeline up to this stage (default: all)     |
-| `--local`     | Force local slicer                               |
-| `-v`          | Verbose output                                   |
-
-The command watches the config file and all part files referenced in it. When any file changes, the pipeline re-runs automatically. Press Ctrl-C to stop.
-
-```bash
-estampo watch                          # watch all inputs, full pipeline
-estampo watch --until plate            # only re-plate on changes
-estampo watch custom.toml --until slice  # watch a specific config
-```
-
 ## `estampo profiles`
 
 Manage slicer profiles.

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -180,7 +180,7 @@ def run(
         print(json.dumps(result, indent=2, default=str))
 
 
-@app.command()
+@app.command(hidden=True)
 def watch(
     config: Annotated[Path | None, typer.Argument(help="Path to config file")] = None,
     output_dir: Annotated[


### PR DESCRIPTION
## Summary
- Hide `estampo watch` from `--help` output (`hidden=True` in Typer)
- Remove watch section from `docs/cli.md`
- Remove watch and status references from `README.md` quick-reference

The command has zero test coverage and has never been tested manually. It remains callable for anyone who knows about it, but isn't advertised until validated.

## Test plan
- [x] All 568 tests pass
- [x] Lint, format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)