### PR TITLE
Recommend profile pinning in AI setup prompt

### DIFF
--- a/changes/550.misc
+++ b/changes/550.misc
@@ -1,0 +1,1 @@
+Recommend profile pinning in AI setup prompt for reproducible builds.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -398,6 +398,9 @@ To set up the secret: run `bambox login` locally, then copy the contents of
 - **Use string values** for OrcaSlicer overrides (they are passed as CLI
   arguments): `layer_height = "0.2"`, not `layer_height = 0.2`.
 - **Pin the slicer version** for reproducibility.
+- **Pin profiles** with `estampo profiles pin` and commit the `profiles/`
+  directory. This makes builds reproducible without depending on locally
+  installed slicer profiles or Docker image contents.
 - estampo runs slicers inside Docker by default. GitHub Actions runners have
   Docker available, so `estampo run` works out of the box in CI.
 
@@ -417,6 +420,25 @@ user's printer. When suggesting or modifying overrides:
   that passes validation can still produce unsafe G-code if the override values
   are wrong for the hardware.
 
+### Pinning profiles for reproducibility
+
+After creating the config, pin the referenced slicer profiles into the project
+so builds are reproducible across machines and CI — regardless of what's
+installed locally:
+
+```bash
+estampo profiles pin
+```
+
+This extracts profiles from the Docker image (using the `slicer.version` in your
+config), squashes the inheritance chain, and writes standalone definition files
+to `profiles/`. **Commit the `profiles/` directory to git.**
+
+For CuraEngine configs using custom printer definitions (e.g. `bambox_p1s`),
+pinning is especially important — the definition file only exists inside the
+Docker image and is not bundled in the pip package. Without pinning, local
+slicing (`--local`) will fail.
+
 ### Verifying the config
 
 After creating or modifying the config, always verify:
@@ -425,7 +447,10 @@ After creating or modifying the config, always verify:
 # 1. Validate — must exit 0 with no errors
 estampo validate
 
-# 2. Test slice — catches profile and override issues
+# 2. Pin profiles for reproducibility
+estampo profiles pin
+
+# 3. Test slice — catches profile and override issues
 estampo run --until slice
 ```
 


### PR DESCRIPTION
## Summary
- Add a new "Pinning profiles for reproducibility" section to the AI setup prompt explaining `estampo profiles pin` and why it matters
- Add profile pinning to the verification steps (validate → pin → test slice)
- Add "pin profiles" to the important rules list

Especially important for CuraEngine configs where definitions like `bambox_p1s` only exist in Docker — without pinning, local slicing fails.

Closes #550

## Test plan
- [x] 582 tests pass
- [x] Doc content reviewed for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)