### PR TITLE
Fix CuraEngine profile validation to recognize definition IDs

### DIFF
--- a/changes/546.bugfix
+++ b/changes/546.bugfix
@@ -1,0 +1,1 @@
+Include CuraEngine definition IDs (e.g. ``bambox_p1s``) in profile validation so ID-based printer references are recognized.

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -128,14 +128,18 @@ def _extract_names(items: list) -> list[str]:
     """Extract name strings from a manifest list.
 
     OrcaSlicer manifests have plain strings.  CuraEngine manifests have
-    ``{"name": "...", "id": "..."}`` objects.
+    ``{"name": "...", "id": "..."}`` objects — both the display name and
+    the definition ID are included so users can configure with either.
     """
     names: list[str] = []
     for item in items:
         if isinstance(item, str):
             names.append(item)
-        elif isinstance(item, dict) and "name" in item:
-            names.append(item["name"])
+        elif isinstance(item, dict):
+            if "name" in item:
+                names.append(item["name"])
+            if "id" in item and item["id"] != item.get("name"):
+                names.append(item["id"])
     return names
 
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -7,6 +7,7 @@ import pytest
 
 from estampo.profiles import (
     SYSTEM_DIRS,
+    _extract_names,
     _resolve_profile_data_from_dir,
     add_profile,
     detect_category,
@@ -211,6 +212,36 @@ def test_bundled_profiles_loadable():
     assert len(result["machine"]) > 10, "Expected many machine profiles"
     assert len(result["process"]) > 10, "Expected many process profiles"
     assert len(result["filament"]) > 10, "Expected many filament profiles"
+
+
+# ---------------------------------------------------------------------------
+# _extract_names
+# ---------------------------------------------------------------------------
+
+
+def test_extract_names_plain_strings():
+    assert _extract_names(["A", "B"]) == ["A", "B"]
+
+
+def test_extract_names_cura_dicts_include_id():
+    """CuraEngine manifests with id field should include both name and id."""
+    items = [{"name": "Bambu Lab P1S (bambox)", "id": "bambox_p1s"}]
+    names = _extract_names(items)
+    assert "Bambu Lab P1S (bambox)" in names
+    assert "bambox_p1s" in names
+
+
+def test_extract_names_skips_duplicate_id():
+    """When id equals name, don't duplicate."""
+    items = [{"name": "same", "id": "same"}]
+    assert _extract_names(items) == ["same"]
+
+
+def test_extract_names_mixed():
+    """Handles a mix of strings and dicts."""
+    items = ["plain", {"name": "Display", "id": "def_id"}]
+    names = _extract_names(items)
+    assert names == ["plain", "Display", "def_id"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_extract_names()` now includes both the display `name` and `id` from CuraEngine manifest entries
- Users configure CuraEngine printers by definition ID (e.g. `bambox_p1s`), which was incorrectly reported as "not found" during validation
- Adds 4 tests for `_extract_names()` covering plain strings, dict entries with IDs, duplicate suppression, and mixed lists

Closes #546

## Test plan
- [x] `uv run pytest tests/test_profiles.py` — 78 passed
- [x] Full suite: 578 passed
- [x] Lint, format, mypy all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)