### PR TITLE
Update bambox to 0.4.4 in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG ORCA_VERSION=2.3.1
 # ---------------------------------------------------------------------------
 FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
 
-ARG BAMBOX_VERSION=0.4.2
+ARG BAMBOX_VERSION=0.4.4
 ARG BAMBU_SLICER_VERSION=02.05.00.00
 ARG BNL_TOKEN=""
 
@@ -58,6 +58,8 @@ RUN curl -fSL -o /out/cert/slicer_base64.cer \
 # ---------------------------------------------------------------------------
 FROM estampo/orca-base:${ORCA_VERSION}
 
+ARG BAMBOX_VERSION=0.4.4
+
 LABEL org.opencontainers.image.description="estampo with OrcaSlicer ${ORCA_VERSION}"
 
 # bambox-bridge + libbambu_networking.so + TLS cert
@@ -87,7 +89,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # dependency, but bundled so command stages like `bambox repack` work
 # inside the container without requiring host-side installation).
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install bambox --python /opt/estampo/.venv/bin/python
+    uv pip install "bambox==${BAMBOX_VERSION}" --python /opt/estampo/.venv/bin/python
 
 ENV PATH="/opt/estampo/.venv/bin:$PATH"
 

--- a/Dockerfile.cura
+++ b/Dockerfile.cura
@@ -16,7 +16,7 @@ ARG CURA_VERSION=5.12.0
 # ---------------------------------------------------------------------------
 FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
 
-ARG BAMBOX_VERSION=0.4.2
+ARG BAMBOX_VERSION=0.4.4
 ARG BAMBU_SLICER_VERSION=02.05.00.00
 ARG BNL_TOKEN=""
 
@@ -59,6 +59,8 @@ RUN curl -fSL -o /out/cert/slicer_base64.cer \
 # ---------------------------------------------------------------------------
 FROM estampo/cura-base:${CURA_VERSION}
 
+ARG BAMBOX_VERSION=0.4.4
+
 USER root
 
 LABEL org.opencontainers.image.description="estampo with CuraEngine ${CURA_VERSION}"
@@ -98,7 +100,7 @@ RUN chmod a+rx /root /root/.local /root/.local/share /root/.local/share/uv \
 # resolver for CuraEngine) from GitHub archive and copy definitions into
 # CuraEngine's search path.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install bambox \
+    uv pip install "bambox==${BAMBOX_VERSION}" \
         "cura-p1s @ https://github.com/estampo/cura-p1s/archive/refs/heads/main.zip" \
         --python /opt/estampo/.venv/bin/python \
     && cp /opt/estampo/.venv/lib/python3.12/site-packages/cura_p1s/data/bambox_p1s.def.json \

--- a/changes/+bambox-0.4.4.misc
+++ b/changes/+bambox-0.4.4.misc
@@ -1,0 +1,1 @@
+Bundle bambox 0.4.4 in Docker images (bambox-bridge binary and Python package).


### PR DESCRIPTION
## Summary
- Bump `BAMBOX_VERSION` from 0.4.2 → 0.4.4 in `Dockerfile` and `Dockerfile.cura`
- Pin the bundled `bambox` pip install to the same version so the bridge binary and Python package stay in lockstep

Closes #574

## Test plan
- [x] `uv run ruff check src tests` — passes
- [x] `uv run ruff format --check src tests` — passes
- [x] `uv run mypy src/estampo` — passes
- [x] `uv run pytest` — 599 passed, 9 skipped
- [ ] CI `publish-docker.yml` builds the new image on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)