### PR TITLE
Make override validation stricter and improve AI guidance

### DIFF
--- a/changes/541.bugfix
+++ b/changes/541.bugfix
@@ -1,0 +1,1 @@
+Make ``estampo validate`` exit non-zero when override keys are invalid, with clearer error messages.

--- a/changes/543.bugfix
+++ b/changes/543.bugfix
@@ -1,0 +1,1 @@
+Error when ``{sliced_3mf}`` cannot resolve to an actual file instead of silently falling back to directory path.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -228,14 +228,34 @@ correct names for your engine. Key mappings:
 | Layer height | `layer_height` | `layer_height` |
 | Wall count | `wall_loops` | `wall_line_count` |
 | Top layers | `top_shell_layers` | `top_layers` |
+| Bottom layers | `bottom_shell_layers` | `bottom_layers` |
 | Infill density | `sparse_infill_density` | `infill_sparse_density` |
 | Infill pattern | `sparse_infill_pattern` | `infill_pattern` |
 | Supports | `enable_support` | `support_enable` |
+| Support type | `support_type` | — |
 | Support angle | `support_threshold_angle` | `support_angle` |
+| Brim type | `brim_type` | `adhesion_type` |
+| Brim width | `brim_width` | `brim_width` |
+| First layer speed | `initial_layer_speed` | `speed_layer_0` |
+| First layer infill speed | `initial_layer_infill_speed` | — |
+| Outer wall speed | `outer_wall_speed` | `speed_wall_0` |
+| Inner wall speed | `inner_wall_speed` | `speed_wall_x` |
 | Travel speed | `travel_speed` | `speed_travel` |
+| Fan min speed | `fan_min_speed` | `cool_fan_speed_min` |
+| Fan max speed | `fan_max_speed` | `cool_fan_speed_max` |
+| Disable fan for first N layers | `close_fan_the_first_x_layers` | `cool_fan_full_layer` |
 | Retraction dist | `retraction_length` | `retraction_amount` |
 | Nozzle temp | `nozzle_temperature` | `material_print_temperature` |
+| First layer nozzle temp | `nozzle_temperature_initial_layer` | `material_print_temperature_layer_0` |
 | Bed temp | `bed_temperature` | `material_bed_temperature` |
+| Ironing | `ironing_type` | `ironing_enabled` |
+| Seam position | `seam_position` | `z_seam_type` |
+| XY hole compensation | `xy_hole_compensation` | `hole_xy_offset` |
+
+**CRITICAL: Setting names differ between slicers.** OrcaSlicer uses `initial_layer_speed`,
+not `first_layer_speed`. OrcaSlicer uses `wall_loops`, not `wall_line_count`. Using the
+wrong engine's setting name will be **silently ignored** — the slicer never sees it.
+Always look up the correct name from this table or the JSON files below.
 
 For the complete list of all settings:
 - OrcaSlicer: 263 settings in [`orca-settings.json`](https://github.com/estampo/estampo/blob/main/docs/orca-settings.json)
@@ -368,9 +388,11 @@ To set up the secret: run `bambox login` locally, then copy the contents of
 
 ### Important rules
 
-- **Do not invent setting names.** Only use keys from the setting lists above
-  or from the JSON files. estampo validates overrides and will reject unknown
-  keys.
+- **Do not invent setting names.** Only use keys from the setting name
+  reference table above or from the JSON files. OrcaSlicer and CuraEngine
+  use completely different names — guessing from PrusaSlicer or general
+  slicer knowledge will produce wrong keys that are **silently ignored**.
+  When in doubt, search the JSON file for the setting you need.
 - **Do not force slicer settings** that conflict with the printer's machine
   profile (e.g. `use_relative_e_distances`). Let the profile chain decide.
 - **Use string values** for OrcaSlicer overrides (they are passed as CLI
@@ -378,6 +400,22 @@ To set up the secret: run `bambox login` locally, then copy the contents of
 - **Pin the slicer version** for reproducibility.
 - estampo runs slicers inside Docker by default. GitHub Actions runners have
   Docker available, so `estampo run` works out of the box in CI.
+
+### Verifying the config
+
+After creating or modifying the config, always verify:
+
+```bash
+# 1. Validate — must exit 0 with no errors
+estampo validate
+
+# 2. Test slice — catches profile and override issues
+estampo run --until slice
+```
+
+`estampo validate` exits non-zero if any override keys are invalid. Fix all
+errors before proceeding — invalid keys are silently dropped by the slicer,
+so the print won't match what the user asked for.
 
 ### Command stage variables
 

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -521,13 +521,16 @@ def validate(
 
     result = validate_config(resolved_config)
 
+    errors = result.errors or []
+
     if json_flag:
         print(
             json.dumps(
                 {
-                    "valid": len(result.warnings) == 0,
+                    "valid": len(result.warnings) == 0 and len(errors) == 0,
                     "passes": result.passes,
                     "warnings": result.warnings,
+                    "errors": errors,
                 },
                 indent=2,
             )
@@ -540,12 +543,23 @@ def validate(
             ui.success(p)
         for w in result.warnings:
             ui.warn(w)
+        for e in errors:
+            ui.error(e)
         ui.console.print()
+        if errors:
+            n = len(errors)
+            ui.console.print(
+                f"  [red]{n}[/red] error{'s' if n != 1 else ''} found — "
+                "invalid override keys will be silently ignored by the slicer."
+            )
         if result.warnings:
             n = len(result.warnings)
             ui.console.print(f"  [yellow]{n}[/yellow] warning{'s' if n != 1 else ''} found.")
-        else:
+        if not errors and not result.warnings:
             ui.success("All checks passed.")
+
+    if errors:
+        raise typer.Exit(code=1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/estampo/commands.py
+++ b/src/estampo/commands.py
@@ -77,10 +77,7 @@ def build_command_context(
     if packaged_dir:
         from estampo.slicer import find_deliverable
 
-        try:
-            sliced_3mf = str(find_deliverable(Path(str(packaged_dir))))
-        except FileNotFoundError:
-            sliced_3mf = str(packaged_dir)
+        sliced_3mf = str(find_deliverable(Path(str(packaged_dir))))
 
     ctx: dict[str, str] = {
         "name": config.name or "",

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -204,10 +204,11 @@ def _load_existing(path: Path) -> _ExistingConfig | None:
 
 @dataclass
 class ValidationResult:
-    """Result of config validation with passes and warnings."""
+    """Result of config validation with passes, warnings, and errors."""
 
     passes: list[str]
     warnings: list[str]
+    errors: list[str] | None = None
 
     def __iter__(self):  # type: ignore[override]
         """Iterate over warnings for backward compatibility."""
@@ -326,6 +327,7 @@ def validate_config(path: Path) -> ValidationResult:
         )
 
     # Check slicer override keys against process profile
+    errors: list[str] = []
     if active.overrides:
         override_warnings = validate_override_keys(
             active.overrides,
@@ -334,7 +336,7 @@ def validate_config(path: Path) -> ValidationResult:
             project_dir=cfg.base_dir,
         )
         if override_warnings:
-            warnings.extend(override_warnings)
+            errors.extend(override_warnings)
         else:
             passes.append(f"Slicer override keys valid ({len(active.overrides)} override(s))")
 
@@ -420,7 +422,7 @@ def validate_config(path: Path) -> ValidationResult:
     if stages_ok:
         passes.append(f"Pipeline: {' → '.join(cfg.pipeline.stages)}")
 
-    return ValidationResult(passes=passes, warnings=warnings)
+    return ValidationResult(passes=passes, warnings=warnings, errors=errors or None)
 
 
 def _closest_match(name: str, candidates: list[str]) -> str | None:

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -379,24 +379,26 @@ def validate_override_keys(
             continue
 
         # Cross-engine detection: key belongs to the other engine
+        engine_label = "OrcaSlicer" if engine == "orca" else "CuraEngine"
+        other_label = "CuraEngine" if engine == "orca" else "OrcaSlicer"
         if key in other_keys:
             suggestion = cross_map.get(key)
             if suggestion and suggestion in all_valid:
                 warnings.append(
-                    f"slicer.overrides key '{key}' is an {other_engine} setting "
-                    f"— did you mean '{suggestion}'?"
+                    f"invalid override '{key}' — this is a {other_label} setting, "
+                    f"use '{suggestion}' for {engine_label}"
                 )
             else:
                 warnings.append(
-                    f"slicer.overrides key '{key}' is an {other_engine} setting, "
-                    f"not a valid {engine} key"
+                    f"invalid override '{key}' — this is a {other_label} setting, "
+                    f"not valid for {engine_label}"
                 )
         else:
             # Unknown key — try fuzzy match against engine keys
             hint = _closest_setting(key, all_valid)
-            msg = f"slicer.overrides key '{key}' not found in {engine} settings"
+            msg = f"invalid override '{key}' — not a known {engine_label} setting"
             if hint:
-                msg += f" — did you mean '{hint}'?"
+                msg += f", did you mean '{hint}'?"
             warnings.append(msg)
 
     return warnings

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from estampo import EstampoError
 from estampo.gcode import parse_gcode_metadata
 
 # Re-export OrcaSlicer symbols for backward compatibility.
@@ -72,7 +73,10 @@ def find_deliverable(sliced_output_dir: Path) -> Path:
     if gcode_files:
         return gcode_files[0]
 
-    raise FileNotFoundError(f"No gcode or 3MF output found in {sliced_output_dir}")
+    raise EstampoError(
+        f"No sliced output found in {sliced_output_dir} — expected a .gcode.3mf or "
+        f".gcode file. Check that the slice stage completed successfully."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -49,12 +49,16 @@ class TestCommandVariablesContract:
     def test_context_keys_with_full_results(self, tmp_path):
         """Keys remain the same regardless of what stage_results contain."""
         cfg = _make_config(tmp_path)
+        output = tmp_path / "output"
+        output.mkdir()
+        # Create a deliverable so find_deliverable resolves
+        (output / "plate_sliced.gcode.3mf").write_bytes(b"fake")
         results = {
             "plate_3mf_path": tmp_path / "plate.3mf",
-            "packaged_output": tmp_path / "output",
+            "packaged_output": output,
             "sliced_output_dir": tmp_path / "sliced",
         }
-        ctx = build_command_context(cfg, tmp_path / "output", results)
+        ctx = build_command_context(cfg, output, results)
         assert set(ctx.keys()) == set(COMMAND_VARIABLES.keys())
 
     def test_all_values_are_strings(self, tmp_path):
@@ -63,6 +67,19 @@ class TestCommandVariablesContract:
         ctx = build_command_context(cfg, tmp_path / "output", {})
         for key, value in ctx.items():
             assert isinstance(value, str), f"{key} is {type(value)}, expected str"
+
+    def test_errors_when_no_deliverable_found(self, tmp_path):
+        """build_command_context raises when packaged_output has no deliverable."""
+        import pytest
+
+        from estampo import EstampoError
+
+        cfg = _make_config(tmp_path)
+        empty_dir = tmp_path / "empty_output"
+        empty_dir.mkdir()
+        results = {"packaged_output": empty_dir}
+        with pytest.raises(EstampoError, match="No sliced output found"):
+            build_command_context(cfg, empty_dir, results)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -437,8 +437,8 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         result = validate_config(toml)
         assert any("override keys valid" in p.lower() for p in result.passes)
 
-    def test_override_keys_unknown_warns(self, tmp_path):
-        """Unknown override keys produce warnings."""
+    def test_override_keys_unknown_errors(self, tmp_path):
+        """Unknown override keys produce errors (not just warnings)."""
         profiles = tmp_path / "profiles" / "orca" / "process"
         profiles.mkdir(parents=True)
         (profiles / "MyProcess.json").write_text('{"type": "process", "layer_height": "0.2"}')
@@ -458,7 +458,8 @@ bogus_setting = "42"
 file = "{_posix(FIXTURES / "cube_10mm.stl")}"
 """)
         result = validate_config(toml)
-        assert any("bogus_setting" in w for w in result.warnings)
+        assert result.errors is not None
+        assert any("bogus_setting" in e for e in result.errors)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1017,7 +1017,7 @@ def test_validate_override_keys_cross_engine_orca_in_cura():
         process=None,
     )
     assert len(warnings) == 1
-    assert "orca" in warnings[0].lower()
+    assert "OrcaSlicer" in warnings[0]
     assert "wall_line_count" in warnings[0]
 
 
@@ -1029,7 +1029,7 @@ def test_validate_override_keys_cross_engine_cura_in_orca():
         process=None,
     )
     assert len(warnings) == 1
-    assert "cura" in warnings[0].lower()
+    assert "CuraEngine" in warnings[0]
     assert "sparse_infill_density" in warnings[0]
 
 


### PR DESCRIPTION
## Summary
- `estampo validate` now exits non-zero when override keys are invalid — AI assistants can no longer treat bad keys as "config is fine"
- Error messages are clearer: `invalid override 'first_layer_speed' — not a known OrcaSlicer setting, did you mean 'initial_layer_speed'?`
- AI prompt setting reference expanded from 11 to 26 entries (first layer speed, fan controls, brim, ironing, seam, XY compensation, etc.)
- Added CRITICAL warning and verification steps to AI prompt

**Context**: Codex used wrong OrcaSlicer setting names (`first_layer_speed` instead of `initial_layer_speed`) and treated the validation warnings as acceptable. This PR makes it impossible to miss.

Closes #541

## Test plan
- [x] Unknown override keys now appear in `result.errors` (not `result.warnings`)
- [x] Cross-engine messages use human-readable names (OrcaSlicer/CuraEngine)
- [x] All 573 tests pass
- [x] Lint, format, type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)