### PR TITLE
Add safety disclaimers and surface command stage warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Same repo, same config → same G-code, locally or [in CI](#cicd-example).
 
 > **Warning:** estampo is in active early development. We are moving fast and breaking things — config format, CLI flags, and Python APIs may change between minor versions without deprecation. Pin your version if stability matters to you.
 
+> **Safety:** estampo generates G-code from your configuration but does not verify that settings are safe for your specific printer. Incorrect temperatures, speeds, or missing supports can damage your printer or create a fire hazard. Always review sliced output before sending to a printer. `estampo validate` checks config structure and setting names — it does not check print safety. **Use at your own risk.**
+
 > **Note:** This project was previously called **fabprint**. If you have an existing install,
 > run `pip install estampo` to upgrade — config files and credentials are migrated automatically.
 

--- a/changes/544.misc
+++ b/changes/544.misc
@@ -1,0 +1,1 @@
+Add safety disclaimers and surface command stage warnings to users.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -401,6 +401,22 @@ To set up the secret: run `bambox login` locally, then copy the contents of
 - estampo runs slicers inside Docker by default. GitHub Actions runners have
   Docker available, so `estampo run` works out of the box in CI.
 
+### Safety
+
+estampo generates G-code but does not verify that settings are safe for the
+user's printer. When suggesting or modifying overrides:
+
+- **Never set temperatures above the filament manufacturer's recommendations.**
+  Excessive nozzle or bed temperatures can damage the printer or create a fire
+  hazard.
+- **Always recommend supports for overhangs** unless the user explicitly says
+  otherwise. Unsupported overhangs can cause print failures and wasted material.
+- **Warn the user to review the sliced output** before sending to a printer,
+  especially when using AI-generated settings for the first time.
+- **`estampo validate` checks config correctness, not print safety.** A config
+  that passes validation can still produce unsafe G-code if the override values
+  are wrong for the hardware.
+
 ### Verifying the config
 
 After creating or modifying the config, always verify:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,6 +72,11 @@ Checks for:
 is expected when profiles are not installed locally. This is not an error —
 profiles are resolved at runtime via Docker. The warning can be safely ignored.
 
+**Safety note:** Validation checks config structure and setting names. It does
+not verify that override values are safe for your printer — for example, it
+will not catch dangerously high temperatures or missing supports. Always review
+sliced output before sending to a printer.
+
 ### Examples
 
 ```bash

--- a/src/estampo/commands.py
+++ b/src/estampo/commands.py
@@ -265,7 +265,13 @@ def run_command_stage(
             f"{result.stderr[:500]}"
         )
 
+    # Surface stdout and stderr from successful runs so downstream tool
+    # warnings (e.g. bambox safety notices) are not silently swallowed.
+    if result.stderr:
+        for line in result.stderr.strip().splitlines():
+            ui.warn(f"[{stage.name}] {line}")
     if result.stdout:
-        log.info("Command stage '%s' stdout:\n%s", stage.name, result.stdout.rstrip())
+        for line in result.stdout.strip().splitlines():
+            ui.info(f"[{stage.name}] {line}")
 
     return output_path


### PR DESCRIPTION
## Summary
- **Code**: command stage stdout/stderr now shown on success — bambox safety warnings are no longer swallowed by `capture_output=True`
- **README**: safety notice about reviewing G-code, clarifying validation doesn't check print safety
- **AI prompt**: safety section covering temperature limits, supports, and human review of AI-generated settings
- **CLI docs**: clarified that `estampo validate` checks config structure, not whether settings are safe for the hardware

Closes #544

## Test plan
- [x] All 574 tests pass
- [x] Lint, format, type checks pass
- [ ] Command stage output visible in `estampo run` (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)