### PR TITLE
Copy bambox_p1s_ams.def.json into CuraEngine Docker image

### DIFF
--- a/Dockerfile.cura
+++ b/Dockerfile.cura
@@ -105,6 +105,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --python /opt/estampo/.venv/bin/python \
     && cp /opt/estampo/.venv/lib/python3.12/site-packages/cura_p1s/data/bambox_p1s.def.json \
           /opt/cura/definitions/ \
+    && cp /opt/estampo/.venv/lib/python3.12/site-packages/cura_p1s/data/bambox_p1s_ams.def.json \
+          /opt/cura/definitions/ \
     && cp /opt/estampo/.venv/lib/python3.12/site-packages/cura_p1s/data/bambox_p1s_extruder_0.def.json \
           /opt/cura/extruders/
 

--- a/changes/577.bugfix
+++ b/changes/577.bugfix
@@ -1,0 +1,1 @@
+Copy ``bambox_p1s_ams.def.json`` into the CuraEngine Docker image so the AMS variant of the P1S printer definition is resolvable by ``estampo profiles pin``.


### PR DESCRIPTION
## Summary
- \`Dockerfile.cura\` installs cura-p1s 0.1.1 but only copied the non-AMS \`bambox_p1s.def.json\` into \`/opt/cura/definitions/\`
- Result in v0.4.0b2: \`estampo profiles pin\` with \`printer = \"bambox_p1s_ams\"\` fails with \"CuraEngine definition 'bambox_p1s_ams' not found\"
- Add the missing \`cp\` line so the AMS variant is exposed on CuraEngine's search path

Closes #577

## Test plan
- [ ] CI green
- [ ] After release, \`estampo profiles pin\` with \`printer = \"bambox_p1s_ams\"\` resolves the definition