### PR TITLE
Surface CuraEngine stderr warnings on successful slices (#590)

### DIFF
--- a/changes/590.bugfix
+++ b/changes/590.bugfix
@@ -1,0 +1,1 @@
+Surface CuraEngine stderr warnings on successful slices. ``JSON setting 'X' has no [default_]value!`` warnings are aggregated into a strong "silently dropped printer-profile setting" log line, other warnings get a total-count summary, and ``-v`` prints every raw warning inline — making bugs like #586/#587 visible instead of silent.

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -1110,6 +1110,57 @@ def _check_local_def(staging: Path, machine_def: str, printer: str | None) -> No
     )
 
 
+_CURA_WARNING_RE = re.compile(r"\[WARNING\]\s+(.*?)\s*$", re.IGNORECASE)
+_CURA_NO_DEFAULT_VALUE_RE = re.compile(r"JSON setting '([^']+)' has no \[default_\]value!")
+
+
+def _surface_cura_warnings(stderr: str) -> None:
+    """Surface CuraEngine stderr warnings after a zero-exit run.
+
+    CuraEngine writes warnings to stderr for silently-dropped settings,
+    unknown keys, and other miscompilation risks even when the slice
+    succeeds.  Without surfacing, bugs like #586/#587 stay invisible.
+
+    Any ``JSON setting 'X' has no [default_]value!`` lines are logged at
+    WARNING with the list of affected keys — these signal printer-profile
+    overrides reverting to fdmprinter defaults.  A total count of all
+    warnings is also logged so users know something happened, and each
+    raw warning is logged at DEBUG so ``-v`` surfaces them inline.
+    """
+    warnings: list[str] = []
+    dropped: list[str] = []
+    for line in stderr.splitlines():
+        m = _CURA_WARNING_RE.search(line)
+        if not m:
+            continue
+        msg = m.group(1).strip()
+        warnings.append(msg)
+        dv = _CURA_NO_DEFAULT_VALUE_RE.search(msg)
+        if dv:
+            dropped.append(dv.group(1))
+
+    if not warnings:
+        return
+
+    if dropped:
+        unique = sorted(set(dropped))
+        log.warning(
+            "CuraEngine silently dropped %d printer-profile setting(s), "
+            "reverting to fdmprinter defaults: %s "
+            "(pinned definition is missing 'default_value' entries — see #587).",
+            len(unique),
+            ", ".join(unique),
+        )
+
+    log.warning(
+        "CuraEngine emitted %d warning(s) — run with -v to see them.",
+        len(warnings),
+    )
+
+    for msg in warnings:
+        log.debug("CuraEngine: %s", msg)
+
+
 def _strip_cura_banner(text: str) -> str:
     """Strip the CuraEngine GPL license banner from output text.
 
@@ -1186,6 +1237,7 @@ def _run_docker_slice(
         combined = (result.stdout + "\n" + result.stderr).strip()
         raise EstampoError(f"CuraEngine produced no output:\n{_strip_cura_banner(combined)[:500]}")
 
+    _surface_cura_warnings(result.stderr)
     _patch_gcode_header(output_gcode, result.stderr)
     _write_cura_settings(output_dir, profile, machine_dims)
 
@@ -1233,6 +1285,7 @@ def _run_local_slice(
         combined = (result.stdout + "\n" + result.stderr).strip()
         raise EstampoError(f"CuraEngine produced no output:\n{_strip_cura_banner(combined)[:500]}")
 
+    _surface_cura_warnings(result.stderr)
     _patch_gcode_header(output_gcode, result.stderr)
     _write_cura_settings(output_dir, profile, machine_dims)
 

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -23,6 +23,7 @@ from estampo.cura import (
     _settings_flags,
     _squash_cura_def,
     _strip_value_overrides,
+    _surface_cura_warnings,
     _write_cura_settings,
     cura_docker_image,
     cura_profile_from_config,
@@ -511,6 +512,86 @@ def test_normalize_staging_value_literals_skips_when_no_changes(tmp_path):
     assert json.loads(def_path.read_text()) == payload
     # And we didn't rewrite the file (mtime preserved)
     assert def_path.stat().st_mtime_ns == mtime_before
+
+
+# --- _surface_cura_warnings (#590) ---
+
+
+def test_surface_cura_warnings_flags_dropped_settings(caplog):
+    """``has no [default_]value!`` warnings produce a strong dropped-settings log."""
+    import logging
+
+    stderr = (
+        "[2026-04-19 06:00:00.000] [1] [tid] [warning] "
+        "JSON setting 'machine_width' has no [default_]value!\n"
+        "[2026-04-19 06:00:00.001] [1] [tid] [warning] "
+        "JSON setting 'adhesion_type' has no [default_]value!\n"
+    )
+    with caplog.at_level(logging.WARNING, logger="estampo.cura"):
+        _surface_cura_warnings(stderr)
+
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    assert "silently dropped 2 printer-profile setting(s)" in text
+    # Sorted & unique
+    assert "adhesion_type, machine_width" in text
+    assert "emitted 2 warning(s)" in text
+
+
+def test_surface_cura_warnings_deduplicates_dropped_keys(caplog):
+    """Repeated warnings for the same setting collapse to one dropped key."""
+    import logging
+
+    stderr = (
+        "[warning] JSON setting 'machine_width' has no [default_]value!\n"
+        "[warning] JSON setting 'machine_width' has no [default_]value!\n"
+    )
+    with caplog.at_level(logging.WARNING, logger="estampo.cura"):
+        _surface_cura_warnings(stderr)
+
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    assert "silently dropped 1 printer-profile setting(s)" in text
+    assert "machine_width" in text
+
+
+def test_surface_cura_warnings_generic_summary(caplog):
+    """Non-dropped warnings still produce a generic count summary."""
+    import logging
+
+    stderr = "[warning] Unknown setting 'something_weird'\n[warning] Mesh has non-manifold edges\n"
+    with caplog.at_level(logging.WARNING, logger="estampo.cura"):
+        _surface_cura_warnings(stderr)
+
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    # No dropped-setting message
+    assert "silently dropped" not in text
+    assert "emitted 2 warning(s)" in text
+
+
+def test_surface_cura_warnings_silent_when_no_warnings(caplog):
+    """Stderr with no ``[warning]`` lines produces no log output."""
+    import logging
+
+    stderr = "[info] Slicing started\nSome random license banner text\n"
+    with caplog.at_level(logging.DEBUG, logger="estampo.cura"):
+        _surface_cura_warnings(stderr)
+
+    assert caplog.records == []
+
+
+def test_surface_cura_warnings_debug_surfaces_each_line(caplog):
+    """Every warning is logged at DEBUG so ``-v`` shows them inline."""
+    import logging
+
+    stderr = (
+        "[warning] JSON setting 'machine_width' has no [default_]value!\n"
+        "[warning] Something else weird\n"
+    )
+    with caplog.at_level(logging.DEBUG, logger="estampo.cura"):
+        _surface_cura_warnings(stderr)
+
+    debug_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+    assert any("machine_width" in m for m in debug_msgs)
+    assert any("Something else weird" in m for m in debug_msgs)
 
 
 def test_machine_dims_flags_emits_s_flags():


### PR DESCRIPTION
## Summary

- ``_run_docker_slice`` and ``_run_local_slice`` only showed stderr on non-zero exit. CuraEngine emits ``[warning]`` lines on successful runs too (dropped settings, unknown keys, mesh warnings) and those were silently discarded — which is why #586 and #587 stayed invisible.
- Add ``_surface_cura_warnings``: scans stderr for ``[warning]`` lines, aggregates every ``JSON setting 'X' has no [default_]value!`` match into a single strong log line naming the dropped keys, emits a total-count summary at WARNING, and logs each raw line at DEBUG so ``-v`` surfaces them inline.
- Call at the end of both runners after success is confirmed, before header patching.

Closes #590.

## Test plan

- [x] ``uv run ruff check src tests``
- [x] ``uv run ruff format --check src tests``
- [x] ``uv run mypy src/estampo``
- [x] ``uv run pytest`` (617 passed, 9 skipped)
- [x] New unit tests cover: dropped-setting aggregation, deduplication of repeated keys, generic warning summary, silence when no ``[warning]`` lines, and DEBUG-level per-line surfacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)