### PR TITLE
Improve CuraEngine definition-not-found error with actionable guidance

### DIFF
--- a/changes/548.bugfix
+++ b/changes/548.bugfix
@@ -1,0 +1,1 @@
+Give actionable guidance when CuraEngine printer definition is not found locally instead of a bare error.

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -232,24 +232,14 @@ def _resolve_def_chain(
                 path = bundled
 
         if path is None:
-            if current_id == def_id:
-                # The root definition itself was not found — give a clear error
-                # rather than silently building a broken Docker command.
-                pinned_loc = (
-                    project_dir / profiles_dir / "cura" / "definitions" / filename
-                    if project_dir
-                    else "(no project dir)"
-                )
-                raise EstampoError(
-                    f"CuraEngine printer definition '{filename}' was not found.\n"
-                    "Search locations checked:\n"
-                    f"  1. {pinned_loc}\n"
-                    f"  2. {_DATA_DIR / filename}\n"
-                    "\n"
-                    "Pin the definition to your project's "
-                    "profiles/cura/definitions/ directory."
-                )
-            # Parent definition not found locally — will rely on Docker's built-in defs
+            # Definition not found locally — Docker has built-in defs, so
+            # this is only fatal for local (non-Docker) slicing.  Callers
+            # that need the file locally will check and raise on their own.
+            log.debug(
+                "CuraEngine definition '%s' not found locally "
+                "(checked pinned + bundled). Docker will provide it.",
+                filename,
+            )
             break
 
         chain.append(path)
@@ -884,6 +874,32 @@ def _prepare_cura_staging(
     return staging, machine_def
 
 
+def _check_local_def(staging: Path, machine_def: str, printer: str | None) -> None:
+    """Raise if the machine definition is missing from staging (local mode only).
+
+    Docker has built-in definitions, but local CuraEngine needs the file
+    on disk.  Gives the user actionable guidance.
+    """
+    if (staging / machine_def).exists():
+        return
+    def_id = machine_def.removesuffix(".def.json")
+    raise EstampoError(
+        f"CuraEngine printer definition '{machine_def}' not found locally.\n"
+        "\n"
+        "This definition exists in the Docker image but is not bundled in\n"
+        "the estampo pip package.  To fix this, either:\n"
+        "\n"
+        f"  1. Pin the definition:  estampo profiles pin\n"
+        f"     (extracts '{def_id}' from the Docker image into profiles/)\n"
+        "\n"
+        "  2. Run via Docker (remove --local flag) — Docker has all\n"
+        "     built-in CuraEngine definitions.\n"
+        "\n"
+        f"  3. Install the definition package:  pip install cura-p1s\n"
+        f"     (if available for your printer)"
+    )
+
+
 def _run_docker_slice(
     inner_cmd: str,
     image: str,
@@ -1039,6 +1055,7 @@ def slice_stl(
     settings = _settings_flags(profile)
 
     if local:
+        _check_local_def(staging, machine_def, printer)
         defs_path = _local_defs_path(staging)
         cura_args = [
             "-d",
@@ -1122,6 +1139,7 @@ def slice_stl_multi(
             shutil.copy2(stl_path, dest)
 
     if local:
+        _check_local_def(staging, machine_def, printer)
         cura_args: list[str] = [
             "-d",
             _local_defs_path(staging),

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -8,10 +8,12 @@ from estampo import EstampoError
 from estampo.cura import (
     _FILAMENT_TEMPS,
     CuraProfile,
+    _check_local_def,
     _extruder_settings_str,
     _fetch_printer_def,
     _patch_gcode_header,
     _place_on_bed,
+    _resolve_def_chain,
     _resolve_def_name,
     _settings_dict,
     _settings_flags,
@@ -59,6 +61,48 @@ def test_resolve_def_name_unknown_raises():
     """Unknown printer name raises EstampoError."""
     with pytest.raises(EstampoError, match="not found in the definition manifest"):
         _resolve_def_name("Totally Unknown Printer XYZ")
+
+
+# --- _resolve_def_chain ---
+
+
+def test_resolve_def_chain_missing_returns_empty(tmp_path):
+    """Missing definition returns empty chain instead of raising."""
+    chain = _resolve_def_chain("nonexistent_printer", project_dir=tmp_path)
+    assert chain == []
+
+
+def test_resolve_def_chain_finds_pinned(tmp_path):
+    """Pinned definition is found and returned."""
+    import json
+
+    defs_dir = tmp_path / "profiles" / "cura" / "definitions"
+    defs_dir.mkdir(parents=True)
+    (defs_dir / "my_printer.def.json").write_text(
+        json.dumps({"name": "My Printer", "overrides": {}})
+    )
+    chain = _resolve_def_chain("my_printer", project_dir=tmp_path)
+    assert len(chain) == 1
+    assert chain[0].name == "my_printer.def.json"
+
+
+# --- _check_local_def ---
+
+
+def test_check_local_def_raises_when_missing(tmp_path):
+    """Raises EstampoError with guidance when def file missing from staging."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    with pytest.raises(EstampoError, match="not found locally"):
+        _check_local_def(staging, "bambox_p1s.def.json", "bambox_p1s")
+
+
+def test_check_local_def_passes_when_present(tmp_path):
+    """No error when def file exists in staging."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (staging / "bambox_p1s.def.json").write_text("{}")
+    _check_local_def(staging, "bambox_p1s.def.json", "bambox_p1s")  # no raise
 
 
 # --- cura_docker_image ---


### PR DESCRIPTION
## Summary
- `_resolve_def_chain` no longer raises when a printer definition isn't found locally — returns an empty chain instead, since Docker has built-in definitions
- New `_check_local_def` guard runs only for `--local` slicing, giving clear guidance: pin the definition, use Docker, or install the definition package
- Previously, `estampo run` with a CuraEngine printer like `bambox_p1s` would fail even for Docker-based slicing because the definition isn't bundled in the pip package

Closes #548

## Test plan
- [x] `test_resolve_def_chain_missing_returns_empty` — empty chain instead of raising
- [x] `test_resolve_def_chain_finds_pinned` — pinned defs still found
- [x] `test_check_local_def_raises_when_missing` — clear error for local mode
- [x] `test_check_local_def_passes_when_present` — no error when def exists
- [x] Full suite: 582 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)