### PR TITLE
Add CuraEngine template variable safety checks

### DIFF
--- a/changes/557.feature
+++ b/changes/557.feature
@@ -1,0 +1,1 @@
+``estampo validate`` now detects CuraEngine template variables in start gcode and errors when no ``resolve_templates`` stage is configured.

--- a/changes/559.misc
+++ b/changes/559.misc
@@ -1,0 +1,1 @@
+Update AI setup prompt to document required ``resolve_templates`` stage for CuraEngine + Bambu printers.

--- a/changes/560.feature
+++ b/changes/560.feature
@@ -1,0 +1,1 @@
+``build_config_toml`` now auto-adds ``resolve_templates`` and ``pack`` command stages for CuraEngine + Bambu printer configurations.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -301,15 +301,28 @@ use.
 
 The command differs by slicer engine:
 
-**CuraEngine** (creates `.gcode.3mf` from plain G-code):
+**CuraEngine** (resolve template gcode variables, then pack):
+
+CuraEngine printer definitions (e.g. `bambox_p1s`) use template variables like
+`{material_bed_temperature_layer_0}` in their start/end G-code. These **must** be
+resolved before packing — otherwise the printer receives literal template strings
+instead of actual values, which causes temperature errors or dangerous behavior.
+
 ```toml
 [pipeline]
-stages = ["load", "arrange", "plate", "slice", "pack"]
+stages = ["load", "arrange", "plate", "slice", "resolve_templates", "pack"]
+
+[resolve_templates]
+command = "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"
 
 [pack]
 command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
 output = "{output_dir}/plate.gcode.3mf"
 ```
+
+**The `resolve_templates` stage is required for CuraEngine + Bambu printers.**
+Without it, `estampo validate` will report an error. The `cura-p1s` package is
+pre-installed in the Docker images.
 
 **OrcaSlicer** (patches the existing `.gcode.3mf` for Bambu Connect compatibility):
 ```toml

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -6,8 +6,12 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from estampo.config import DEFAULT_STAGES, SUPPORTED_EXTENSIONS
+
+if TYPE_CHECKING:
+    from estampo.config import EstampoConfig
 
 log = logging.getLogger(__name__)
 
@@ -427,7 +431,75 @@ def validate_config(path: Path) -> ValidationResult:
     if stages_ok:
         passes.append(f"Pipeline: {' → '.join(cfg.pipeline.stages)}")
 
+    # Check CuraEngine definitions for unresolved template variables
+    if cfg.slicer.engine == "cura" and active.printer and "slice" in cfg.pipeline.stages:
+        _check_cura_template_gcode(cfg, warnings, errors)
+
     return ValidationResult(passes=passes, warnings=warnings, errors=errors or None)
+
+
+def _check_cura_template_gcode(
+    cfg: "EstampoConfig",
+    warnings: list[str],
+    errors: list[str],
+) -> None:
+    """Warn if CuraEngine start gcode has template variables but no resolve stage."""
+    import json
+    import re
+
+    from estampo.cura import _resolve_def_chain, _resolve_def_name
+
+    try:
+        def_id = _resolve_def_name(cfg.slicer.active.printer)
+    except Exception:
+        return  # can't resolve — other warnings will cover this
+
+    chain = _resolve_def_chain(def_id, cfg.base_dir, cfg.slicer.profiles_dir)
+    if not chain:
+        return
+
+    # Read start gcode from the leaf definition
+    try:
+        with open(chain[0]) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return
+
+    start_gcode = data.get("overrides", {}).get("machine_start_gcode", {})
+    gcode_text = start_gcode.get("default_value", "")
+    if not gcode_text:
+        return
+
+    # Check for CuraEngine template variables like {material_bed_temperature_layer_0}
+    templates = re.findall(r"\{(\w+)\}", gcode_text)
+    # Filter to likely CuraEngine setting names (not command stage variables)
+    cura_templates = [t for t in templates if "_" in t and not t.startswith("if ")]
+    if not cura_templates:
+        return
+
+    # Check if any pipeline stage resolves templates
+    has_resolver = False
+    for stage_name in cfg.pipeline.stages:
+        if stage_name in cfg.pipeline.command_stages:
+            cmd = cfg.pipeline.command_stages[stage_name].command
+            if "resolve" in cmd.lower():
+                has_resolver = True
+                break
+
+    if not has_resolver:
+        examples = ", ".join(cura_templates[:3])
+        errors.append(
+            f"CuraEngine printer definition '{def_id}' uses template variables "
+            f"in start gcode (e.g. {examples}) but the pipeline has no stage to "
+            f"resolve them. Unresolved templates cause dangerous printer behavior.\n"
+            f"  Fix: add a resolve_templates stage to your pipeline:\n"
+            f"    [pipeline]\n"
+            f'    stages = [..., "slice", "resolve_templates", "pack"]\n'
+            f"\n"
+            f"    [resolve_templates]\n"
+            f'    command = "cura-p1s resolve {{sliced_dir}}/plate.gcode '
+            f'--settings {{cura_settings}}"'
+        )
 
 
 def _closest_match(name: str, candidates: list[str]) -> str | None:
@@ -1277,6 +1349,25 @@ def build_config_toml(
 ) -> str:
     """Build estampo.toml content from explicit parameters (non-interactive)."""
     part_dicts = [{"file": p, "copies": 1, "orient": "flat", "filament": 1} for p in parts]
+    effective_stages = list(stages) if stages else list(DEFAULT_STAGES)
+    command_stages: dict[str, dict[str, str | bool]] | None = None
+
+    # Auto-add resolve_templates + pack for CuraEngine with Bambu printers
+    if printer and _is_bambu_printer(printer) and "pack" not in effective_stages:
+        command_stages = {}
+        if engine == "cura":
+            effective_stages.append("resolve_templates")
+            command_stages["resolve_templates"] = {
+                "command": ("cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"),
+            }
+        effective_stages.append("pack")
+        command_stages["pack"] = {
+            "command": ("bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf")
+            if engine == "cura"
+            else "bambox repack {sliced_3mf}",
+            "output": "{output_dir}/plate.gcode.3mf" if engine == "cura" else "{sliced_3mf}",
+        }
+
     return _build_toml(
         project_name=name,
         engine=engine,
@@ -1286,8 +1377,9 @@ def build_config_toml(
         parts=part_dicts,
         plate_size=plate_size,
         slicer_version=slicer_version,
-        stages=stages or list(DEFAULT_STAGES),
+        stages=effective_stages,
         bed_type=bed_type,
+        command_stages=command_stages,
     )
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,9 +8,11 @@ from estampo.cli import main
 from estampo.init import (
     ValidationResult,
     _build_toml,
+    _check_cura_template_gcode,
     _closest_match,
     _is_bambu_printer,
     _validate_override,
+    build_config_toml,
     dump_template,
     generate_workflow,
     validate_config,
@@ -847,3 +849,185 @@ class TestWizard:
 
         run_wizard()
         assert not (tmp_path / "estampo.toml").exists()
+
+
+# ---------------------------------------------------------------------------
+# _check_cura_template_gcode tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCuraTemplateGcode:
+    """Tests for _check_cura_template_gcode (#557)."""
+
+    def _make_cfg(self, tmp_path, *, has_resolve_stage=False):
+        """Create a minimal CuraEngine config with pinned definition containing templates."""
+        import json
+
+        # Create a pinned definition with template variables in start gcode
+        defs_dir = tmp_path / "profiles" / "cura" / "definitions"
+        defs_dir.mkdir(parents=True)
+        (defs_dir / "bambox_p1s.def.json").write_text(
+            json.dumps(
+                {
+                    "name": "Bambu P1S",
+                    "inherits": "fdmprinter",
+                    "overrides": {
+                        "machine_start_gcode": {
+                            "default_value": (
+                                "M104 S{material_print_temperature_layer_0}\n"
+                                "M140 S{material_bed_temperature_layer_0}\n"
+                            ),
+                        },
+                    },
+                }
+            )
+        )
+
+        # Create a dummy part file so config parses
+        dummy_stl = tmp_path / "part.stl"
+        dummy_stl.write_bytes(b"solid\nendsolid\n")
+
+        stages = ["load", "arrange", "plate", "slice"]
+        toml_lines = [
+            "[pipeline]",
+            "stages = {}".format(
+                json.dumps(stages + (["resolve_templates", "pack"] if has_resolve_stage else []))
+            ),
+            "",
+            "[slicer]",
+            'engine = "cura"',
+            "",
+            "[slicer.cura]",
+            'printer = "bambox_p1s"',
+            "",
+            "[[parts]]",
+            'file = "part.stl"',
+        ]
+        if has_resolve_stage:
+            toml_lines += [
+                "",
+                "[resolve_templates]",
+                'command = "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"',
+                "",
+                "[pack]",
+                'command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"',
+                'output = "{output_dir}/plate.gcode.3mf"',
+            ]
+
+        toml_path = tmp_path / "estampo.toml"
+        toml_path.write_text("\n".join(toml_lines))
+
+        from estampo.config import load_config
+
+        return load_config(toml_path)
+
+    def test_error_when_no_resolve_stage(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._make_cfg(tmp_path, has_resolve_stage=False)
+        warnings: list[str] = []
+        errors: list[str] = []
+        _check_cura_template_gcode(cfg, warnings, errors)
+        assert len(errors) == 1
+        assert "template variables" in errors[0]
+        assert "resolve_templates" in errors[0]
+
+    def test_no_error_when_resolve_stage_present(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._make_cfg(tmp_path, has_resolve_stage=True)
+        warnings: list[str] = []
+        errors: list[str] = []
+        _check_cura_template_gcode(cfg, warnings, errors)
+        assert errors == []
+
+    def test_no_error_when_no_templates(self, tmp_path, monkeypatch):
+        """No error when start gcode has no template variables."""
+        import json
+
+        monkeypatch.chdir(tmp_path)
+        dummy_stl = tmp_path / "part.stl"
+        dummy_stl.write_bytes(b"solid\nendsolid\n")
+        defs_dir = tmp_path / "profiles" / "cura" / "definitions"
+        defs_dir.mkdir(parents=True)
+        (defs_dir / "bambox_p1s.def.json").write_text(
+            json.dumps(
+                {
+                    "name": "Bambu P1S",
+                    "inherits": "fdmprinter",
+                    "overrides": {
+                        "machine_start_gcode": {
+                            "default_value": "G28\nG1 Z5 F3000\n",
+                        },
+                    },
+                }
+            )
+        )
+        toml_path = tmp_path / "estampo.toml"
+        toml_path.write_text(
+            '[pipeline]\nstages = ["load", "arrange", "plate", "slice"]\n'
+            "[slicer]\n"
+            'engine = "cura"\n'
+            "[slicer.cura]\n"
+            'printer = "bambox_p1s"\n'
+            "[[parts]]\n"
+            'file = "part.stl"\n'
+        )
+        from estampo.config import load_config
+
+        cfg = load_config(toml_path)
+        warnings: list[str] = []
+        errors: list[str] = []
+        _check_cura_template_gcode(cfg, warnings, errors)
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# build_config_toml tests (#560)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConfigTomlCommandStages:
+    """Tests for auto-generated command stages in build_config_toml."""
+
+    def test_cura_bambu_adds_resolve_and_pack(self):
+        toml = build_config_toml(
+            engine="cura",
+            printer="bambox_p1s",
+            filaments=["PLA"],
+            parts=["part.stl"],
+        )
+        assert "resolve_templates" in toml
+        assert "cura-p1s resolve" in toml
+        assert "bambox pack" in toml
+        assert '"resolve_templates", "pack"' in toml
+
+    def test_orca_bambu_adds_pack_only(self):
+        toml = build_config_toml(
+            engine="orca",
+            printer="Bambu Lab P1S 0.4 nozzle",
+            filaments=["PLA"],
+            parts=["part.stl"],
+        )
+        assert "resolve_templates" not in toml
+        assert "bambox repack" in toml
+        assert '"pack"' in toml
+
+    def test_non_bambu_no_command_stages(self):
+        toml = build_config_toml(
+            engine="cura",
+            printer="creality_ender3",
+            filaments=["PLA"],
+            parts=["part.stl"],
+        )
+        assert "resolve_templates" not in toml
+        assert "bambox" not in toml
+
+    def test_explicit_stages_with_pack_not_duplicated(self):
+        toml = build_config_toml(
+            engine="cura",
+            printer="bambox_p1s",
+            filaments=["PLA"],
+            parts=["part.stl"],
+            stages=["load", "arrange", "plate", "slice", "pack"],
+        )
+        # Should not add a second pack
+        assert toml.count('"pack"') == 1


### PR DESCRIPTION
## Summary

- **#557**: `estampo validate` now detects CuraEngine template variables (e.g. `{material_bed_temperature_layer_0}`) in start gcode and errors when no `resolve_templates` stage is configured. Without this, unresolved templates cause dangerous printer behavior (heated bed exceeds limit, wrong temperatures).
- **#560**: `build_config_toml` (non-interactive init path) auto-adds `resolve_templates` and `pack` command stages for CuraEngine + Bambu printer configurations, matching the interactive wizard behavior.
- **#559**: AI setup prompt updated to document the required `resolve_templates` stage for CuraEngine + Bambu printers.

Also fixes a bug where `_check_cura_template_gcode` called `.get("command", "")` on a `CommandStageConfig` dataclass (should use `.command` attribute).

Closes #557, closes #559, closes #560

## Test plan
- [x] `_check_cura_template_gcode` errors when templates found and no resolve stage
- [x] No error when resolve_templates stage is present
- [x] No error when start gcode has no template variables
- [x] `build_config_toml` adds resolve_templates + pack for CuraEngine + Bambu
- [x] `build_config_toml` adds pack only (no resolve) for OrcaSlicer + Bambu
- [x] `build_config_toml` adds nothing for non-Bambu printers
- [x] No duplicate pack when stages already include it
- [x] All 592 tests pass, mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)