### PR TITLE
Set docker=true on generated command stages and validate executables

### DIFF
--- a/changes/570.bugfix
+++ b/changes/570.bugfix
@@ -1,0 +1,1 @@
+Set ``docker = true`` on generated command stages (resolve_templates, pack) so container-only tools like ``cura-p1s`` run inside the Docker image. Validation now warns when a command stage executable is not on PATH and ``docker`` is not enabled.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -336,15 +336,18 @@ stages = ["load", "arrange", "plate", "slice", "resolve_templates", "pack"]
 
 [resolve_templates]
 command = "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"
+docker = true
 
 [pack]
 command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
 output = "{output_dir}/plate.gcode.3mf"
+docker = true
 ```
 
 **The `resolve_templates` stage is required for CuraEngine + Bambu printers.**
-Without it, `estampo validate` will report an error. The `cura-p1s` package is
-pre-installed in the Docker images.
+Without it, `estampo validate` will report an error. The `cura-p1s` and `bambox`
+tools are pre-installed in the Docker images — `docker = true` runs the command
+inside the slicer container so they don't need to be installed locally.
 
 **OrcaSlicer** (patches the existing `.gcode.3mf` for Bambu Connect compatibility):
 ```toml
@@ -354,11 +357,12 @@ stages = ["load", "arrange", "plate", "slice", "pack"]
 [pack]
 command = "bambox repack {sliced_3mf}"
 output = "{sliced_3mf}"
+docker = true
 ```
 
-Both `bambox pack` and `bambox repack` are pre-installed in the Docker images,
-so no extra installation is needed when using the GitHub Action or `docker run`
-approach above.
+`docker = true` runs the command inside the slicer Docker image where `bambox`
+is pre-installed. This is the default for locally generated configs — no extra
+host-side installation needed.
 
 ### Cloud printing for Bambu Lab printers (optional)
 

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -449,6 +449,19 @@ def validate_config(path: Path) -> ValidationResult:
     if stages_ok:
         passes.append(f"Pipeline: {' → '.join(cfg.pipeline.stages)}")
 
+    # Check command stage executables
+    import shutil
+
+    for stage_name, stage_cfg in cfg.pipeline.command_stages.items():
+        executable = stage_cfg.command.split()[0]
+        if not stage_cfg.docker and shutil.which(executable) is None:
+            warnings.append(
+                f"command stage '{stage_name}' uses '{executable}' which is not "
+                f"on PATH.\n"
+                f"  Fix: add 'docker = true' to [{stage_name}] to run it inside "
+                f"the slicer Docker image, or install '{executable}' locally."
+            )
+
     # Check CuraEngine definitions for unresolved template variables
     if cfg.slicer.engine == "cura" and active.printer and "slice" in cfg.pipeline.stages:
         _check_cura_template_gcode(cfg, warnings, errors)
@@ -516,7 +529,8 @@ def _check_cura_template_gcode(
             f"\n"
             f"    [resolve_templates]\n"
             f'    command = "cura-p1s resolve {{sliced_dir}}/plate.gcode '
-            f'--settings {{cura_settings}}"'
+            f'--settings {{cura_settings}}"\n'
+            f"    docker = true"
         )
 
 
@@ -908,17 +922,20 @@ def _wizard_pick_command_stages(
             stages.append("resolve_templates")
             command_stages["resolve_templates"] = {
                 "command": ("cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"),
+                "docker": True,
             }
             stages.append("pack")
             command_stages["pack"] = {
                 "command": ("bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"),
                 "output": "{output_dir}/plate.gcode.3mf",
+                "docker": True,
             }
         else:
             stages.append("pack")
             command_stages["pack"] = {
                 "command": "bambox repack {sliced_3mf}",
                 "output": "{sliced_3mf}",
+                "docker": True,
             }
     ui.console.print()
     return command_stages
@@ -1377,6 +1394,7 @@ def build_config_toml(
             effective_stages.append("resolve_templates")
             command_stages["resolve_templates"] = {
                 "command": ("cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"),
+                "docker": True,
             }
         effective_stages.append("pack")
         command_stages["pack"] = {
@@ -1384,6 +1402,7 @@ def build_config_toml(
             if engine == "cura"
             else "bambox repack {sliced_3mf}",
             "output": "{output_dir}/plate.gcode.3mf" if engine == "cura" else "{sliced_3mf}",
+            "docker": True,
         }
 
     return _build_toml(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -424,6 +424,7 @@ version = "2.3.1"
 [pack]
 command = "bambox repack {{sliced_3mf}}"
 output = "{{sliced_3mf}}"
+docker = true
 
 [[parts]]
 file = "{_posix(FIXTURES / "cube_10mm.stl")}"
@@ -431,6 +432,49 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         result = validate_config(toml)
         assert not any("unknown" in w for w in result.warnings)
         assert any("pack" in p for p in result.passes)
+
+    def test_missing_executable_warns_without_docker(self, tmp_path):
+        """Warn when command stage executable is not on PATH and docker is not set."""
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[pipeline]
+stages = ["load", "arrange", "plate", "slice", "pack"]
+
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[pack]
+command = "nonexistent_tool_xyz repack {{sliced_3mf}}"
+output = "{{sliced_3mf}}"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        result = validate_config(toml)
+        assert any("nonexistent_tool_xyz" in w and "docker = true" in w for w in result.warnings)
+
+    def test_no_executable_warning_with_docker_true(self, tmp_path):
+        """No warning when docker=true even if executable is not on PATH."""
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[pipeline]
+stages = ["load", "arrange", "plate", "slice", "pack"]
+
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[pack]
+command = "nonexistent_tool_xyz repack {{sliced_3mf}}"
+output = "{{sliced_3mf}}"
+docker = true
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        result = validate_config(toml)
+        assert not any("nonexistent_tool_xyz" in w for w in result.warnings)
 
     def test_override_keys_valid_passes(self, tmp_path):
         """Valid override keys produce a pass message."""
@@ -708,6 +752,7 @@ class TestBuildToml:
                 "pack": {
                     "command": "bambox repack {sliced_3mf}",
                     "output": "{sliced_3mf}",
+                    "docker": True,
                 },
             },
         )
@@ -715,6 +760,7 @@ class TestBuildToml:
         assert "[pack]" in toml
         assert "bambox repack" in toml
         assert 'output = "{sliced_3mf}"' in toml
+        assert "docker = true" in toml
 
     def test_cura_resolve_and_pack_stages(self):
         toml = _build_toml(
@@ -731,12 +777,14 @@ class TestBuildToml:
                     "command": (
                         "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"
                     ),
+                    "docker": True,
                 },
                 "pack": {
                     "command": (
                         "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"
                     ),
                     "output": "{output_dir}/plate.gcode.3mf",
+                    "docker": True,
                 },
             },
         )
@@ -744,6 +792,7 @@ class TestBuildToml:
         assert '"pack"' in toml
         assert "[resolve_templates]" in toml
         assert "cura-p1s resolve" in toml
+        assert "docker = true" in toml
         assert "[pack]" in toml
         assert "bambox pack" in toml
 
@@ -926,10 +975,12 @@ class TestCheckCuraTemplateGcode:
                 "",
                 "[resolve_templates]",
                 'command = "cura-p1s resolve {sliced_dir}/plate.gcode --settings {cura_settings}"',
+                "docker = true",
                 "",
                 "[pack]",
                 'command = "bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"',
                 'output = "{output_dir}/plate.gcode.3mf"',
+                "docker = true",
             ]
 
         toml_path = tmp_path / "estampo.toml"
@@ -948,6 +999,7 @@ class TestCheckCuraTemplateGcode:
         assert len(errors) == 1
         assert "template variables" in errors[0]
         assert "resolve_templates" in errors[0]
+        assert "docker = true" in errors[0]
 
     def test_no_error_when_resolve_stage_present(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -1017,6 +1069,7 @@ class TestBuildConfigTomlCommandStages:
         assert "cura-p1s resolve" in toml
         assert "bambox pack" in toml
         assert '"resolve_templates", "pack"' in toml
+        assert "docker = true" in toml
 
     def test_orca_bambu_adds_pack_only(self):
         toml = build_config_toml(
@@ -1028,6 +1081,7 @@ class TestBuildConfigTomlCommandStages:
         assert "resolve_templates" not in toml
         assert "bambox repack" in toml
         assert '"pack"' in toml
+        assert "docker = true" in toml
 
     def test_non_bambu_no_command_stages(self):
         toml = build_config_toml(


### PR DESCRIPTION
## Summary
- Generated command stages (resolve_templates, pack) now include `docker = true` so container-only tools like `cura-p1s` and `bambox` run inside the slicer Docker image instead of failing with "not found on PATH"
- `estampo validate` now warns when a command stage executable is not on PATH and `docker` is not enabled, with an actionable fix suggestion
- Updated the validation fix suggestion for missing resolve_templates to include `docker = true`
- Updated `ai-setup-prompt.md` examples to show `docker = true` on all command stages

Closes #570

## Test plan
- [x] All 597 tests pass (2 new tests for executable validation)
- [x] Lint, format, and mypy clean
- [ ] `estampo init` with CuraEngine + Bambu printer generates TOML with `docker = true`
- [ ] `estampo validate` warns when command stage executable missing without docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)