### PR TITLE
Add --workflow flag to estampo init

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ The action slices your model, uploads G-code as an artifact, and posts print tim
 ```bash
 estampo init                        # interactive config wizard
 estampo init --template             # dump commented TOML template
+estampo init --workflow             # wizard + GitHub Actions workflow
 estampo validate                    # check config for issues
 estampo run                         # full pipeline
 estampo run --until plate           # stop after plating

--- a/changes/538.feature
+++ b/changes/538.feature
@@ -1,0 +1,1 @@
+Add ``--workflow`` flag to ``estampo init`` to generate a GitHub Actions slice workflow.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -25,7 +25,7 @@ post-processing command stages.
    install command).
 4. Create an `estampo.toml` config file in the repo root.
 5. Validate the config with `estampo validate`.
-6. Optionally add a GitHub Actions workflow that slices on every push.
+6. Optionally add a GitHub Actions workflow (`estampo init --workflow` or create manually).
 
 ### What to ask me
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,14 +7,15 @@ estampo provides commands for creating configs (`init`, `validate`), running the
 Create a new `estampo.toml` config file.
 
 ```
-estampo init [--template] [-o OUTPUT] [--engine ENGINE] [--printer PRINTER]
-             [--process PROCESS] [--filament FILAMENT]... [--part PART]...
-             [--from-3mf FILE]
+estampo init [--template] [--workflow] [-o OUTPUT] [--engine ENGINE]
+             [--printer PRINTER] [--process PROCESS]
+             [--filament FILAMENT]... [--part PART]... [--from-3mf FILE]
 ```
 
 | Option         | Description                                         |
 |----------------|-----------------------------------------------------|
 | `--template`   | Dump a commented template to stdout (skip wizard)   |
+| `--workflow`   | Generate a GitHub Actions slice workflow (`.github/workflows/slice.yml`) |
 | `-o, --output` | Output file path (default: `./estampo.toml`)       |
 | `--engine`     | Slicer engine: `orca` or `cura` (non-interactive)  |
 | `--printer`    | Printer profile name (non-interactive)              |
@@ -45,6 +46,8 @@ estampo init -o myproject.toml            # wizard writes to custom path
 estampo init --engine orca --printer "Bambu Lab P1S 0.4 nozzle" \
   --filament "Generic PLA @base" --part bracket.stl   # non-interactive
 estampo init --from-3mf project.3mf       # extract from OrcaSlicer project
+estampo init --workflow                   # wizard + generate GitHub Actions workflow
+estampo init --template --workflow        # template + workflow file
 ```
 
 ## `estampo validate`

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -434,6 +434,10 @@ def init(
         list[str] | None,
         typer.Option("--part", help="Part file path (repeatable, non-interactive)"),
     ] = None,
+    workflow: Annotated[
+        bool,
+        typer.Option("--workflow", help="Generate a GitHub Actions slice workflow"),
+    ] = False,
     verbose: Annotated[bool, typer.Option("-v", "--verbose", help="Enable debug logging")] = False,
 ) -> None:
     """Create a new estampo.toml config file.
@@ -446,6 +450,8 @@ def init(
     Use --from-3mf to extract settings from an OrcaSlicer project.
     """
     _setup_logging(verbose)
+
+    config_path = str(output or "estampo.toml")
 
     # Non-interactive mode: all required params provided
     if engine and filament and part:
@@ -479,6 +485,11 @@ def init(
         from estampo.init import run_wizard
 
         run_wizard(output=output)
+
+    if workflow:
+        from estampo.init import write_workflow
+
+        write_workflow(config_path)
 
 
 def _write_or_print(toml: str, output: Path | None) -> None:

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -82,6 +82,47 @@ def dump_template() -> str:
 
 
 # ---------------------------------------------------------------------------
+# GitHub Actions workflow generation
+# ---------------------------------------------------------------------------
+
+_WORKFLOW_TEMPLATE = """\
+name: Slice
+on: [push, pull_request]
+
+jobs:
+  slice:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: estampo/estampo/action@main
+        with:
+          config: {config}
+"""
+
+
+def generate_workflow(config_path: str = "estampo.toml") -> str:
+    """Return a GitHub Actions workflow YAML for slicing."""
+    return _WORKFLOW_TEMPLATE.format(config=config_path)
+
+
+def write_workflow(config_path: str = "estampo.toml") -> Path:
+    """Write a GitHub Actions slice workflow and return the path."""
+    from estampo import ui
+
+    workflow_dir = Path(".github/workflows")
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    dest = workflow_dir / "slice.yml"
+    if dest.exists():
+        ui.warn(f"{dest} already exists — skipping workflow generation")
+        return dest
+    dest.write_text(generate_workflow(config_path))
+    ui.success(f"Wrote {dest}")
+    return dest
+
+
+# ---------------------------------------------------------------------------
 # Load existing config for pre-population
 # ---------------------------------------------------------------------------
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,7 +12,9 @@ from estampo.init import (
     _is_bambu_printer,
     _validate_override,
     dump_template,
+    generate_workflow,
     validate_config,
+    write_workflow,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -113,6 +115,40 @@ class TestTemplate:
         out = capsys.readouterr().out
         assert "[slicer]" in out
         assert "[[parts]]" in out
+
+
+class TestWorkflow:
+    def test_generate_workflow_default_config(self):
+        yml = generate_workflow()
+        assert "config: estampo.toml" in yml
+        assert "estampo/estampo/action@main" in yml
+        assert "pull-requests: write" in yml
+
+    def test_generate_workflow_custom_config(self):
+        yml = generate_workflow("custom/path.toml")
+        assert "config: custom/path.toml" in yml
+
+    def test_write_workflow_creates_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        dest = write_workflow()
+        assert dest == Path(".github/workflows/slice.yml")
+        assert dest.exists()
+        content = dest.read_text()
+        assert "estampo/estampo/action@main" in content
+
+    def test_write_workflow_skips_existing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        workflow_dir = tmp_path / ".github" / "workflows"
+        workflow_dir.mkdir(parents=True)
+        existing = workflow_dir / "slice.yml"
+        existing.write_text("existing content")
+        dest = write_workflow()
+        assert dest.read_text() == "existing content"
+
+    def test_cli_init_template_with_workflow(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        main(["init", "--template", "--workflow"])
+        assert (tmp_path / ".github" / "workflows" / "slice.yml").exists()
 
 
 class TestExtractFrom3MF:


### PR DESCRIPTION
## Summary
- Add `--workflow` flag to `estampo init` that generates `.github/workflows/slice.yml`
- Works with all init modes: wizard, `--template`, non-interactive, `--from-3mf`
- Skips if `slice.yml` already exists
- Updated CLI docs, README, and AI setup prompt

Closes #538

## Test plan
- [x] `generate_workflow()` returns valid YAML with correct action reference
- [x] `write_workflow()` creates the file in `.github/workflows/`
- [x] Skips existing `slice.yml` without overwriting
- [x] `estampo init --template --workflow` creates both template output and workflow file
- [x] All 573 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)