### PR TITLE
Replace deprecated printer/credential references with bambox guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ pipx install estampo
 Generate a config with the interactive wizard, or dump a commented template:
 
 ```bash
-estampo setup                      # configures printer targets
 estampo init                       # interactive wizard — discovers profiles and CAD files, creates TOML
 estampo init --template            # dump a commented template
 ```
@@ -161,10 +160,7 @@ Or create `estampo.toml` by hand (see [full config reference](https://github.com
 
 ```toml
 [pipeline]
-stages = ["load", "arrange", "plate", "slice", "print"]
-
-[printer]
-name = "workshop"       # references ~/.config/estampo/credentials.toml
+stages = ["load", "arrange", "plate", "slice", "pack"]
 
 [plate]
 size = [256, 256]       # build plate dimensions in mm
@@ -246,7 +242,6 @@ The action slices your model, uploads G-code as an artifact, and posts print tim
 estampo init                        # interactive config wizard
 estampo init --template             # dump commented TOML template
 estampo validate                    # check config for issues
-estampo setup                       # set up a printer (credentials + connection type)
 estampo run                         # full pipeline
 estampo run --until plate           # stop after plating
 estampo run --only slice            # run just one stage
@@ -255,9 +250,9 @@ estampo profiles list               # list available slicer profiles
 estampo profiles pin                # pin profiles for reproducible builds
 ```
 
-## Credentials
+## Printing
 
-Printer credentials are stored in `~/.config/estampo/credentials.toml`, created by `estampo setup`. The file is set to `600` permissions (owner read/write only) and is never committed to your repo — only the printer *name* appears in `estampo.toml`. Credentials can also be supplied via environment variables (`BAMBU_PRINTER_IP`, `BAMBU_ACCESS_CODE`, `BAMBU_SERIAL`) for CI or shared environments.
+estampo is printer-agnostic — it produces sliced output but does not send files to printers. For Bambu Lab printers, use [bambox](https://github.com/estampo/bambox) as a command stage to pack and print. Run `bambox login` to set up credentials (`~/.config/bambox/credentials.toml`). See the [AI setup prompt](docs/ai-setup-prompt.md) for full examples.
 
 ## Documentation
 

--- a/changes/+fix-stale-docs.misc
+++ b/changes/+fix-stale-docs.misc
@@ -1,0 +1,1 @@
+Replace deprecated printer/credential references in docs with bambox guidance

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -58,52 +58,12 @@ estampo validate                  # check ./estampo.toml
 estampo validate myproject.toml   # check a specific file
 ```
 
-## `estampo setup`
+## `estampo setup` *(deprecated — removed in v0.4.0)*
 
-Interactively set up a printer in `~/.config/estampo/credentials.toml`.
-
-```
-estampo setup
-```
-
-Walks through:
-1. **Printer name** — used to reference this printer in `estampo.toml` (e.g. `name = "workshop"`)
-2. **Printer type** — `bambu-lan` (direct LAN), `bambu-cloud` (cloud bridge), or `moonraker` (Klipper)
-3. **Type-specific fields** — IP/access code/serial for Bambu LAN, serial for Bambu Cloud, URL for Moonraker
-4. **Cloud login** — for `bambu-cloud` type, optionally logs in to Bambu Cloud
-
-The credentials file is created with `600` permissions (owner read/write only). If the file already exists, new printers are added alongside existing ones.
-
-### Supported printer types
-
-| Type          | Required fields              | Description                          |
-|---------------|------------------------------|--------------------------------------|
-| `bambu-lan`   | ip, access_code, serial      | Direct LAN connection to Bambu Lab   |
-| `bambu-cloud` | serial                       | Cloud bridge (requires cloud login)  |
-| `moonraker`   | url (+ optional api_key)     | Klipper/Moonraker REST API           |
-
-### Example session
-
-```
-$ estampo setup
-Printer name (e.g. 'workshop'): workshop
-
-Printer types:
-  [1] bambu-lan — Bambu Lab printer via LAN (direct connection)
-  [2] bambu-cloud — Bambu Lab printer via cloud (requires cloud login)
-  [3] moonraker — Klipper/Moonraker printer via REST API
-Choose type [1]: 1
-
-Setting up 'workshop' (bambu-lan)
-  ip: 192.168.1.100
-  access_code: 12345678
-  serial: 01P00A451601106
-
-Wrote ~/.config/estampo/credentials.toml (mode 600)
-Reference this printer in estampo.toml with:
-  [printer]
-  name = "workshop"
-```
+> **Use [bambox](https://github.com/estampo/bambox) instead.** estampo is
+> printer-agnostic — printer setup and credentials are managed by bambox.
+> Run `bambox login` to authenticate with Bambu Cloud. Credentials are
+> saved to `~/.config/bambox/credentials.toml`.
 
 ## `estampo run`
 
@@ -176,35 +136,6 @@ estampo run myproject.toml --until plate
 - **`--only slice`** runs *just* the slice stage. It expects `output/plate.3mf` to already exist on disk (e.g. from a previous `--until plate` run). Fails with an error if the prerequisite is missing.
 
 You cannot combine `--until` and `--only`.
-
-## `estampo status`
-
-Query printer status or control a running/failed print.
-
-```
-estampo status [--printer NAME] [--watch] [--interval SECONDS] [--stop] [--resume] [--clear]
-```
-
-| Option              | Description                                      |
-|---------------------|--------------------------------------------------|
-| `--printer NAME`    | Query a specific printer (default: all)          |
-| `-w, --watch`       | Live dashboard mode with auto-refresh            |
-| `--interval SECONDS`| Refresh interval in watch mode (default: 10)     |
-| `--stop`            | Stop the current print job                       |
-| `--resume`          | Resume a paused print                            |
-| `--clear`           | Clear FAILED state and dismiss error dialog      |
-
-Without `--printer`, shows all configured printers. Add `-w` for a live dashboard.
-
-### Examples
-
-```bash
-estampo status                             # show all printers
-estampo status --printer workshop -w       # live dashboard for one printer
-estampo status --printer workshop --stop   # stop current print
-estampo status --printer workshop --resume # resume paused print
-estampo status --printer workshop --clear  # clear FAILED state
-```
 
 ## `estampo profiles`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -8,10 +8,7 @@ estampo is configured with a single TOML file (typically `estampo.toml`). This p
 name = "benchy"
 
 [pipeline]
-stages = ["load", "arrange", "plate", "slice", "print"]
-
-[printer]
-name = "workshop"
+stages = ["load", "arrange", "plate", "slice", "pack"]
 
 [plate]
 size = [256, 256]
@@ -83,59 +80,17 @@ If your workflow doesn't need printing, omit `print`:
 stages = ["load", "arrange", "plate", "slice"]
 ```
 
-## `[printer]`
+## `[printer]` *(deprecated — removed in v0.4.0)*
 
-Defines which printer to send gcode to. Optional — omit if you only need to plate and slice.
-
-| Key    | Type     | Default | Description                                           |
-|--------|----------|---------|-------------------------------------------------------|
-| `name` | `string` | —       | Printer name in `~/.config/estampo/credentials.toml` |
-
-The `name` field references a printer configured via `estampo setup`. All connection details (type, IP, credentials) are stored in `credentials.toml`, not in the project config.
-
-### Credentials file
-
-Run `estampo setup` to create `~/.config/estampo/credentials.toml`. It stores printer connection details and optional cloud login:
-
-```toml
-# ~/.config/estampo/credentials.toml
-
-[cloud]
-token = "..."
-refresh_token = "..."
-email = "user@example.com"
-uid = "12345"
-
-[printers.workshop]
-type = "bambu-lan"
-ip = "192.168.1.100"
-access_code = "12345678"
-serial = "01P00A451601106"
-
-[printers.p1s-cloud]
-type = "bambu-cloud"
-serial = "01P00A451601106"
-
-[printers.voron]
-type = "moonraker"
-url = "http://voron.local:7125"
+> **Use [bambox](https://github.com/estampo/bambox) instead.** estampo is
+> printer-agnostic — printing and packaging are handled by external tools
+> configured as [command stages](#command-stages). See the
+> [AI setup prompt](ai-setup-prompt.md) for examples of `bambox pack`,
+> `bambox repack`, and `bambox print`.
+>
+> Credentials are managed by bambox: run `bambox login` to authenticate,
+> credentials are saved to `~/.config/bambox/credentials.toml`.
 ```
-
-### Printer types
-
-| Type          | Required fields              | Description                          |
-|---------------|------------------------------|--------------------------------------|
-| `bambu-lan`   | ip, access_code, serial      | Direct LAN connection (fastest)      |
-| `bambu-cloud` | serial                       | Cloud bridge (requires `[cloud]` login) |
-| `moonraker`   | url (+ optional api_key)     | Klipper/Moonraker REST API           |
-
-**Environment variable overrides** (take precedence over credentials.toml):
-
-| Env var              | Overrides      |
-|----------------------|----------------|
-| `BAMBU_PRINTER_IP`   | `ip`           |
-| `BAMBU_ACCESS_CODE`  | `access_code`  |
-| `BAMBU_SERIAL`       | `serial`       |
 
 ## `[plate]`
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -107,10 +107,11 @@ The `TimingAdapter` in `src/estampo/adapters.py` hooks into Hamilton's lifecycle
 |------|---------|
 | `src/estampo/pipeline.py` | Hamilton DAG nodes and stage registry |
 | `src/estampo/adapters.py` | TimingAdapter for observability |
-| `src/estampo/cli.py` | CLI entry point (`run`, `setup`, `status`, `profiles`) |
+| `src/estampo/cli.py` | CLI entry point (`run`, `init`, `validate`, `profiles`) |
 | `src/estampo/config.py` | TOML parsing and validation |
 | `src/estampo/arrange.py` | 2D bin-packing |
 | `src/estampo/plate.py` | 3MF export with extruder metadata |
-| `src/estampo/slicer.py` | OrcaSlicer CLI integration (local + Docker) |
-| `src/estampo/printer.py` | Print dispatch (LAN, cloud, Bambu Connect) |
-| `src/estampo/credentials.py` | Credential loading from `~/.config/estampo/credentials.toml` |
+| `src/estampo/slicer.py` | Slicer dispatch (routes to `orca.py` / `cura.py`) |
+| `src/estampo/orca.py` | OrcaSlicer engine (local + Docker) |
+| `src/estampo/cura.py` | CuraEngine engine (Docker) |
+| `src/estampo/commands.py` | Command stage execution (generic subprocess runner) |

--- a/docs/printers.md
+++ b/docs/printers.md
@@ -114,12 +114,7 @@ docker run -d --name virtual-klipper \
 # Check readiness:
 curl -s http://localhost:7125/printer/info | python3 -m json.tool
 
-# Configure estampo
-estampo setup  # choose moonraker, url = http://localhost:7125
-
-# Test
-estampo status --printer <name>
-estampo status --printer <name> --watch
+# The moonraker module was verified against this virtual printer
 ```
 
 **Verified operations (2026-03-18):**
@@ -127,8 +122,6 @@ estampo status --printer <name> --watch
 - `get_moonraker_status()` — state, temperatures, progress, layer info
 - `_send_moonraker()` upload-only — file appears in Moonraker file list
 - `_send_moonraker()` upload + start — print runs to completion
-- `estampo status` — renders state, task name, temperatures
-- `estampo status --watch` — live dashboard with polling
 
 **Note:** The simulavr virtual printer executes gcode nearly instantly, so `RUNNING` state is brief. On real hardware, progress and layer tracking will update over time.
 


### PR DESCRIPTION
## Summary
- Replace `[printer]` section in config.md with deprecation notice pointing to bambox
- Remove `estampo setup` and `estampo status` sections from cli.md (deprecated/deleted commands)
- Update developing.md key files table — remove printer.py/credentials.py, add orca.py/cura.py/commands.py
- Remove stale estampo status/setup references from printers.md
- README.md: remove `estampo setup`, replace Credentials section with Printing section pointing to bambox

Closes #520
Closes #524

## Test plan
- [x] All 568 tests pass
- [x] Lint, format, mypy clean
- [x] Docs-only change — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)