### PR TITLE
Pass machine dimensions as -s flags to CuraEngine (#586)

### DIFF
--- a/changes/586.bugfix
+++ b/changes/586.bugfix
@@ -1,0 +1,1 @@
+Pass ``machine_width``/``machine_depth``/``machine_height`` as ``-s`` flags so CuraEngine's bed size agrees with mesh placement; fixes silently-dropped brim when the pinned def declares bed dims with ``value`` only.

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -811,6 +811,26 @@ def _settings_flags(profile: CuraProfile) -> list[str]:
     return flags
 
 
+def _machine_dims_flags(machine_dims: dict[str, float]) -> list[str]:
+    """Build -s flags for machine bed dimensions.
+
+    Pinned definitions commonly declare bed size with ``value`` only and
+    no ``default_value``.  CuraEngine logs "has no [default_]value!" for
+    these fields and silently falls back to the fdmprinter defaults
+    (100×100).  ``_place_on_bed`` reads the ``value`` directly, so the
+    mesh gets centred for the real bed and ends up off the bed CuraEngine
+    thinks it has — which silently drops brim/skirt generation (see #586).
+
+    Passing the dims as ``-s`` flags keeps CuraEngine in sync with mesh
+    placement regardless of how the def declares them.
+    """
+    flags: list[str] = []
+    for key in ("machine_width", "machine_depth", "machine_height"):
+        if key in machine_dims:
+            flags.extend(["-s", f"{key}={machine_dims[key]}"])
+    return flags
+
+
 def _extruder_settings_list(profile: CuraProfile, ext_idx: int) -> list[str]:
     """Build ``-s key=value`` args list for one extruder's ``-g -eN`` block.
 
@@ -1206,7 +1226,7 @@ def slice_stl(
     # Place mesh on the build plate (Z>=0, centered) before slicing.
     staged_stl = _place_on_bed(stl_path, staging, bed_width=bed_w, bed_depth=bed_d)
 
-    settings = _settings_flags(profile)
+    settings = _settings_flags(profile) + _machine_dims_flags(machine_dims)
 
     if local:
         _check_local_def(staging, machine_def, printer)
@@ -1300,6 +1320,8 @@ def slice_stl_multi(
         if not dest.exists():
             shutil.copy2(stl_path, dest)
 
+    global_flags = _settings_flags(profile) + _machine_dims_flags(machine_dims)
+
     if local:
         _check_local_def(staging, machine_def, printer)
         cura_args: list[str] = [
@@ -1309,7 +1331,7 @@ def slice_stl_multi(
             str(staging / machine_def),
             "-o",
             str(output_dir / "plate.gcode"),
-            *_settings_flags(profile),
+            *global_flags,
         ]
         for ext_idx, stl_path in stl_meshes:
             cura_args.extend(["-g", f"-e{ext_idx}"])
@@ -1320,7 +1342,7 @@ def slice_stl_multi(
     c_staging = "/work/output/.cura-staging"
     c_output = "/work/output/plate.gcode"
 
-    global_settings_str = " ".join(f'"{s}"' for s in _settings_flags(profile))
+    global_settings_str = " ".join(f'"{s}"' for s in global_flags)
 
     mesh_groups = ""
     for ext_idx, stl_path in stl_meshes:

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -11,6 +11,7 @@ from estampo.cura import (
     _check_local_def,
     _extruder_settings_str,
     _fetch_printer_def,
+    _machine_dims_flags,
     _patch_gcode_header,
     _place_on_bed,
     _profile_setting_keys,
@@ -393,6 +394,27 @@ def test_strip_value_overrides_ignores_missing_keys(tmp_path):
     assert json.loads(def_path.read_text()) == original
 
 
+def test_machine_dims_flags_emits_s_flags():
+    """All three bed dims are emitted as -s flags."""
+    flags = _machine_dims_flags(
+        {"machine_width": 256.0, "machine_depth": 200.0, "machine_height": 250.0}
+    )
+    assert flags == [
+        "-s",
+        "machine_width=256.0",
+        "-s",
+        "machine_depth=200.0",
+        "-s",
+        "machine_height=250.0",
+    ]
+
+
+def test_machine_dims_flags_skips_missing_keys():
+    """Missing dim keys are omitted from the flag list."""
+    flags = _machine_dims_flags({"machine_width": 256.0})
+    assert flags == ["-s", "machine_width=256.0"]
+
+
 def test_profile_setting_keys_includes_per_extruder():
     """Per-extruder override keys show up alongside global settings."""
     profile = CuraProfile()
@@ -474,6 +496,10 @@ def test_slice_stl_docker_command(tmp_path):
     inner_cmd = cmd[-1]
     assert "test_printer.def.json" in inner_cmd
     assert "-g -e0" in inner_cmd
+    # #586: machine dims must be passed as -s flags so CuraEngine's bed size
+    # agrees with _place_on_bed; otherwise brim/skirt is silently dropped.
+    assert "machine_width=256" in inner_cmd
+    assert "machine_depth=256" in inner_cmd
 
 
 def test_slice_stl_docker_failure(tmp_path):


### PR DESCRIPTION
## Summary

- CuraEngine ignored `value`-only def fields (`machine_width`, `machine_depth`) and fell back to fdmprinter's 100×100 bed, while `_place_on_bed` centred the mesh for the real 256×256 bed — result: mesh off-bed from CuraEngine's view, brim silently dropped.
- Pass `machine_width`/`machine_depth`/`machine_height` as explicit `-s` flags so CuraEngine and mesh placement agree on bed size regardless of how the def declares them.

## Test plan

- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] `uv run mypy src/estampo`
- [x] `uv run pytest` (605 passed, 9 skipped)
- [x] End-to-end repro with user's 256-bed def + centered mesh: `;TYPE:SKIRT` now generated at LAYER:0

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)