### PR TITLE
Add missing topics to AI prompt and gcode-info to examples

### DIFF
--- a/changes/+ai-prompt-gaps.misc
+++ b/changes/+ai-prompt-gaps.misc
@@ -1,0 +1,1 @@
+Add advanced config features to AI setup prompt and ``gcode-info`` to examples

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -100,6 +100,41 @@ file = "{MODEL_FILE}"
 # wall_loops = "3"
 ```
 
+#### Additional config features
+
+These are optional — skip them for simple setups:
+
+- **`output_dir`** (top-level) — output directory, default `"estampo_output"`.
+- **`gcode-info`** stage — add to pipeline to see print time and filament usage after slicing.
+- **`bed_type`** in `[slicer]` — bed surface (e.g. `"Textured PEI Plate"`).
+- **`profiles_dir`** in `[slicer]` — directory for pinned profiles (default `"profiles"`).
+- **`machine_overrides`** / **`filament_overrides`** in `[slicer.orca]` — override machine or filament profile settings (separate from process `overrides`).
+- **`[slicer.orca.slots]`** — explicit AMS slot-to-filament mapping:
+  ```toml
+  [slicer.orca.slots]
+  1 = "Generic PLA @base"
+  3 = "Generic PETG-CF @base"
+  ```
+- **`[filaments]`** — material alias table, decoupling parts from specific profiles:
+  ```toml
+  [filaments]
+  structural = "Generic PETG-CF @BBL P1S"
+  decorative = "Generic PLA @BBL P1S"
+  ```
+- **`scale`** on `[[parts]]` — uniform scale factor (default 1.0). Also available as `--scale` CLI flag.
+- **`object`** on `[[parts]]` — select a named object from a multi-object 3MF file.
+- **`sequence`** on `[[parts]]` — print order for sequential printing.
+- **Per-object filament overrides** via `[parts.filaments]`:
+  ```toml
+  [[parts]]
+  file = "widget.3mf"
+  filament = "Generic PETG-CF @base"
+  [parts.filaments]
+  inlay = "Bambu PLA Basic @BBL X1C"
+  ```
+- **`estampo profiles pin`** — copies referenced profiles into a local `profiles/` directory for reproducible builds across machines.
+- **Code-CAD workflow** — estampo works with OpenSCAD, build123d, and CadQuery. Generate STL/3MF from code-CAD scripts, then configure estampo to slice the output.
+
 ### Discovering available profiles
 
 ```bash

--- a/examples/cura-p1s/estampo.toml
+++ b/examples/cura-p1s/estampo.toml
@@ -10,7 +10,7 @@
 #   - bambox (pipx install bambox) — packs G-code into .gcode.3mf
 
 [pipeline]
-stages = ["load", "arrange", "plate", "slice", "resolve_templates", "pack"]
+stages = ["load", "arrange", "plate", "slice", "gcode-info", "resolve_templates", "pack"]
 
 [plate]
 size = [256, 256]

--- a/examples/multi-filament/estampo.toml
+++ b/examples/multi-filament/estampo.toml
@@ -6,7 +6,7 @@
 # Requires: bambox (pipx install bambox)
 
 [pipeline]
-stages = ["load", "arrange", "plate", "slice", "pack"]
+stages = ["load", "arrange", "plate", "slice", "gcode-info", "pack"]
 
 [plate]
 size = [256, 256]
@@ -40,5 +40,5 @@ file = "box_20x20x10.step"
 filament = 2
 
 [pack]
-command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
-output = "{output_dir}/plate_sliced.gcode.3mf"
+command = "bambox repack {sliced_3mf}"
+output = "{sliced_3mf}"

--- a/examples/multi-part/estampo.toml
+++ b/examples/multi-part/estampo.toml
@@ -6,7 +6,7 @@
 # Requires: bambox (pipx install bambox)
 
 [pipeline]
-stages = ["load", "arrange", "plate", "slice", "pack"]
+stages = ["load", "arrange", "plate", "slice", "gcode-info", "pack"]
 
 [plate]
 size = [256, 256]
@@ -44,5 +44,5 @@ orient = "upright"
 rotate = [0, 0, 45]
 
 [pack]
-command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
-output = "{output_dir}/plate_sliced.gcode.3mf"
+command = "bambox repack {sliced_3mf}"
+output = "{sliced_3mf}"

--- a/examples/quickstart/estampo.toml
+++ b/examples/quickstart/estampo.toml
@@ -20,5 +20,5 @@ process = "0.20mm Standard @BBL X1C"
 file = "cube_10mm.stl"
 
 [pack]
-command = "bambox repack {output_dir}/plate_sliced.gcode.3mf"
-output = "{output_dir}/plate_sliced.gcode.3mf"
+command = "bambox repack {sliced_3mf}"
+output = "{sliced_3mf}"


### PR DESCRIPTION
## Summary
- Add advanced config features section to AI setup prompt (slots, filament aliases, scale, object, sequence, per-object filaments, profiles pin, code-CAD, etc.)
- Add `gcode-info` stage to multi-part, multi-filament, and cura-p1s examples
- Update pack commands in examples to use `{sliced_3mf}` instead of hardcoded paths (follows #516 fix)

Closes #522
Closes #526

## Test plan
- [x] All 568 tests pass
- [x] Lint, format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)