### PR TITLE
Add floating major version tag for GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,6 +456,22 @@ jobs:
           fi
           "${ARGS[@]}"
 
+      - name: Update action version tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          # Only update floating major tag for stable releases (not pre-releases)
+          if [[ "$VERSION" =~ (a|b|rc)[0-9]+$ ]]; then
+            echo "::notice::Pre-release — skipping action version tag update"
+          else
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            # Force-update the floating vN tag to point to this release
+            git tag -f "v${MAJOR}" "v${VERSION}"
+            git push -f origin "v${MAJOR}"
+            echo "::notice::Updated action tag v${MAJOR} → v${VERSION}"
+          fi
+
       - name: Remind to update website
         run: |
           echo "::notice::Release complete! Remember to redeploy estampo.dev — run the deploy workflow at https://github.com/estampo/website/actions/workflows/deploy.yml"

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ CuraEngine CLI (`CuraEngine slice -j definition.json -s KEY=VALUE -l model.stl -
 | Multi-extruder mapping | `-g -e0 -l a.stl -g -e1 -l b.stl` per mesh group | `filament = 1` per part |
 | Reproducible builds | Track all definition JSONs yourself | `version = "5.12.0"` + Docker |
 | Version control | Shell scripts + scattered JSON definitions | Single TOML file — git-diffable and reviewable |
-| Run in CI | Install CuraEngine + definitions manually | `uses: estampo/estampo/action@main` |
+| Run in CI | Install CuraEngine + definitions manually | `uses: estampo/estampo/action@v1` |
 | Pack for Bambu printers | Separate manual step | `[pack]` command stage |
 
 With CuraEngine CLI, your build config ends up spread across shell scripts, `-s` flag lists, and JSON definition files — hard to diff, review, or commit as a coherent unit. estampo replaces all of that with a single declarative TOML file: git-friendly, diffable, and accessible to AI assistants and code review.
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: estampo/estampo@main
+      - uses: estampo/estampo/action@v1
 ```
 
 The action slices your model, uploads G-code as an artifact, and posts print time / filament stats as a PR comment. See [`action/README.md`](action/README.md) for all options.

--- a/action/README.md
+++ b/action/README.md
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-      - uses: estampo/estampo/action@main
+      - uses: estampo/estampo/action@v1
         with:
           config: estampo.toml
 ```

--- a/changes/537.misc
+++ b/changes/537.misc
@@ -1,0 +1,1 @@
+Add floating major version tag (``v1``) for the GitHub Action on each stable release.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -261,7 +261,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: estampo/estampo/action@main
+      - uses: estampo/estampo/action@v1
         with:
           config: estampo.toml
 ```
@@ -347,7 +347,7 @@ jobs:
           echo "$BAMBOX_CREDENTIALS" > ~/.config/bambox/credentials.toml
         env:
           BAMBOX_CREDENTIALS: ${{ secrets.BAMBOX_CREDENTIALS }}
-      - uses: estampo/estampo/action@main
+      - uses: estampo/estampo/action@v1
         with:
           config: estampo.toml
           comment: "false"

--- a/docs/code-cad.md
+++ b/docs/code-cad.md
@@ -144,7 +144,7 @@ estampo_output/
 Use the estampo GitHub Action to slice on every PR:
 
 ```yaml
-- uses: estampo/estampo@main
+- uses: estampo/estampo/action@v1
   with:
     config: estampo.toml
     orca-version: "2.3.1"

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -413,7 +413,7 @@ estampo profiles pin config.toml                 # pin profiles for reproducibil
 ## Running in CI
 
 ```yaml
-- uses: estampo/estampo/action@main
+- uses: estampo/estampo/action@v1
   with:
     config: estampo.toml
     comment: "true"


### PR DESCRIPTION
## Summary
- Release workflow now updates a floating `v1` tag on each stable release (skipped for pre-releases)
- All docs updated from `@main` to `@v1`: README, AI prompt, llm.md, code-cad.md, action README
- Fixes incorrect `estampo/estampo@main` references (missing `/action` path) in README and code-cad.md

Closes #537

## Test plan
- [ ] Release workflow YAML is valid (CI validates)
- [ ] No remaining `@main` action references in docs
- [ ] Tag update step only runs for stable releases (not pre-releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)