### PR TITLE
Fix validation not recognizing pinned CuraEngine definition IDs

### DIFF
--- a/changes/554.bugfix
+++ b/changes/554.bugfix
@@ -1,0 +1,1 @@
+Include CuraEngine definition IDs in pinned profile validation so ``bambox_p1s`` is recognized after ``estampo profiles pin``.

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -286,9 +286,14 @@ def validate_config(path: Path) -> ValidationResult:
                         f"variant, e.g. '{active.printer} 0.4 nozzle'"
                     )
                 else:
+                    pin_hint = ""
+                    if source != "pinned":
+                        pin_hint = (
+                            " Run 'estampo profiles pin' to extract profiles from the Docker image."
+                        )
                     warnings.append(
                         f"slicer.printer '{active.printer}' not found in "
-                        f"{cfg.slicer.engine} profiles ({source}).{hint}"
+                        f"{cfg.slicer.engine} profiles ({source}).{hint}{pin_hint}"
                     )
                 profile_ok = False
 

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -179,17 +179,22 @@ def discover_profile_names(
                     if f.is_file()
                 )
                 if names:
-                    # Read human names from the definition files
-                    display_names: list[str] = []
+                    # Include both display names and definition IDs so
+                    # users can configure with either (e.g. "Bambu Lab
+                    # P1S (bambox)" or "bambox_p1s").
+                    machine_names: list[str] = []
                     for stem in names:
                         try:
                             with open(defs_dir / f"{stem}.def.json") as fh:
                                 d = json.load(fh)
-                            display_names.append(d.get("name", stem))
+                            display = d.get("name", stem)
+                            machine_names.append(display)
+                            if stem != display:
+                                machine_names.append(stem)
                         except (json.JSONDecodeError, OSError):
-                            display_names.append(stem)
+                            machine_names.append(stem)
                     pinned_cura: dict[str, list[str]] = {
-                        "machine": display_names,
+                        "machine": machine_names,
                         "process": [],
                         "filament": [],
                     }

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -270,6 +270,21 @@ def test_discover_profile_names_pinned_fallback(tmp_path):
     assert "MyPrinter" in names["machine"]
 
 
+def test_discover_profile_names_pinned_cura_includes_id(tmp_path):
+    """Pinned CuraEngine definitions include both display name and def ID."""
+    defs_dir = tmp_path / "profiles" / "cura" / "definitions"
+    defs_dir.mkdir(parents=True)
+    (defs_dir / "bambox_p1s.def.json").write_text(
+        json.dumps({"name": "Bambu Lab P1S (bambox)", "overrides": {}})
+    )
+
+    with patch("estampo.profiles.discover_profiles", return_value={}):
+        names, source = discover_profile_names("cura", project_dir=tmp_path)
+    assert source == "pinned"
+    assert "Bambu Lab P1S (bambox)" in names["machine"]
+    assert "bambox_p1s" in names["machine"]
+
+
 def test_discover_profile_names_bundled_fallback(tmp_path):
     """Falls back to bundled profiles when no system or pinned."""
     bundled = {"machine": ["Bundled"], "process": [], "filament": []}


### PR DESCRIPTION
## Summary
- Pinned CuraEngine profile discovery now includes both the display name and the definition ID (file stem)
- Previously `estampo validate` warned `bambox_p1s` wasn't found even after `estampo profiles pin`, because only the display name ("Bambu Lab P1S (bambox)") was returned
- Same class of bug as #546 (bundled profiles) but for pinned profiles

Closes #554

## Test plan
- [x] `test_discover_profile_names_pinned_cura_includes_id` — both name and ID returned
- [x] Full suite: 585 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)