### PR TITLE
Add --workflow-only flag to estampo init

### DIFF
--- a/changes/568.feature
+++ b/changes/568.feature
@@ -1,0 +1,1 @@
+Add ``--workflow-only`` flag to ``estampo init`` for generating just the GitHub Actions workflow.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -291,6 +291,28 @@ The action runs the full pipeline, uploads artifacts, and posts build metrics
 pip/pipx tool on the runner** — use the action instead, which has all
 dependencies pre-installed in Docker.
 
+To generate just the workflow file for an existing project:
+```bash
+estampo init --workflow-only
+```
+This requires an existing `estampo.toml` — it will error if the config file is missing.
+
+#### Projects with build scripts (STEP/code-CAD)
+
+If the project generates STL/3MF files from STEP files, OpenSCAD, build123d, or
+CadQuery via a build script, and the generated files are `.gitignore`d, the CI
+runner won't have them. Add a build step before the estampo action:
+
+```yaml
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build models
+        run: python build.py  # or make, ./generate.sh, etc.
+      - uses: estampo/estampo/action@v1
+        with:
+          config: estampo.toml
+```
+
 ### Post-processing for Bambu Lab printers
 
 If the printer is a Bambu Lab printer (P1S, X1C, A1, etc.), you **must** add a

--- a/src/estampo/cli.py
+++ b/src/estampo/cli.py
@@ -438,6 +438,13 @@ def init(
         bool,
         typer.Option("--workflow", help="Generate a GitHub Actions slice workflow"),
     ] = False,
+    workflow_only: Annotated[
+        bool,
+        typer.Option(
+            "--workflow-only",
+            help="Generate only the GitHub Actions workflow (requires existing estampo.toml)",
+        ),
+    ] = False,
     verbose: Annotated[bool, typer.Option("-v", "--verbose", help="Enable debug logging")] = False,
 ) -> None:
     """Create a new estampo.toml config file.
@@ -452,6 +459,22 @@ def init(
     _setup_logging(verbose)
 
     config_path = str(output or "estampo.toml")
+
+    # --workflow-only: just generate the workflow, skip all init processing
+    if workflow_only:
+        config_file = Path(config_path)
+        if not config_file.exists():
+            from estampo import ui
+
+            ui.error(
+                f"'{config_path}' not found — --workflow-only requires an existing config.\n"
+                f"  Fix: run 'estampo init' first to create the config file."
+            )
+            raise typer.Exit(1)
+        from estampo.init import write_workflow
+
+        write_workflow(config_path)
+        return
 
     # Non-interactive mode: all required params provided
     if engine and filament and part:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -152,6 +152,24 @@ class TestWorkflow:
         main(["init", "--template", "--workflow"])
         assert (tmp_path / ".github" / "workflows" / "slice.yml").exists()
 
+    def test_cli_workflow_only_creates_workflow(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "estampo.toml").write_text("[slicer]\nengine = 'orca'\n")
+        main(["init", "--workflow-only"])
+        assert (tmp_path / ".github" / "workflows" / "slice.yml").exists()
+
+    def test_cli_workflow_only_errors_without_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        main(["init", "--workflow-only"])
+        assert not (tmp_path / ".github" / "workflows" / "slice.yml").exists()
+
+    def test_cli_workflow_only_custom_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "custom.toml").write_text("[slicer]\nengine = 'orca'\n")
+        main(["init", "--workflow-only", "--output", "custom.toml"])
+        content = (tmp_path / ".github" / "workflows" / "slice.yml").read_text()
+        assert "config: custom.toml" in content
+
 
 class TestExtractFrom3MF:
     def test_extracts_profiles(self, tmp_path):


### PR DESCRIPTION
## Summary
- Add `--workflow-only` flag to `estampo init` that generates just the GitHub Actions workflow file without running the full init process
- Errors with actionable message if no `estampo.toml` exists
- Documents the build-step pattern in `ai-setup-prompt.md` for projects that `.gitignore` generated STL/3MF files (STEP, OpenSCAD, build123d, CadQuery)

Closes #568

## Test plan
- [x] All 595 tests pass (3 new tests for workflow-only)
- [x] Lint, format, and mypy clean
- [ ] `estampo init --workflow-only` with existing config creates workflow
- [ ] `estampo init --workflow-only` without config shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)