### PR TITLE
Release v0.4.0b3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 <!-- towncrier release notes start -->
 
+## 0.4.0b3 — 2026-04-18
+
+### Bugfixes
+
+- Copy ``bambox_p1s_ams.def.json`` into the CuraEngine Docker image so the AMS variant of the P1S printer definition is resolvable by ``estampo profiles pin``. ([#577](https://github.com/estampo/estampo/pull/577))
+- ``estampo profiles pin`` now resolves printer definitions from ``profiles/cura/definitions/`` (where ``profiles add`` drops them) before falling back to bundled data or the CuraEngine Docker image, so user-added variants can be pinned without re-extracting from Docker. ([#579](https://github.com/estampo/estampo/pull/579))
+
+
 ## 0.4.0b2 — 2026-04-18
 
 ### Features

--- a/changes/577.bugfix
+++ b/changes/577.bugfix
@@ -1,1 +1,0 @@
-Copy ``bambox_p1s_ams.def.json`` into the CuraEngine Docker image so the AMS variant of the P1S printer definition is resolvable by ``estampo profiles pin``.

--- a/changes/579.bugfix
+++ b/changes/579.bugfix
@@ -1,1 +1,0 @@
-``estampo profiles pin`` now resolves printer definitions from ``profiles/cura/definitions/`` (where ``profiles add`` drops them) before falling back to bundled data or the CuraEngine Docker image, so user-added variants can be pinned without re-extracting from Docker.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estampo"
-version = "0.4.0b2"
+version = "0.4.0b3"
 description = "The build system for reproducible 3D prints. Define parts, slicer settings, and printer targets in code."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release v0.4.0b3


### Bugfixes

- Copy ``bambox_p1s_ams.def.json`` into the CuraEngine Docker image so the AMS variant of the P1S printer definition is resolvable by ``estampo profiles pin``. ([#577](https://github.com/estampo/estampo/pull/577))
- ``estampo profiles pin`` now resolves printer definitions from ``profiles/cura/definitions/`` (where ``profiles add`` drops them) before falling back to bundled data or the CuraEngine Docker image, so user-added variants can be pinned without re-extracting from Docker. ([#579](https://github.com/estampo/estampo/pull/579))

---
**Merge this PR to trigger the release pipeline.**
The release workflow will auto-tag `v0.4.0b3`, build all artifacts, validate on TestPyPI, then publish to PyPI + Docker Hub + GHCR.