### PR TITLE
Fix CuraEngine pinned definitions failing at slice time

### DIFF
--- a/changes/550.misc
+++ b/changes/550.misc
@@ -1,0 +1,1 @@
+Recommend profile pinning in AI setup prompt for reproducible builds.

--- a/changes/552.bugfix
+++ b/changes/552.bugfix
@@ -1,0 +1,1 @@
+Fix CuraEngine pinned definitions failing at slice time by preserving ``inherits`` for root definitions.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -398,6 +398,9 @@ To set up the secret: run `bambox login` locally, then copy the contents of
 - **Use string values** for OrcaSlicer overrides (they are passed as CLI
   arguments): `layer_height = "0.2"`, not `layer_height = 0.2`.
 - **Pin the slicer version** for reproducibility.
+- **Pin profiles** with `estampo profiles pin` and commit the `profiles/`
+  directory. This makes builds reproducible without depending on locally
+  installed slicer profiles or Docker image contents.
 - estampo runs slicers inside Docker by default. GitHub Actions runners have
   Docker available, so `estampo run` works out of the box in CI.
 
@@ -417,6 +420,25 @@ user's printer. When suggesting or modifying overrides:
   that passes validation can still produce unsafe G-code if the override values
   are wrong for the hardware.
 
+### Pinning profiles for reproducibility
+
+After creating the config, pin the referenced slicer profiles into the project
+so builds are reproducible across machines and CI — regardless of what's
+installed locally:
+
+```bash
+estampo profiles pin
+```
+
+This extracts profiles from the Docker image (using the `slicer.version` in your
+config), squashes the inheritance chain, and writes standalone definition files
+to `profiles/`. **Commit the `profiles/` directory to git.**
+
+For CuraEngine configs using custom printer definitions (e.g. `bambox_p1s`),
+pinning is especially important — the definition file only exists inside the
+Docker image and is not bundled in the pip package. Without pinning, local
+slicing (`--local`) will fail.
+
 ### Verifying the config
 
 After creating or modifying the config, always verify:
@@ -425,7 +447,10 @@ After creating or modifying the config, always verify:
 # 1. Validate — must exit 0 with no errors
 estampo validate
 
-# 2. Test slice — catches profile and override issues
+# 2. Pin profiles for reproducibility
+estampo profiles pin
+
+# 3. Test slice — catches profile and override issues
 estampo run --until slice
 ```
 

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -914,6 +914,23 @@ def _check_local_def(staging: Path, machine_def: str, printer: str | None) -> No
     )
 
 
+def _strip_cura_banner(text: str) -> str:
+    """Strip the CuraEngine GPL license banner from output text.
+
+    CuraEngine prints a multi-line license notice to stderr on every run.
+    It wastes space in error messages and pushes the actual diagnostic off
+    screen.  Strip everything up to and including the blank line after the
+    ``<http...>`` URL.
+    """
+    marker = "<http://www.gnu.org/licenses/>."
+    idx = text.find(marker)
+    if idx == -1:
+        return text
+    # Skip past the marker line and any trailing blank lines
+    rest = text[idx + len(marker) :].lstrip("\n")
+    return rest
+
+
 def _run_docker_slice(
     inner_cmd: str,
     image: str,
@@ -963,12 +980,14 @@ def _run_docker_slice(
     if result.returncode != 0:
         combined = (result.stdout + "\n" + result.stderr).strip()
         log.error("CuraEngine output:\n%s", combined)
-        raise EstampoError(f"CuraEngine failed (exit {result.returncode}):\n{combined[:500]}")
+        raise EstampoError(
+            f"CuraEngine failed (exit {result.returncode}):\n{_strip_cura_banner(combined)[:500]}"
+        )
 
     output_gcode = output_dir / f"{output_stem}.gcode"
     if not output_gcode.exists() or output_gcode.stat().st_size < 100:
         combined = (result.stdout + "\n" + result.stderr).strip()
-        raise EstampoError(f"CuraEngine produced no output:\n{combined[:500]}")
+        raise EstampoError(f"CuraEngine produced no output:\n{_strip_cura_banner(combined)[:500]}")
 
     _patch_gcode_header(output_gcode, result.stderr)
     _write_cura_settings(output_dir, profile)
@@ -1007,12 +1026,14 @@ def _run_local_slice(
     if result.returncode != 0:
         combined = (result.stdout + "\n" + result.stderr).strip()
         log.error("CuraEngine output:\n%s", combined)
-        raise EstampoError(f"CuraEngine failed (exit {result.returncode}):\n{combined[:500]}")
+        raise EstampoError(
+            f"CuraEngine failed (exit {result.returncode}):\n{_strip_cura_banner(combined)[:500]}"
+        )
 
     output_gcode = output_dir / f"{output_stem}.gcode"
     if not output_gcode.exists() or output_gcode.stat().st_size < 100:
         combined = (result.stdout + "\n" + result.stderr).strip()
-        raise EstampoError(f"CuraEngine produced no output:\n{combined[:500]}")
+        raise EstampoError(f"CuraEngine produced no output:\n{_strip_cura_banner(combined)[:500]}")
 
     _patch_gcode_header(output_gcode, result.stderr)
     _write_cura_settings(output_dir, profile)

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -436,11 +436,19 @@ def _squash_cura_def(def_id: str, defs_dir: Path) -> dict:
     """Walk the inheritance chain for a CuraEngine definition and squash it.
 
     Reads ``*.def.json`` files from *defs_dir*, follows ``inherits`` links,
-    and deep-merges overrides from root to leaf.  If the chain ends at an
-    unresolved parent (e.g. ``fdmprinter`` which ships inside the CuraEngine
-    Docker image), ``inherits`` is preserved so CuraEngine can resolve it
-    at runtime via its ``-d`` search path.
+    and deep-merges overrides from root to leaf.
+
+    Root definitions like ``fdmprinter`` provide the full settings schema in
+    a ``settings`` tree (not ``overrides``).  Since we only merge
+    ``overrides``, we must stop before including root definitions and
+    preserve ``inherits`` so CuraEngine resolves the base at runtime via
+    its ``-d`` search path.
     """
+    # Root definitions that provide the full settings schema.  These must
+    # NOT be squashed — their ``settings`` tree is too large and not
+    # representable as ``overrides``.  CuraEngine resolves them at runtime.
+    _ROOT_DEFS = {"fdmprinter", "fdmextruder"}
+
     chain: list[dict] = []
     current_id: str | None = def_id
     seen: set[str] = set()
@@ -448,6 +456,12 @@ def _squash_cura_def(def_id: str, defs_dir: Path) -> dict:
 
     while current_id and current_id not in seen:
         seen.add(current_id)
+
+        # Stop before root definitions — they provide the base schema
+        if current_id in _ROOT_DEFS and current_id != def_id:
+            unresolved_parent = current_id
+            break
+
         path = defs_dir / f"{current_id}.def.json"
         if not path.exists():
             # Parent not available locally — CuraEngine resolves it at runtime

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -17,6 +17,7 @@ from estampo.cura import (
     _resolve_def_name,
     _settings_dict,
     _settings_flags,
+    _squash_cura_def,
     _write_cura_settings,
     cura_docker_image,
     cura_profile_from_config,
@@ -103,6 +104,75 @@ def test_check_local_def_passes_when_present(tmp_path):
     staging.mkdir()
     (staging / "bambox_p1s.def.json").write_text("{}")
     _check_local_def(staging, "bambox_p1s.def.json", "bambox_p1s")  # no raise
+
+
+# --- _squash_cura_def ---
+
+
+def test_squash_preserves_inherits_for_fdmprinter(tmp_path):
+    """Squash must preserve 'inherits': 'fdmprinter' — never merge the root."""
+    import json
+
+    # Create a fake fdmprinter (root definition with settings tree, not overrides)
+    (tmp_path / "fdmprinter.def.json").write_text(
+        json.dumps(
+            {
+                "name": "FDM Printer Base",
+                "version": 2,
+                "settings": {"machine_width": {"default_value": 200}},
+                "overrides": {},
+            }
+        )
+    )
+    # Create a machine definition that inherits from fdmprinter
+    (tmp_path / "my_printer.def.json").write_text(
+        json.dumps(
+            {
+                "name": "My Printer",
+                "version": 2,
+                "inherits": "fdmprinter",
+                "overrides": {"machine_width": {"value": 300}},
+            }
+        )
+    )
+    result = _squash_cura_def("my_printer", tmp_path)
+    # Must keep inherits so CuraEngine resolves fdmprinter at runtime
+    assert result["inherits"] == "fdmprinter"
+    assert result["overrides"]["machine_width"]["value"] == 300
+
+
+def test_squash_merges_intermediate_definitions(tmp_path):
+    """Intermediate definitions (not fdmprinter) should be merged."""
+    import json
+
+    (tmp_path / "fdmprinter.def.json").write_text(
+        json.dumps({"name": "FDM Base", "version": 2, "settings": {}, "overrides": {}})
+    )
+    (tmp_path / "base_printer.def.json").write_text(
+        json.dumps(
+            {
+                "name": "Base Printer",
+                "version": 2,
+                "inherits": "fdmprinter",
+                "overrides": {"speed_print": {"value": 60}},
+            }
+        )
+    )
+    (tmp_path / "my_printer.def.json").write_text(
+        json.dumps(
+            {
+                "name": "My Printer",
+                "version": 2,
+                "inherits": "base_printer",
+                "overrides": {"machine_width": {"value": 300}},
+            }
+        )
+    )
+    result = _squash_cura_def("my_printer", tmp_path)
+    # fdmprinter preserved, intermediate merged
+    assert result["inherits"] == "fdmprinter"
+    assert result["overrides"]["speed_print"]["value"] == 60
+    assert result["overrides"]["machine_width"]["value"] == 300
 
 
 # --- cura_docker_image ---


### PR DESCRIPTION
## Summary
- `_squash_cura_def` was merging `fdmprinter` (the root definition) into the squashed output and removing `inherits`
- Since `fdmprinter` stores defaults in a `settings` tree (not `overrides`), the squashed definition lost all base values
- CuraEngine then failed with `JSON setting 'machine_width' has no [default_]value!` for every inherited setting
- Fix: stop the chain walk before root definitions (`fdmprinter`, `fdmextruder`) and always preserve `inherits` so CuraEngine resolves the base at runtime

This is the root cause of the "no [default_]value" errors users see after running `estampo profiles pin` followed by `estampo run`.

Closes #552

## Test plan
- [x] `test_squash_preserves_inherits_for_fdmprinter` — root is not merged, `inherits` preserved
- [x] `test_squash_merges_intermediate_definitions` — intermediate defs still merged correctly
- [x] Full suite: 584 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)