### PR TITLE
Fix import ordering in http-cloud-print.py

### DIFF
--- a/changes/+fix-lint-import-order.misc
+++ b/changes/+fix-lint-import-order.misc
@@ -1,0 +1,1 @@
+Fix import ordering lint error in ``http-cloud-print.py``.

--- a/docs/cloud-experiments/http-cloud-print.py
+++ b/docs/cloud-experiments/http-cloud-print.py
@@ -14,8 +14,9 @@ import time
 import uuid
 from pathlib import Path
 
-from estampo import require_file
 from estampo.cloud.ams import _build_ams_mapping, _strip_gcode_from_3mf
+
+from estampo import require_file
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Fix pre-existing `ruff` I001 (unsorted imports) error in `docs/cloud-experiments/http-cloud-print.py`

## Test plan
- [x] `uv run ruff check src tests docs` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)