### PR TITLE
Add missing topics to human docs from AI setup prompt

### DIFF
--- a/changes/521.misc
+++ b/changes/521.misc
@@ -1,0 +1,1 @@
+Add command stages, override recipes, and important rules to human docs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,23 +1,33 @@
 # CLI reference
 
-estampo provides commands for creating configs (`init`, `validate`), setting up printers (`setup`), running the pipeline (`run`), and managing printers (`status`, `profiles`).
+estampo provides commands for creating configs (`init`, `validate`), running the pipeline (`run`), and managing slicer profiles (`profiles`).
 
 ## `estampo init`
 
 Create a new `estampo.toml` config file.
 
 ```
-estampo init [--template] [-o OUTPUT]
+estampo init [--template] [-o OUTPUT] [--engine ENGINE] [--printer PRINTER]
+             [--process PROCESS] [--filament FILAMENT]... [--part PART]...
+             [--from-3mf FILE]
 ```
 
-| Option        | Description                                         |
-|---------------|-----------------------------------------------------|
-| `--template`  | Dump a commented template to stdout (skip wizard)   |
-| `-o, --output`| Output file path (default: `./estampo.toml`)       |
+| Option         | Description                                         |
+|----------------|-----------------------------------------------------|
+| `--template`   | Dump a commented template to stdout (skip wizard)   |
+| `-o, --output` | Output file path (default: `./estampo.toml`)       |
+| `--engine`     | Slicer engine: `orca` or `cura` (non-interactive)  |
+| `--printer`    | Printer profile name (non-interactive)              |
+| `--process`    | Process/quality profile name (non-interactive, OrcaSlicer only) |
+| `--filament`   | Filament profile (repeatable, non-interactive)      |
+| `--part`       | Part file path (repeatable, non-interactive)        |
+| `--from-3mf`   | Extract settings from an OrcaSlicer project file    |
 
-Without `--template`, runs an interactive wizard that:
-1. Checks for configured printers (offers to run `estampo setup` if none found)
-2. Discovers installed OrcaSlicer profiles (printer, process, filament) with search/filter
+**Non-interactive mode:** pass `--engine`, `--filament`, and `--part` to generate
+a config without the wizard. Use `--printer` and `--process` for OrcaSlicer.
+
+**Interactive wizard** (default when non-interactive flags are omitted):
+1. Discovers installed slicer profiles (printer, process, filament) with search/filter
 3. Detects printer capabilities from the selected machine profile (plate size, multi-material support)
 4. Queries AMS tray contents in the background and auto-suggests matching filament profiles
 5. Auto-discovers CAD files (STL, 3MF, STEP) in the current directory
@@ -32,6 +42,9 @@ estampo init                              # interactive wizard
 estampo init --template                   # print commented template
 estampo init --template > estampo.toml   # save template to file
 estampo init -o myproject.toml            # wizard writes to custom path
+estampo init --engine orca --printer "Bambu Lab P1S 0.4 nozzle" \
+  --filament "Generic PLA @base" --part bracket.stl   # non-interactive
+estampo init --from-3mf project.3mf       # extract from OrcaSlicer project
 ```
 
 ## `estampo validate`
@@ -46,10 +59,15 @@ If `config` is omitted, looks for `estampo.toml` in the current directory.
 
 Checks for:
 - Missing `slicer.version` (reproducibility)
-- Profile names not matching installed slicer profiles (with suggestions)
-- Printer name not found in credentials file
+- Profile names not matching installed slicer profiles (with "did you mean?" suggestions)
+- Cross-engine detection — catches CuraEngine setting names used with OrcaSlicer and vice versa
 - Absolute part file paths (portability)
 - Unknown pipeline stages
+- Unknown override keys (with suggestions for typos)
+
+**Note:** The validation warning "slicer profile names could not be validated"
+is expected when profiles are not installed locally. This is not an error —
+profiles are resolved at runtime via Docker. The warning can be safely ignored.
 
 ### Examples
 
@@ -101,9 +119,19 @@ The default pipeline runs these stages in order:
 | `load`      | Load meshes, apply orientation and scaling         | Part summary              |
 | `arrange`   | Bin-pack parts onto the build plate                | Placements                |
 | `plate`     | Export arranged plate as 3MF (+ preview)           | `plate.3mf`, `plate_preview.3mf` |
-| `slice`     | Slice via OrcaSlicer (Docker or local)             | gcode in output dir       |
+| `slice`     | Slice via OrcaSlicer or CuraEngine (Docker or local) | gcode in output dir     |
 | `gcode-info`| Parse print time and filament usage from gcode     | Stats summary             |
-| `print`     | Send sliced gcode to printer                       | Print job                 |
+| `print`     | *(deprecated)* Send sliced gcode to printer        | Print job                 |
+
+In addition to built-in stages, you can define **command stages** — custom
+pipeline stages that run external CLI tools. See the
+[config reference](config.md#command-stages) for details.
+
+**Tip:** Add `gcode-info` after `slice` to see print time and filament usage:
+```toml
+[pipeline]
+stages = ["load", "arrange", "plate", "slice", "gcode-info"]
+```
 
 ### Examples
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -71,13 +71,14 @@ Controls which stages run and in what order. Optional — defaults to the full p
 |----------|------------|---------------------------------------------------|----------------------------|
 | `stages` | `[string]` | `["load", "arrange", "plate", "slice"]`  | Ordered list of stages     |
 
-Valid stage names: `load`, `arrange`, `plate`, `slice`, `gcode-info`, `print`.
+Built-in stage names: `load`, `arrange`, `plate`, `slice`, `gcode-info`.
 
-If your workflow doesn't need printing, omit `print`:
+You can also add custom [command stages](#command-stages) to the pipeline — any
+stage name that has a corresponding `[stage_name]` section with a `command` key.
 
 ```toml
 [pipeline]
-stages = ["load", "arrange", "plate", "slice"]
+stages = ["load", "arrange", "plate", "slice", "gcode-info", "pack"]
 ```
 
 ## `[printer]` *(deprecated — removed in v0.4.0)*
@@ -142,10 +143,11 @@ Parts can reference slots by number (`filament = 3`) or by name (`filament = "Ge
 
 CuraEngine-specific settings — printer definition and overrides.
 
-| Key         | Type      | Default | Description                      |
-|-------------|-----------|---------|----------------------------------|
-| `printer`   | `string`  | —       | CuraEngine printer definition ID |
-| `overrides` | `{k = v}` | —      | Flat key-value setting overrides |
+| Key         | Type       | Default | Description                      |
+|-------------|------------|---------|----------------------------------|
+| `printer`   | `string`   | —       | CuraEngine printer definition ID |
+| `filaments` | `[string]` | —       | Filament/material profile names  |
+| `overrides` | `{k = v}`  | —       | Flat key-value setting overrides |
 
 ### `[slicer.orca.overrides]` / `[slicer.cura.overrides]`
 
@@ -251,3 +253,122 @@ Both objects come from the same 3MF, so estampo guarantees identical bed positio
 ```bash
 estampo run estampo.toml --only print   # after slicing sequence 1
 ```
+
+## Command stages
+
+Command stages run external CLI tools as pipeline stages. Any stage name in
+`[pipeline].stages` that has a matching TOML section with a `command` key is
+treated as a command stage.
+
+```toml
+[pipeline]
+stages = ["load", "arrange", "plate", "slice", "pack"]
+
+[pack]
+command = "bambox repack {sliced_3mf}"
+output = "{sliced_3mf}"
+```
+
+| Key       | Type     | Default | Description                                           |
+|-----------|----------|---------|-------------------------------------------------------|
+| `command` | `string` | —       | Shell command with `{variable}` placeholders          |
+| `output`  | `string` | —       | Output path (makes it available to downstream stages) |
+| `docker`  | `bool`   | `false` | Run inside the slicer Docker container                |
+| `image`   | `string` | —       | Docker image override (default: slicer image)         |
+
+When `docker = true`, the command runs inside a Docker container with the
+output directory mounted at `/work/output`. This is useful for tools bundled
+in the slicer Docker image (like `bambox`).
+
+### Template variables
+
+Command strings use `{variable}` placeholders substituted at runtime.
+estampo will error on unknown variable names.
+
+| Variable | Available after | Description |
+|----------|----------------|-------------|
+| `{name}` | always | Project name from TOML config (empty if unset) |
+| `{output_dir}` | always | Output directory path |
+| `{engine}` | always | Slicer engine name (`orca` or `cura`) |
+| `{machine}` | always | Printer/machine profile name (empty if unset) |
+| `{filament}` | always | First filament profile name (empty if unset) |
+| `{filaments}` | always | All filament profiles, comma-separated |
+| `{slicer_image}` | always | Docker image tag for the active slicer |
+| `{input_3mf}` | `plate` | Plate 3MF file path |
+| `{sliced_3mf}` | `slice` | Sliced output file (`.gcode.3mf` or `.gcode`) |
+| `{sliced_dir}` | `slice` | Slicer output directory |
+| `{cura_settings}` | `slice` | CuraEngine settings JSON path (CuraEngine only) |
+
+### Example: Bambu Lab pack stage
+
+**OrcaSlicer** (patches existing `.gcode.3mf` for Bambu Connect compatibility):
+```toml
+[pack]
+command = "bambox repack {sliced_3mf}"
+output = "{sliced_3mf}"
+```
+
+**CuraEngine** (creates `.gcode.3mf` from plain G-code):
+```toml
+[pack]
+command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
+output = "{output_dir}/plate.gcode.3mf"
+```
+
+## Common override recipes
+
+Choose overrides based on your print goals:
+
+**Strong functional part (PETG):**
+```toml
+[slicer.orca.overrides]
+wall_loops = "5"
+sparse_infill_density = "40%"
+sparse_infill_pattern = "gyroid"
+top_shell_layers = "6"
+bottom_shell_layers = "6"
+```
+
+**Fast draft:**
+```toml
+[slicer.orca.overrides]
+sparse_infill_density = "10%"
+wall_loops = "2"
+enable_support = "0"
+```
+
+**Smooth top surface:**
+```toml
+[slicer.orca.overrides]
+ironing_type = "top surface only"
+top_shell_layers = "6"
+```
+
+**Dimensional accuracy (engineering parts):**
+```toml
+[slicer.orca.overrides]
+xy_hole_compensation = "0.1"
+xy_contour_compensation = "-0.05"
+outer_wall_speed = "30"
+```
+
+**Tree supports for complex overhangs:**
+```toml
+[slicer.orca.overrides]
+enable_support = "1"
+support_type = "tree(auto)"
+support_threshold_angle = "45"
+```
+
+## Important rules
+
+- **Do not invent setting names.** Only use keys from the override tables above
+  or from the JSON setting files. estampo validates overrides and will reject
+  unknown keys with "did you mean?" suggestions.
+- **Do not force slicer settings** that conflict with the printer's machine
+  profile (e.g. `use_relative_e_distances`). Let the profile chain decide.
+- **Use string values** for OrcaSlicer overrides — they are passed as CLI
+  arguments: `layer_height = "0.2"`, not `layer_height = 0.2`.
+- **Pin the slicer version** in `[slicer].version` for reproducible builds.
+- **OrcaSlicer and CuraEngine use different setting names** for the same
+  concepts. See the [AI setup prompt](ai-setup-prompt.md) for a mapping table.


### PR DESCRIPTION
## Summary
The AI setup prompt had several important topics that were absent from the human-facing docs. This adds them:

**cli.md:**
- Non-interactive `estampo init` flags (`--engine`, `--printer`, `--filament`, `--part`, `--from-3mf`)
- Validation warning about unresolvable profiles + cross-engine detection
- `gcode-info` stage tip and command stages cross-reference
- CuraEngine support in pipeline stages table

**config.md:**
- Full command stages section with variable table, `docker` flag, and bambox examples
- `filaments` field added to `[slicer.cura]` table
- Common override recipes (strong functional, fast draft, smooth surface, dimensional accuracy, tree supports)
- Important rules section (don't invent setting names, use string values for OrcaSlicer, pin versions)

Closes #521

## Test plan
- [x] All 568 tests pass
- [x] Lint, format, mypy clean
- [x] Docs-only change — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)