### PR TITLE
Update ai-setup-prompt validation note

### DIFF
--- a/changes/566.misc
+++ b/changes/566.misc
@@ -1,0 +1,1 @@
+Update ``ai-setup-prompt.md`` validation note to reflect actionable warning messages.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -168,10 +168,10 @@ recognized (with "did you mean?" suggestions for typos and cross-engine
 detection if you accidentally use CuraEngine setting names with OrcaSlicer or
 vice versa).
 
-**Note:** The validation warning "slicer profile names could not be validated"
-is expected when profiles are not installed locally. This is not an error —
-profiles are resolved at runtime via Docker or the bambox package. The warning
-can be safely ignored.
+**Note:** If validation warns that profile names could not be validated, it
+means no profiles are available locally. Run `estampo profiles pin` to extract
+them from the Docker image. Profiles are also resolved at runtime via Docker,
+so this warning is non-blocking.
 
 ### Common override recipes
 


### PR DESCRIPTION
## Summary
- Update the validation warning note in `ai-setup-prompt.md` to reflect the new actionable message format from #565
- Now suggests `estampo profiles pin` instead of saying to ignore the warning

## Test plan
- [ ] Doc-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)