### PR TITLE
Strip Cura `value` expressions that override user settings

### DIFF
--- a/changes/584.bugfix
+++ b/changes/584.bugfix
@@ -1,0 +1,1 @@
+Fix CuraEngine user overrides being silently ignored when the pinned printer definition has a matching ``value`` expression (e.g. ``adhesion_type = "brim"`` losing to a def-level ``"value": "'skirt'"``).

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -932,6 +932,41 @@ def _write_cura_settings(
     return settings_path
 
 
+def _strip_value_overrides(staging: Path, setting_keys: set[str]) -> None:
+    """Strip ``value`` expressions from staged defs for settings we pass via ``-s``.
+
+    CuraEngine ``value`` expressions in ``.def.json`` take precedence over
+    ``-s`` command-line flags, silently dropping user overrides (see #584).
+    For any key we're about to pass via ``-s``, remove the ``value`` entry
+    from matching override blocks in every staged def so ``-s`` actually wins.
+    ``default_value`` is left intact.
+    """
+    for def_path in staging.glob("*.def.json"):
+        try:
+            data = json.loads(def_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        overrides = data.get("overrides", {})
+        if not isinstance(overrides, dict):
+            continue
+        changed = False
+        for key in setting_keys:
+            entry = overrides.get(key)
+            if isinstance(entry, dict) and "value" in entry:
+                del entry["value"]
+                changed = True
+        if changed:
+            def_path.write_text(json.dumps(data, indent=4))
+
+
+def _profile_setting_keys(profile: CuraProfile) -> set[str]:
+    """Return every setting key we pass via ``-s`` for *profile*."""
+    keys = set(_settings_dict(profile).keys())
+    for ext_overrides in profile.per_extruder:
+        keys.update(ext_overrides.keys())
+    return keys
+
+
 def _prepare_cura_staging(
     printer: str | None,
     project_dir: Path | None,
@@ -1162,6 +1197,7 @@ def slice_stl(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     staging, machine_def = _prepare_cura_staging(printer, project_dir, profiles_dir, output_dir)
+    _strip_value_overrides(staging, _profile_setting_keys(profile))
 
     # Get machine dimensions for mesh centering and settings JSON
     machine_dims = resolve_cura_machine_dims(printer or "", project_dir, profiles_dir)
@@ -1253,6 +1289,7 @@ def slice_stl_multi(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     staging, machine_def = _prepare_cura_staging(printer, project_dir, profiles_dir, output_dir)
+    _strip_value_overrides(staging, _profile_setting_keys(profile))
 
     # Get machine dimensions for settings JSON
     machine_dims = resolve_cura_machine_dims(printer or "", project_dir, profiles_dir)

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -13,11 +13,13 @@ from estampo.cura import (
     _fetch_printer_def,
     _patch_gcode_header,
     _place_on_bed,
+    _profile_setting_keys,
     _resolve_def_chain,
     _resolve_def_name,
     _settings_dict,
     _settings_flags,
     _squash_cura_def,
+    _strip_value_overrides,
     _write_cura_settings,
     cura_docker_image,
     cura_profile_from_config,
@@ -343,6 +345,64 @@ def test_bundled_def_path_returns_path():
     path = _bundled_def_path("some_printer.def.json")
     assert path.name == "some_printer.def.json"
     assert "data" in str(path)
+
+
+# --- _strip_value_overrides (#584) ---
+
+
+def test_strip_value_overrides_removes_value_for_overridden_key(tmp_path):
+    """``value`` is removed for keys we pass via ``-s`` so the flag wins."""
+    import json
+
+    def_path = tmp_path / "printer.def.json"
+    def_path.write_text(
+        json.dumps(
+            {
+                "overrides": {
+                    "adhesion_type": {"value": "'skirt'"},
+                    "brim_width": {"default_value": 3, "value": "machine_width / 10"},
+                    "machine_width": {"value": 256},
+                }
+            }
+        )
+    )
+
+    _strip_value_overrides(tmp_path, {"adhesion_type", "brim_width"})
+
+    data = json.loads(def_path.read_text())
+    overrides = data["overrides"]
+    # `value` removed for overridden keys
+    assert "value" not in overrides["adhesion_type"]
+    assert "value" not in overrides["brim_width"]
+    # `default_value` preserved
+    assert overrides["brim_width"]["default_value"] == 3
+    # Non-overridden keys untouched
+    assert overrides["machine_width"]["value"] == 256
+
+
+def test_strip_value_overrides_ignores_missing_keys(tmp_path):
+    """Keys not present in the def are silently skipped."""
+    import json
+
+    def_path = tmp_path / "printer.def.json"
+    original = {"overrides": {"machine_width": {"value": 256}}}
+    def_path.write_text(json.dumps(original))
+
+    _strip_value_overrides(tmp_path, {"adhesion_type"})
+
+    assert json.loads(def_path.read_text()) == original
+
+
+def test_profile_setting_keys_includes_per_extruder():
+    """Per-extruder override keys show up alongside global settings."""
+    profile = CuraProfile()
+    profile.overrides = {"adhesion_type": "brim"}
+    profile.per_extruder = [{"material_type": "PLA"}, {"material_type": "PETG"}]
+
+    keys = _profile_setting_keys(profile)
+    assert "adhesion_type" in keys
+    assert "material_type" in keys
+    assert "layer_height" in keys  # from base settings dict
 
 
 # --- slice_stl Docker execution ---


### PR DESCRIPTION
## Summary

- CuraEngine ``value`` expressions in ``.def.json`` take precedence over ``-s`` CLI flags, silently dropping user overrides from ``[slicer.cura.overrides]``. Observed in `pzfreo/g3d` where `adhesion_type = "brim"` was ignored because the pinned `bambox_p1s_ams.def.json` has `"adhesion_type": {"value": "'skirt'"}`.
- After staging, strip ``value`` from every override entry whose key we pass via ``-s`` (``default_value`` is left intact). Same theme as the existing `infill_line_distance` workaround at `cura.py:767`.

## Test plan

- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] `uv run mypy src/estampo`
- [x] `uv run pytest` (603 passed, 9 skipped)
- [x] New unit tests:
  - `test_strip_value_overrides_removes_value_for_overridden_key`
  - `test_strip_value_overrides_ignores_missing_keys`
  - `test_profile_setting_keys_includes_per_extruder`

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)