### PR TITLE
Promote literal CuraEngine value overrides to default_value (#587)

### DIFF
--- a/changes/587.bugfix
+++ b/changes/587.bugfix
@@ -1,0 +1,1 @@
+Promote literal ``value`` overrides to ``default_value`` when pinning CuraEngine defs, so settings like ``relative_extrusion``, ``retraction_amount``, ``speed_print``, and the machine dimensions are no longer silently dropped and replaced with fdmprinter defaults.

--- a/examples-old/cura-ams-p1s/profiles/cura/definitions/bambox_p1s_ams.def.json
+++ b/examples-old/cura-ams-p1s/profiles/cura/definitions/bambox_p1s_ams.def.json
@@ -2,8 +2,7 @@
     "version": 2,
     "name": "Bambu Lab P1S AMS (bambox)",
     "inherits": "fdmprinter",
-    "metadata":
-    {
+    "metadata": {
         "visible": true,
         "author": "bambox",
         "manufacturer": "Bambu Lab",
@@ -12,78 +11,151 @@
         "has_textured_buildplate": true,
         "has_variant_buildplates": false,
         "has_variants": false,
-        "machine_extruder_trains":
-        {
+        "machine_extruder_trains": {
             "0": "bambox_p1s_ams_extruder_0",
             "1": "bambox_p1s_ams_extruder_1",
             "2": "bambox_p1s_ams_extruder_2",
             "3": "bambox_p1s_ams_extruder_3"
         }
     },
-    "overrides":
-    {
-        "machine_name": { "default_value": "Bambu Lab P1S" },
-        "machine_width": { "value": 256 },
-        "machine_depth": { "value": 256 },
-        "machine_height": { "value": 250 },
-        "machine_heated_bed": { "default_value": true },
-        "machine_center_is_zero": { "default_value": false },
-        "machine_gcode_flavor": { "default_value": "Marlin" },
-        "machine_extruder_count": { "value": 4 },
-
-        "machine_nozzle_size": { "default_value": 0.4 },
-        "material_diameter": { "default_value": 1.75 },
-        "machine_nozzle_cool_down_speed": { "default_value": 1.3 },
-        "machine_nozzle_heat_up_speed": { "default_value": 1.9 },
-
-        "machine_max_feedrate_x": { "value": 500 },
-        "machine_max_feedrate_y": { "value": 500 },
-        "machine_max_feedrate_z": { "value": 15 },
-        "machine_max_feedrate_e": { "value": 150 },
-        "machine_max_jerk_xy": { "default_value": 5000 },
-        "machine_max_jerk_z": { "default_value": 100 },
-        "machine_max_jerk_e": { "default_value": 100 },
-        "machine_acceleration": { "value": 10000 },
-
-        "acceleration_print": { "value": 20000 },
-        "acceleration_travel": { "value": 20000 },
-        "acceleration_layer_0": { "value": 2000 },
-        "speed_print": { "maximum_value_warning": 500, "value": 300 },
-        "speed_layer_0": { "maximum_value_warning": 500, "value": "speed_print/6" },
-
-        "relative_extrusion": { "value": true },
-        "retraction_amount": { "value": 0.5 },
-        "retraction_speed": { "value": 30 },
-        "retraction_prime_speed": { "value": 15 },
-        "retraction_hop": { "value": 0.2 },
-        "retraction_hop_enabled": { "value": true },
-        "retraction_hop_after_extruder_switch_height": { "value": 2 },
-
-        "line_width": { "value": 0.42 },
-        "infill_sparse_density": { "value": 15 },
-        "infill_pattern": { "value": "'zigzag' if infill_sparse_density > 80 else 'gyroid'" },
-        "adhesion_type": { "value": "'skirt'" },
-        "skirt_line_count": { "value": 5 },
-
-        "prime_tower_enable": { "default_value": true },
-        "prime_tower_size": { "default_value": 40 },
-        "prime_tower_min_volume": { "default_value": 250 },
-
-        "roofing_layer_count": { "default_value": 0 },
-        "flooring_layer_count": { "default_value": 0 },
-
-        "machine_buildplate_type":
-        {
+    "overrides": {
+        "machine_name": {
+            "default_value": "Bambu Lab P1S"
+        },
+        "machine_width": {
+            "default_value": 256
+        },
+        "machine_depth": {
+            "default_value": 256
+        },
+        "machine_height": {
+            "default_value": 250
+        },
+        "machine_heated_bed": {
+            "default_value": true
+        },
+        "machine_center_is_zero": {
+            "default_value": false
+        },
+        "machine_gcode_flavor": {
+            "default_value": "Marlin"
+        },
+        "machine_extruder_count": {
+            "default_value": 4
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        },
+        "machine_nozzle_cool_down_speed": {
+            "default_value": 1.3
+        },
+        "machine_nozzle_heat_up_speed": {
+            "default_value": 1.9
+        },
+        "machine_max_feedrate_x": {
+            "default_value": 500
+        },
+        "machine_max_feedrate_y": {
+            "default_value": 500
+        },
+        "machine_max_feedrate_z": {
+            "default_value": 15
+        },
+        "machine_max_feedrate_e": {
+            "default_value": 150
+        },
+        "machine_max_jerk_xy": {
+            "default_value": 5000
+        },
+        "machine_max_jerk_z": {
+            "default_value": 100
+        },
+        "machine_max_jerk_e": {
+            "default_value": 100
+        },
+        "machine_acceleration": {
+            "default_value": 10000
+        },
+        "acceleration_print": {
+            "default_value": 20000
+        },
+        "acceleration_travel": {
+            "default_value": 20000
+        },
+        "acceleration_layer_0": {
+            "default_value": 2000
+        },
+        "speed_print": {
+            "maximum_value_warning": 500,
+            "default_value": 300
+        },
+        "speed_layer_0": {
+            "maximum_value_warning": 500,
+            "value": "speed_print/6"
+        },
+        "relative_extrusion": {
+            "default_value": true
+        },
+        "retraction_amount": {
+            "default_value": 0.5
+        },
+        "retraction_speed": {
+            "default_value": 30
+        },
+        "retraction_prime_speed": {
+            "default_value": 15
+        },
+        "retraction_hop": {
+            "default_value": 0.2
+        },
+        "retraction_hop_enabled": {
+            "default_value": true
+        },
+        "retraction_hop_after_extruder_switch_height": {
+            "default_value": 2
+        },
+        "line_width": {
+            "default_value": 0.42
+        },
+        "infill_sparse_density": {
+            "default_value": 15
+        },
+        "infill_pattern": {
+            "value": "'zigzag' if infill_sparse_density > 80 else 'gyroid'"
+        },
+        "adhesion_type": {
+            "default_value": "skirt"
+        },
+        "skirt_line_count": {
+            "default_value": 5
+        },
+        "prime_tower_enable": {
+            "default_value": true
+        },
+        "prime_tower_size": {
+            "default_value": 40
+        },
+        "prime_tower_min_volume": {
+            "default_value": 250
+        },
+        "roofing_layer_count": {
+            "default_value": 0
+        },
+        "flooring_layer_count": {
+            "default_value": 0
+        },
+        "machine_buildplate_type": {
             "default_value": "textured_pei_plate",
-            "options":
-            {
+            "options": {
                 "cool_plate": "Cool Plate",
                 "engineering_plate": "Engineering Plate",
                 "high_temp_plate": "High Temp Plate",
                 "textured_pei_plate": "Textured PEI Plate"
             }
         },
-
         "machine_start_gcode": {
             "default_value": "; BAMBOX_PRINTER=p1s\n; BAMBOX_EXTRUDERS=4\n; BAMBOX_BED_TEMP={material_bed_temperature_layer_0}\n; BAMBOX_NOZZLE_TEMP={material_print_temperature_layer_0}\n; BAMBOX_NOZZLE_DIAMETER={machine_nozzle_size}\n; BAMBOX_BED_TYPE={machine_buildplate_type}\n; BAMBOX_ASSEMBLE=true\n"
         },

--- a/examples/cura-p1s/profiles/cura/definitions/bambox_p1s.def.json
+++ b/examples/cura-p1s/profiles/cura/definitions/bambox_p1s.def.json
@@ -2,8 +2,7 @@
     "version": 2,
     "name": "Bambu Lab P1S (bambox)",
     "inherits": "fdmprinter",
-    "metadata":
-    {
+    "metadata": {
         "visible": true,
         "author": "bambox",
         "manufacturer": "Bambu Lab",
@@ -12,75 +11,141 @@
         "has_textured_buildplate": true,
         "has_variant_buildplates": false,
         "has_variants": false,
-        "machine_extruder_trains":
-        {
+        "machine_extruder_trains": {
             "0": "bambox_p1s_extruder_0"
         }
     },
-    "overrides":
-    {
-        "machine_name": { "default_value": "Bambu Lab P1S" },
-        "machine_width": { "value": 256 },
-        "machine_depth": { "value": 256 },
-        "machine_height": { "value": 250 },
-        "machine_heated_bed": { "default_value": true },
-        "machine_center_is_zero": { "default_value": false },
-        "machine_gcode_flavor": { "default_value": "Marlin" },
-        "machine_extruder_count": { "value": 1 },
-
-        "machine_nozzle_size": { "default_value": 0.4 },
-        "material_diameter": { "default_value": 1.75 },
-        "machine_nozzle_cool_down_speed": { "default_value": 1.3 },
-        "machine_nozzle_heat_up_speed": { "default_value": 1.9 },
-
-        "machine_max_feedrate_x": { "value": 500 },
-        "machine_max_feedrate_y": { "value": 500 },
-        "machine_max_feedrate_z": { "value": 15 },
-        "machine_max_feedrate_e": { "value": 150 },
-        "machine_max_jerk_xy": { "default_value": 5000 },
-        "machine_max_jerk_z": { "default_value": 100 },
-        "machine_max_jerk_e": { "default_value": 100 },
-        "machine_acceleration": { "value": 10000 },
-
-        "acceleration_print": { "value": 20000 },
-        "acceleration_travel": { "value": 20000 },
-        "acceleration_layer_0": { "value": 2000 },
-        "speed_print": { "maximum_value_warning": 500, "value": 300 },
-        "speed_layer_0": { "maximum_value_warning": 500, "value": "speed_print/6" },
-
-        "relative_extrusion": { "value": true },
-        "retraction_amount": { "value": 0.5 },
-        "retraction_speed": { "value": 30 },
-        "retraction_prime_speed": { "value": 15 },
-        "retraction_hop": { "value": 0.2 },
-        "retraction_hop_enabled": { "value": true },
-
-        "line_width": { "value": 0.42 },
-        "infill_sparse_density": { "value": 15 },
-        "infill_pattern": { "value": "'zigzag' if infill_sparse_density > 80 else 'gyroid'" },
-        "adhesion_type": { "value": "'skirt'" },
-        "skirt_line_count": { "value": 5 },
-
-        "roofing_layer_count": { "default_value": 0 },
-        "flooring_layer_count": { "default_value": 0 },
-
-        "machine_buildplate_type":
-        {
+    "overrides": {
+        "machine_name": {
+            "default_value": "Bambu Lab P1S"
+        },
+        "machine_width": {
+            "default_value": 256
+        },
+        "machine_depth": {
+            "default_value": 256
+        },
+        "machine_height": {
+            "default_value": 250
+        },
+        "machine_heated_bed": {
+            "default_value": true
+        },
+        "machine_center_is_zero": {
+            "default_value": false
+        },
+        "machine_gcode_flavor": {
+            "default_value": "Marlin"
+        },
+        "machine_extruder_count": {
+            "default_value": 1
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        },
+        "machine_nozzle_cool_down_speed": {
+            "default_value": 1.3
+        },
+        "machine_nozzle_heat_up_speed": {
+            "default_value": 1.9
+        },
+        "machine_max_feedrate_x": {
+            "default_value": 500
+        },
+        "machine_max_feedrate_y": {
+            "default_value": 500
+        },
+        "machine_max_feedrate_z": {
+            "default_value": 15
+        },
+        "machine_max_feedrate_e": {
+            "default_value": 150
+        },
+        "machine_max_jerk_xy": {
+            "default_value": 5000
+        },
+        "machine_max_jerk_z": {
+            "default_value": 100
+        },
+        "machine_max_jerk_e": {
+            "default_value": 100
+        },
+        "machine_acceleration": {
+            "default_value": 10000
+        },
+        "acceleration_print": {
+            "default_value": 20000
+        },
+        "acceleration_travel": {
+            "default_value": 20000
+        },
+        "acceleration_layer_0": {
+            "default_value": 2000
+        },
+        "speed_print": {
+            "maximum_value_warning": 500,
+            "default_value": 300
+        },
+        "speed_layer_0": {
+            "maximum_value_warning": 500,
+            "value": "speed_print/6"
+        },
+        "relative_extrusion": {
+            "default_value": true
+        },
+        "retraction_amount": {
+            "default_value": 0.5
+        },
+        "retraction_speed": {
+            "default_value": 30
+        },
+        "retraction_prime_speed": {
+            "default_value": 15
+        },
+        "retraction_hop": {
+            "default_value": 0.2
+        },
+        "retraction_hop_enabled": {
+            "default_value": true
+        },
+        "line_width": {
+            "default_value": 0.42
+        },
+        "infill_sparse_density": {
+            "default_value": 15
+        },
+        "infill_pattern": {
+            "value": "'zigzag' if infill_sparse_density > 80 else 'gyroid'"
+        },
+        "adhesion_type": {
+            "default_value": "skirt"
+        },
+        "skirt_line_count": {
+            "default_value": 5
+        },
+        "roofing_layer_count": {
+            "default_value": 0
+        },
+        "flooring_layer_count": {
+            "default_value": 0
+        },
+        "machine_buildplate_type": {
             "default_value": "textured_pei_plate",
-            "options":
-            {
+            "options": {
                 "cool_plate": "Cool Plate",
                 "engineering_plate": "Engineering Plate",
                 "high_temp_plate": "High Temp Plate",
                 "textured_pei_plate": "Textured PEI Plate"
             }
         },
-
         "machine_start_gcode": {
             "default_value": ";===== machine: P1S-0.4 (native, single extruder) ===\n;===== date: 20251031 =====================\n;===== turn on the HB fan & MC board fan =================\nM104 S75 ;set extruder temp to turn on the HB fan and prevent filament oozing from nozzle\nM710 A1 S255 ;turn on MC fan by default(P1S)\n;===== reset machine status =================\nM290 X40 Y40 Z2.6666666\nG91\nM17 Z0.4 ; lower the z-motor current\nG380 S2 Z30 F300 ; G380 is same as G38; lower the hotbed , to prevent the nozzle is below the hotbed\nG380 S2 Z-25 F300 ;\nG1 Z5 F300;\nG90\nM17 X1.2 Y1.2 Z0.75 ; reset motor current to default\nM960 S5 P1 ; turn on logo lamp\nG90\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nM73.2   R1.0 ;Reset left time magnitude\nM1002 set_gcode_claim_speed_level : 5\nM221 X0 Y0 Z0 ; turn off soft endstop to prevent protential logic problem\nG29.1 Z0.0 ; clear z-trim value first\nM204 S10000 ; init ACC set to 10m/s^2\n\n;===== heatbed preheat ====================\nM1002 gcode_claim_action:54\nM140 S{material_bed_temperature_layer_0} ;set bed temp\nM190 S{material_bed_temperature_layer_0} ;wait for bed temp\n\n\n\n;=============turn on fans to prevent PLA jamming=================\n{if material_type == \"PLA\"}\n{if material_bed_temperature_layer_0 > 45}\nM106 P3 S180\n{endif}\n;Prevent PLA from jamming\n{endif}\nM106 P2 S100 ; turn on big fan ,to cool down toolhead\n\n;===== prepare print temperature and material ==========\nM104 S{material_print_temperature_layer_0} ;set extruder temp\nG91\nG0 Z10 F1200\nG90\nG28 X\nM975 S1 ; turn on\nG1 X60 F12000\nG1 Y245\nG1 Y265 F3000\nM620 M\nM620 S0A   ; switch material if AMS exist\n    M109 S{material_print_temperature_layer_0}\n    G1 X120 F12000\n\n    G1 X20 Y50 F12000\n    G1 Y-3\n    T0\n    G1 X54 F12000\n    G1 Y265\n    M400\nM621 S0A\nM620.1 E F{material_print_temperature} T{material_print_temperature}\n\n\nM412 S1 ; ===turn on filament runout detection===\n\nM109 S250 ;set nozzle to common flush temp\nM106 P1 S0\nG92 E0\nG1 E50 F200\nM400\nM104 S{material_print_temperature_layer_0}\nG92 E0\nG1 E50 F200\nM400\nM106 P1 S255\nG92 E0\nG1 E5 F300\nM109 S{material_print_temperature_layer_0 - 20} ; drop nozzle temp, make filament shink a bit\nG92 E0\nG1 E-0.5 F300\n\nG1 X70 F9000\nG1 X76 F15000\nG1 X65 F15000\nG1 X76 F15000\nG1 X65 F15000; shake to put down garbage\nG1 X80 F6000\nG1 X95 F15000\nG1 X80 F15000\nG1 X165 F15000; wipe and shake\nM400\nM106 P1 S0\n;===== prepare print temperature and material end =====\n\n\n;===== wipe nozzle ===============================\nM1002 gcode_claim_action : 14\nM975 S1\nM106 S255\nG1 X65 Y230 F18000\nG1 Y264 F6000\nM109 S{material_print_temperature_layer_0 - 20}\nG1 X100 F18000 ; first wipe mouth\n\nG0 X135 Y253 F20000  ; move to exposed steel surface edge\nG28 Z P0 T300; home z with low precision,permit 300deg temperature\nG29.2 S0 ; turn off ABL\nG0 Z5 F20000\n\nG1 X60 Y265\nG92 E0\nG1 E-0.5 F300 ; retrack more\nG1 X100 F5000; second wipe mouth\nG1 X70 F15000\nG1 X100 F5000\nG1 X70 F15000\nG1 X100 F5000\nG1 X70 F15000\nG1 X100 F5000\nG1 X70 F15000\nG1 X90 F5000\nG0 X128 Y261 Z-1.5 F20000  ; move to exposed steel surface and stop the nozzle\nM104 S140 ; set temp down to heatbed acceptable\nM106 S255 ; turn on fan (G28 has turn off fan)\n\nM221 S; push soft endstop status\nM221 Z0 ;turn off Z axis endstop\nG0 Z0.5 F20000\nG0 X125 Y259.5 Z-1.01\nG0 X131 F211\nG0 X124\nG0 Z0.5 F20000\nG0 X125 Y262.5\nG0 Z-1.01\nG0 X131 F211\nG0 X124\nG0 Z0.5 F20000\nG0 X125 Y260.0\nG0 Z-1.01\nG0 X131 F211\nG0 X124\nG0 Z0.5 F20000\nG0 X125 Y262.0\nG0 Z-1.01\nG0 X131 F211\nG0 X124\nG0 Z0.5 F20000\nG0 X125 Y260.5\nG0 Z-1.01\nG0 X131 F211\nG0 X124\nG0 Z0.5 F20000\nG0 X125 Y261.5\nG0 Z-1.01\nG0 X131 F211\nG0 X124\nG0 Z0.5 F20000\nG0 X125 Y261.0\nG0 Z-1.01\nG0 X131 F211\nG0 X124\nG0 X128\nG2 I0.5 J0 F300\nG2 I0.5 J0 F300\nG2 I0.5 J0 F300\nG2 I0.5 J0 F300\n\nM109 S140 ; wait nozzle temp down to heatbed acceptable\nG2 I0.5 J0 F3000\nG2 I0.5 J0 F3000\nG2 I0.5 J0 F3000\nG2 I0.5 J0 F3000\n\nM221 R; pop softend status\nG1 Z10 F1200\nM400\nG1 Z10\nG1 F30000\nG1 X230 Y15\nG29.2 S1 ; turn on ABL\n;G28 ; home again after hard wipe mouth\nM106 S0 ; turn off fan , too noisy\n;===== wipe nozzle end ================================\n\n\n;===== bed leveling ==================================\nM1002 judge_flag g29_before_print_flag\nM622 J1\n\n    M1002 gcode_claim_action : 1\n    G29 A X0 Y0 I256 J256\n    M400\n    M500 ; save cali data\n\nM623\n;===== bed leveling end ================================\n\n;===== home after wipe mouth============================\nM1002 judge_flag g29_before_print_flag\nM622 J0\n\n    M1002 gcode_claim_action : 13\n    G28\n\nM623\n;===== home after wipe mouth end =======================\n\nM975 S1 ; turn on vibration supression\n\n\n;=============turn on fans to prevent PLA jamming=================\n{if material_type == \"PLA\"}\n{if material_bed_temperature_layer_0 > 45}\nM106 P3 S180\n{endif}\n;Prevent PLA from jamming\n{endif}\nM106 P2 S100 ; turn on big fan ,to cool down toolhead\n\n\nM104 S{material_print_temperature_layer_0} ; set extrude temp earlier, to reduce wait time\n\n;===== mech mode fast check============================\nG1 X128 Y128 Z10 F20000\nM400 P200\nM970.3 Q1 A7 B30 C80  H15 K0\nM974 Q1 S2 P0\n\nG1 X128 Y128 Z10 F20000\nM400 P200\nM970.3 Q0 A7 B30 C90 Q0 H15 K0\nM974 Q0 S2 P0\n\nM975 S1\nG1 F30000\nG1 X230 Y15\nG28 X ; re-home XY\n;===== fmech mode fast check============================\n\n\n;===== nozzle load line ===============================\nM975 S1\nG90\nM83\nT1000\nG1 X18.0 Y1.0 Z0.8 F18000;Move to start position\nM109 S{material_print_temperature_layer_0}\nG1 Z0.2\nG0 E2 F300\nG0 X240 E15 F{speed_print * 60}\nG0 Y11 E0.700 F{speed_print * 15}\nG0 X239.5\nG0 E0.2\nG0 Y1.5 E0.700\nG0 X18 E15 F{speed_print * 60}\nM400\n\n;===== for Textured PEI Plate , lower the nozzle as the nozzle was touching topmost of the texture when homing ==\n;curr_bed_type={machine_buildplate_type}\n{if machine_buildplate_type == \"textured_pei_plate\"}\nG29.1 Z-0.04 ; for Textured PEI Plate\n{endif}\n;========turn off light and wait extrude temperature =============\nM1002 gcode_claim_action : 0\nM106 S0 ; turn off fan\nM106 P2 S0 ; turn off big fan\nM106 P3 S0 ; turn off chamber fan\n\nM975 S1 ; turn on mech mode supression\n"
         },
         "machine_end_gcode": {
-            "default_value": ";===== date: 20230428 =====================\nM400 ; wait for buffer to clear\nG92 E0 ; zero the extruder\nG1 E-0.8 F1800 ; retract\nG91 ; relative positioning\nG1 Z0.5 F900 ; raise z a little (relative)\nG90 ; back to absolute positioning\nG1 X65 Y245 F12000 ; move to safe pos\nG1 Y265 F3000\n\nG1 X65 Y245 F12000\nG1 Y265 F3000\nM140 S0 ; turn off bed\nM106 S0 ; turn off fan\nM106 P2 S0 ; turn off remote part cooling fan\nM106 P3 S0 ; turn off chamber cooling fan\n\nG1 X100 F12000 ; wipe\n; pull back filament to AMS\nM620 S255\nG1 X20 Y50 F12000\nG1 Y-3\nT255\nG1 X65 F12000\nG1 Y265\nG1 X100 F12000 ; wipe\nM621 S255\nM104 S0 ; turn off hotend\n\nM622.1 S1 ; for prev firmware, default turned on\nM1002 judge_flag timelapse_record_flag\nM622 J1\n    M400 ; wait all motion done\n    M991 S0 P-1 ;end smooth timelapse at safe pos\n    M400 S3 ;wait for last picture to be taken\nM623; end of \"timelapse_record_flag\"\n\nM400 ; wait all motion done\nM17 S\nM17 Z0.4 ; lower z motor current to reduce impact if there is something in the bottom\nG1 Z{machine_height} F600 ; drop bed for part removal\nG1 Z{machine_height - 2}\nM400 P100\nM17 R ; restore z current\n\nM220 S100  ; Reset feedrate magnitude\nM201.2 K1.0 ; Reset acc magnitude\nM73.2   R1.0 ;Reset left time magnitude\nM73 P100 R0 ; signal 100% complete — without this the printer stays stuck at 99%\nM1002 set_gcode_claim_speed_level : 0\n\nM17 X0.8 Y0.8 Z0.5 ; lower motor current to 45% power\n"
+            "default_value": ";===== date: 20230428 =====================\nM400 ; wait for buffer to clear\nG92 E0 ; zero the extruder\nG1 E-0.8 F1800 ; retract\nG91 ; relative positioning\nG1 Z0.5 F900 ; raise z a little (relative)\nG90 ; back to absolute positioning\nG1 X65 Y245 F12000 ; move to safe pos\nG1 Y265 F3000\n\nG1 X65 Y245 F12000\nG1 Y265 F3000\nM140 S0 ; turn off bed\nM106 S0 ; turn off fan\nM106 P2 S0 ; turn off remote part cooling fan\nM106 P3 S0 ; turn off chamber cooling fan\n\nG1 X100 F12000 ; wipe\n; pull back filament to AMS\nM620 S255\nG1 X20 Y50 F12000\nG1 Y-3\nT255\nG1 X65 F12000\nG1 Y265\nG1 X100 F12000 ; wipe\nM621 S255\nM104 S0 ; turn off hotend\n\nM622.1 S1 ; for prev firmware, default turned on\nM1002 judge_flag timelapse_record_flag\nM622 J1\n    M400 ; wait all motion done\n    M991 S0 P-1 ;end smooth timelapse at safe pos\n    M400 S3 ;wait for last picture to be taken\nM623; end of \"timelapse_record_flag\"\n\nM400 ; wait all motion done\nM17 S\nM17 Z0.4 ; lower z motor current to reduce impact if there is something in the bottom\nG1 Z{machine_height} F600 ; drop bed for part removal\nG1 Z{machine_height - 2}\nM400 P100\nM17 R ; restore z current\n\nM220 S100  ; Reset feedrate magnitude\nM201.2 K1.0 ; Reset acc magnitude\nM73.2   R1.0 ;Reset left time magnitude\nM73 P100 R0 ; signal 100% complete \u2014 without this the printer stays stuck at 99%\nM1002 set_gcode_claim_speed_level : 0\n\nM17 X0.8 Y0.8 Z0.5 ; lower motor current to 45% power\n"
         }
     }
 }

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -9,6 +9,7 @@ image with bundled printer definitions.  Default printer: Ultimaker 2.
 
 from __future__ import annotations
 
+import ast
 import importlib.resources
 import json
 import logging
@@ -419,6 +420,42 @@ def _deep_merge_cura_overrides(base: dict, child: dict) -> dict:
     return merged
 
 
+def _normalize_value_literals(overrides: dict) -> None:
+    """Promote literal ``value`` entries to ``default_value`` in place.
+
+    CuraEngine silently ignores setting entries that carry a ``value`` but no
+    ``default_value`` when the fdmprinter settings tree isn't in scope — it
+    logs ``JSON setting 'X' has no [default_]value!`` and reverts to the
+    root-schema default (see #587).  Squashed pinned defs hit this because
+    ``_squash_cura_def`` only merges ``overrides`` dicts, leaving literal
+    ``value`` entries unpaired with a ``default_value``.
+
+    For each override, if ``value`` is a literal — a native bool/int/float,
+    or a string that parses via :func:`ast.literal_eval` (e.g., ``"'skirt'"``
+    or ``"True"``) — set ``default_value`` to the evaluated literal and drop
+    ``value``.  Entries whose ``value`` is a Python expression referencing
+    other settings (e.g., ``"'zigzag' if infill_sparse_density > 80 else
+    'gyroid'"``) are left untouched so CuraEngine can evaluate them.
+    """
+    for entry in overrides.values():
+        if not isinstance(entry, dict):
+            continue
+        if "default_value" in entry or "value" not in entry:
+            continue
+        raw = entry["value"]
+        if isinstance(raw, bool) or isinstance(raw, (int, float)):
+            literal: object = raw
+        elif isinstance(raw, str):
+            try:
+                literal = ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                continue
+        else:
+            literal = raw
+        entry["default_value"] = literal
+        del entry["value"]
+
+
 def extract_cura_docker_defs(
     version: str | None = None,
     image: str | None = None,
@@ -518,6 +555,8 @@ def _squash_cura_def(def_id: str, defs_dirs: Path | list[Path]) -> dict:
     for data in reversed(chain):
         merged_overrides = _deep_merge_cura_overrides(merged_overrides, data.get("overrides", {}))
         merged_metadata.update(data.get("metadata", {}))
+
+    _normalize_value_literals(merged_overrides)
 
     # Build squashed result from the leaf definition
     leaf = chain[0]
@@ -952,6 +991,28 @@ def _write_cura_settings(
     return settings_path
 
 
+def _normalize_staging_value_literals(staging: Path) -> None:
+    """Apply :func:`_normalize_value_literals` to every staged ``.def.json``.
+
+    Runs before :func:`_strip_value_overrides` at slice time so that legacy
+    pinned defs — produced before the pin-time normalization in
+    :func:`_squash_cura_def` existed — still reach CuraEngine in well-formed
+    shape (see #587).
+    """
+    for def_path in staging.glob("*.def.json"):
+        try:
+            data = json.loads(def_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        overrides = data.get("overrides")
+        if not isinstance(overrides, dict):
+            continue
+        before = json.dumps(overrides, sort_keys=True)
+        _normalize_value_literals(overrides)
+        if json.dumps(overrides, sort_keys=True) != before:
+            def_path.write_text(json.dumps(data, indent=4))
+
+
 def _strip_value_overrides(staging: Path, setting_keys: set[str]) -> None:
     """Strip ``value`` expressions from staged defs for settings we pass via ``-s``.
 
@@ -1217,6 +1278,7 @@ def slice_stl(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     staging, machine_def = _prepare_cura_staging(printer, project_dir, profiles_dir, output_dir)
+    _normalize_staging_value_literals(staging)
     _strip_value_overrides(staging, _profile_setting_keys(profile))
 
     # Get machine dimensions for mesh centering and settings JSON
@@ -1309,6 +1371,7 @@ def slice_stl_multi(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     staging, machine_def = _prepare_cura_staging(printer, project_dir, profiles_dir, output_dir)
+    _normalize_staging_value_literals(staging)
     _strip_value_overrides(staging, _profile_setting_keys(profile))
 
     # Get machine dimensions for settings JSON

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -12,6 +12,8 @@ from estampo.cura import (
     _extruder_settings_str,
     _fetch_printer_def,
     _machine_dims_flags,
+    _normalize_staging_value_literals,
+    _normalize_value_literals,
     _patch_gcode_header,
     _place_on_bed,
     _profile_setting_keys,
@@ -142,7 +144,8 @@ def test_squash_preserves_inherits_for_fdmprinter(tmp_path):
     result = _squash_cura_def("my_printer", tmp_path)
     # Must keep inherits so CuraEngine resolves fdmprinter at runtime
     assert result["inherits"] == "fdmprinter"
-    assert result["overrides"]["machine_width"]["value"] == 300
+    # Literal ``value`` is promoted to ``default_value`` at pin-time (#587)
+    assert result["overrides"]["machine_width"]["default_value"] == 300
 
 
 def test_squash_merges_intermediate_definitions(tmp_path):
@@ -175,8 +178,9 @@ def test_squash_merges_intermediate_definitions(tmp_path):
     result = _squash_cura_def("my_printer", tmp_path)
     # fdmprinter preserved, intermediate merged
     assert result["inherits"] == "fdmprinter"
-    assert result["overrides"]["speed_print"]["value"] == 60
-    assert result["overrides"]["machine_width"]["value"] == 300
+    # Literal ``value`` is promoted to ``default_value`` at pin-time (#587)
+    assert result["overrides"]["speed_print"]["default_value"] == 60
+    assert result["overrides"]["machine_width"]["default_value"] == 300
 
 
 # --- cura_docker_image ---
@@ -392,6 +396,121 @@ def test_strip_value_overrides_ignores_missing_keys(tmp_path):
     _strip_value_overrides(tmp_path, {"adhesion_type"})
 
     assert json.loads(def_path.read_text()) == original
+
+
+# --- _normalize_value_literals (#587) ---
+
+
+def test_normalize_value_literals_promotes_native_literals():
+    """Native bool/int/float ``value`` entries become ``default_value``."""
+    overrides = {
+        "machine_width": {"value": 256},
+        "retraction_amount": {"value": 0.8},
+        "relative_extrusion": {"value": True},
+    }
+    _normalize_value_literals(overrides)
+    assert overrides == {
+        "machine_width": {"default_value": 256},
+        "retraction_amount": {"default_value": 0.8},
+        "relative_extrusion": {"default_value": True},
+    }
+
+
+def test_normalize_value_literals_evaluates_quoted_string_literals():
+    """Python-literal strings (e.g., ``"'skirt'"``) evaluate and promote."""
+    overrides = {
+        "adhesion_type": {"value": "'skirt'"},
+        "retraction_hop_enabled": {"value": "True"},
+    }
+    _normalize_value_literals(overrides)
+    assert overrides == {
+        "adhesion_type": {"default_value": "skirt"},
+        "retraction_hop_enabled": {"default_value": True},
+    }
+
+
+def test_normalize_value_literals_leaves_expressions_alone():
+    """Expressions referencing other settings are not touched."""
+    overrides = {
+        "infill_pattern": {"value": "'zigzag' if infill_sparse_density > 80 else 'gyroid'"},
+        "brim_width": {"value": "machine_width / 10"},
+    }
+    before = {k: dict(v) for k, v in overrides.items()}
+    _normalize_value_literals(overrides)
+    assert overrides == before
+
+
+def test_normalize_value_literals_preserves_existing_default_value():
+    """Entries already carrying ``default_value`` are left untouched."""
+    overrides = {
+        "brim_width": {"default_value": 3, "value": "machine_width / 10"},
+    }
+    _normalize_value_literals(overrides)
+    assert overrides == {
+        "brim_width": {"default_value": 3, "value": "machine_width / 10"},
+    }
+
+
+def test_normalize_value_literals_skips_entries_without_value():
+    """Entries with only ``default_value`` or unrelated keys are unchanged."""
+    overrides = {
+        "speed_print": {"default_value": 60},
+        "metadata_only": {"label": "Hello"},
+    }
+    _normalize_value_literals(overrides)
+    assert overrides == {
+        "speed_print": {"default_value": 60},
+        "metadata_only": {"label": "Hello"},
+    }
+
+
+def test_normalize_staging_value_literals_rewrites_files(tmp_path):
+    """Staging normalization rewrites defs on disk, in place."""
+    import json
+
+    def_path = tmp_path / "bambox_p1s.def.json"
+    def_path.write_text(
+        json.dumps(
+            {
+                "overrides": {
+                    "machine_width": {"value": 256},
+                    "relative_extrusion": {"value": True},
+                    "adhesion_type": {"value": "'skirt'"},
+                    "infill_pattern": {
+                        "value": "'zigzag' if infill_sparse_density > 80 else 'gyroid'"
+                    },
+                }
+            }
+        )
+    )
+    _normalize_staging_value_literals(tmp_path)
+
+    data = json.loads(def_path.read_text())
+    overrides = data["overrides"]
+    assert overrides["machine_width"] == {"default_value": 256}
+    assert overrides["relative_extrusion"] == {"default_value": True}
+    assert overrides["adhesion_type"] == {"default_value": "skirt"}
+    # Expression untouched
+    assert overrides["infill_pattern"] == {
+        "value": "'zigzag' if infill_sparse_density > 80 else 'gyroid'"
+    }
+
+
+def test_normalize_staging_value_literals_skips_when_no_changes(tmp_path):
+    """Files whose overrides are already normalized are not rewritten."""
+    import json
+
+    def_path = tmp_path / "already_ok.def.json"
+    payload = {"overrides": {"speed_print": {"default_value": 60}}}
+    def_path.write_text(json.dumps(payload))
+    mtime_before = def_path.stat().st_mtime_ns
+
+    _normalize_staging_value_literals(tmp_path)
+
+    # Content is unchanged
+    assert json.loads(def_path.read_text()) == payload
+    # And we didn't rewrite the file (mtime preserved)
+    assert def_path.stat().st_mtime_ns == mtime_before
 
 
 def test_machine_dims_flags_emits_s_flags():

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -864,12 +864,12 @@ def test_squash_cura_def(tmp_path):
     # Both definitions are local — fully resolved, no inherits
     assert "inherits" not in squashed
     assert squashed["name"] == "Child Printer"
-    # Child overrides parent
-    assert squashed["overrides"]["machine_width"] == {"value": 256}
-    # Parent-only setting preserved
+    # Child overrides parent; literal ``value`` is promoted to ``default_value`` (#587)
+    assert squashed["overrides"]["machine_width"] == {"default_value": 256}
+    # Parent-only setting preserved — existing ``default_value`` blocks promotion
     assert squashed["overrides"]["speed_print"] == {"value": 60, "default_value": 60}
-    # Child-only setting added
-    assert squashed["overrides"]["machine_depth"] == {"value": 256}
+    # Child-only setting added (also promoted)
+    assert squashed["overrides"]["machine_depth"] == {"default_value": 256}
     # Metadata merged (child visible overrides parent)
     assert squashed["metadata"]["visible"] is True
     assert squashed["metadata"]["author"] == "test"
@@ -904,8 +904,10 @@ def test_squash_cura_def_keeps_unresolved_parent(tmp_path):
     # fdmprinter is not local — keep inherits so CuraEngine resolves at runtime
     assert squashed["inherits"] == "fdmprinter"
     assert squashed["name"] == "My Printer"
-    assert squashed["overrides"]["machine_width"] == {"value": 256}
-    assert squashed["overrides"]["speed_print"] == {"value": 100}
+    # Literal ``value`` entries are promoted to ``default_value`` at pin-time (#587)
+    assert squashed["overrides"]["machine_width"] == {"default_value": 256}
+    assert squashed["overrides"]["speed_print"] == {"default_value": 100}
+    # Expression left intact — depends on another setting
     assert squashed["overrides"]["acceleration_infill"] == {"value": "acceleration_print"}
 
 
@@ -981,8 +983,9 @@ def test_pin_cura_definitions_from_project_dir(tmp_path):
 
     squashed = json.loads(dest.read_text())
     assert squashed["name"] == "My AMS Variant"
-    assert squashed["overrides"]["machine_width"] == {"value": 200}
-    assert squashed["overrides"]["machine_depth"] == {"value": 256}
+    # Literal ``value`` is promoted to ``default_value`` at pin-time (#587)
+    assert squashed["overrides"]["machine_width"] == {"default_value": 200}
+    assert squashed["overrides"]["machine_depth"] == {"default_value": 256}
     assert squashed["inherits"] == "fdmprinter"
 
 


### PR DESCRIPTION
## Summary

- CuraEngine silently ignores override entries that carry only ``value`` (no ``default_value``) when the fdmprinter settings tree isn't in scope — it logs ``JSON setting 'X' has no [default_]value!`` and reverts to the fdmprinter default. Our pinned defs hit this because ``_squash_cura_def`` only merges ``overrides`` dicts; leaf ``value`` entries end up unpaired.
- In ``bambox_p1s_ams.def.json``, 30 of 47 overrides were being dropped this way — including ``relative_extrusion``, ``retraction_amount``, ``speed_print``, and the machine dimensions (the brim-specific symptom fixed in #586).
- Add ``_normalize_value_literals``: for each override with ``value`` and no ``default_value``, detect literals via ``ast.literal_eval`` (native int/float/bool, or Python-literal strings like ``"'skirt'"``) and promote to ``default_value``. Expressions referencing other settings (e.g., ``"'zigzag' if infill_sparse_density > 80 else 'gyroid'"``) are left alone so CuraEngine evaluates them normally.
- Apply at two points: pin-time in ``_squash_cura_def`` so freshly-pinned defs land well-formed, and slice-time via ``_normalize_staging_value_literals`` so pre-existing legacy pinned defs are normalized on the way into CuraEngine.
- Also re-normalize the committed bambox example defs so the repo state is itself correct.

Closes #587.

## Test plan

- [x] ``uv run ruff check src tests``
- [x] ``uv run ruff format --check src tests``
- [x] ``uv run mypy src/estampo``
- [x] ``uv run pytest`` (612 passed, 9 skipped)
- [x] New unit tests cover native literals, quoted-string literals, expression preservation, pre-existing ``default_value`` passthrough, and the staging-level wrapper
- [x] Confirmed normalized ``bambox_p1s.def.json`` / ``bambox_p1s_ams.def.json`` retain only genuine expressions (``speed_layer_0``, ``infill_pattern``) as ``value``-only entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)