### PR TITLE
Always use multi-mesh CuraEngine path

### DIFF
--- a/changes/+cura-always-multi-mesh.misc
+++ b/changes/+cura-always-multi-mesh.misc
@@ -1,0 +1,1 @@
+Drop the single-mesh CuraEngine fallback: ``slice_plate`` with ``engine="cura"`` now always exports per-part STLs and slices through the multi-mesh path, group-centered on the bed.

--- a/examples-old/cura-ams-p1s/README.md
+++ b/examples-old/cura-ams-p1s/README.md
@@ -86,8 +86,8 @@ Tool change count should be identical (both use 2 filaments on separate objects)
 
 ## Notes
 
-- `plate.gcode` in `{sliced_dir}` is the fixed output name for both single-mesh
-  and multi-mesh CuraEngine slices (from `slice_stl`/`slice_stl_multi`).
+- `plate.gcode` in `{sliced_dir}` is the fixed output name for CuraEngine
+  slices (produced by `slice_stl_multi`).
 - The `bambox_p1s_ams` printer definition must be available to CuraEngine via
   the bambox package or a local `profiles/` directory.
 - To send to the printer, add a `[print]` command stage:

--- a/scripts/compare_engines.py
+++ b/scripts/compare_engines.py
@@ -22,7 +22,6 @@ from pathlib import Path
 # Ensure project root is on sys.path for imports
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from estampo.cura import cura_docker_image, slice_stl
 from estampo.gcode import analyze_gcode, parse_gcode_metadata
 from estampo.slicer import slice_plate
 
@@ -150,8 +149,13 @@ def _slice_cura(stl_path: Path, output_base: Path) -> Path:
         "machine_buildplate_type": "textured_pei_plate",
         "material_type": "PETG-CF",
     }
-    image = cura_docker_image(CURA_VERSION)
-    return slice_stl(stl_path, output_dir, overrides=overrides, image=image)
+    return slice_plate(
+        stl_path,
+        engine="cura",
+        output_dir=output_dir,
+        overrides=overrides,
+        docker_version=CURA_VERSION,
+    )
 
 
 def _pct_diff(a: float, b: float) -> str:

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -770,9 +770,9 @@ def _machine_dims_flags(machine_dims: dict[str, float]) -> list[str]:
     Pinned definitions commonly declare bed size with ``value`` only and
     no ``default_value``.  CuraEngine logs "has no [default_]value!" for
     these fields and silently falls back to the fdmprinter defaults
-    (100×100).  ``_place_on_bed`` reads the ``value`` directly, so the
-    mesh gets centred for the real bed and ends up off the bed CuraEngine
-    thinks it has — which silently drops brim/skirt generation (see #586).
+    (100×100).  Slicer-side mesh placement reads the ``value`` directly,
+    so the mesh gets centred for the real bed and ends up off the bed
+    CuraEngine thinks it has — which silently drops brim/skirt (see #586).
 
     Passing the dims as ``-s`` flags keeps CuraEngine in sync with mesh
     placement regardless of how the def declares them.
@@ -845,47 +845,6 @@ def _patch_gcode_header(gcode_path: Path, stderr: str) -> None:
         log.info("Patched G-code header with real values from CuraEngine stderr")
     else:
         log.debug("G-code header patch had no effect")
-
-
-def _place_on_bed(
-    stl_path: Path,
-    staging_dir: Path,
-    bed_width: float = DEFAULT_PLATE_SIZE[0],
-    bed_depth: float = DEFAULT_PLATE_SIZE[1],
-    center_is_zero: bool = False,
-) -> Path:
-    """Copy STL into staging, ensuring the mesh sits on the bed (Z>=0)
-    and is centered on the build plate.
-
-    CuraEngine only slices geometry above Z=0.  Bed-origin convention is
-    selected by ``center_is_zero``: when ``False`` (CuraEngine default —
-    origin at the front-left corner) the mesh is centered at
-    ``(bed_width/2, bed_depth/2)``; when ``True`` it is centered at
-    ``(0, 0)``.
-    """
-    import trimesh
-
-    mesh: trimesh.Trimesh = trimesh.load(str(stl_path), force="mesh")  # type: ignore[assignment]
-
-    x_center = float((mesh.bounds[0][0] + mesh.bounds[1][0]) / 2)
-    y_center = float((mesh.bounds[0][1] + mesh.bounds[1][1]) / 2)
-    target_x = 0.0 if center_is_zero else bed_width / 2
-    target_y = 0.0 if center_is_zero else bed_depth / 2
-    dx = target_x - x_center
-    dy = target_y - y_center
-    if abs(dx) > 0.01 or abs(dy) > 0.01:
-        mesh.vertices[:, 0] += dx  # type: ignore[attr-defined]
-        mesh.vertices[:, 1] += dy  # type: ignore[attr-defined]
-        log.info("Centered mesh on bed (shifted by %.2f, %.2f)", dx, dy)
-
-    z_min = float(mesh.bounds[0][2])
-    if z_min < 0:
-        mesh.vertices[:, 2] -= z_min
-        log.info("Shifted mesh up by %.2fmm to place on bed", -z_min)
-
-    out = staging_dir / stl_path.name
-    mesh.export(str(out), file_type="stl")
-    return out
 
 
 def _write_cura_settings(
@@ -1153,110 +1112,6 @@ def _run_local_slice(
 
     log.info("CuraEngine output: %s (%d bytes)", output_gcode, output_gcode.stat().st_size)
     return output_dir
-
-
-def slice_stl(
-    stl_path: Path,
-    output_dir: Path,
-    overrides: CuraOverrides | None = None,
-    per_extruder: CuraPerExtruder | None = None,
-    image: str | None = None,
-    printer: str | None = None,
-    project_dir: Path | None = None,
-    profiles_dir: str = "profiles",
-    local: bool = False,
-) -> Path:
-    """Slice a single STL file with CuraEngine and return the output directory.
-
-    Uses Docker with the estampo/estampo:cura-X.Y.Z image.  The machine
-    definition (resolved from *printer* name) provides machine geometry
-    and start/end G-code; process settings come from *overrides*.
-
-    Args:
-        stl_path: Path to the input STL file.
-        output_dir: Directory for output G-code.
-        overrides: Raw CuraEngine setting overrides (TOML passthrough).
-        per_extruder: Per-extruder overrides, one dict per extruder slot.
-        image: Docker image override. Defaults to estampo/estampo:cura-5.12.0.
-        printer: Printer definition name (e.g. ``"Ultimaker 2"``).
-        project_dir: Project root for pinned profile lookup.
-        profiles_dir: Profiles directory name within the project.
-
-    Returns:
-        The output directory (matching slicer.slice_plate contract).
-    """
-    if overrides is None:
-        overrides = {}
-    if per_extruder is None:
-        per_extruder = []
-    if image is None:
-        image = cura_docker_image()
-
-    _warn_unknown_cura_settings(overrides, per_extruder)
-
-    stl_path = stl_path.resolve()
-    output_dir = output_dir.resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    staging, machine_def = _prepare_cura_staging(printer, project_dir, profiles_dir, output_dir)
-
-    # Get machine dimensions for mesh centering and settings JSON
-    machine_dims = resolve_cura_machine_dims(printer or "", project_dir, profiles_dir)
-    bed_w, bed_d = machine_dims["machine_width"], machine_dims["machine_depth"]
-    center_is_zero = resolve_cura_center_is_zero(printer or "", project_dir, profiles_dir)
-
-    # Place mesh on the build plate (Z>=0, centered) before slicing.
-    staged_stl = _place_on_bed(
-        stl_path, staging, bed_width=bed_w, bed_depth=bed_d, center_is_zero=center_is_zero
-    )
-
-    settings = _settings_flags(overrides) + _machine_dims_flags(machine_dims)
-
-    if local:
-        _check_local_def(staging, machine_def, printer)
-        defs_path = _local_defs_path(staging)
-        cura_args = [
-            "-d",
-            defs_path,
-            "-j",
-            str(staging / machine_def),
-            "-o",
-            str(output_dir / (stl_path.stem + ".gcode")),
-            *settings,
-            "-g",
-            "-e0",
-            *settings,
-            "-l",
-            str(staged_stl),
-        ]
-        return _run_local_slice(
-            cura_args, output_dir, staging, stl_path.stem, overrides, machine_dims
-        )
-
-    # Container paths (output_dir mounted at /work/output)
-    c_staging = "/work/output/.cura-staging"
-    c_stl = f"{c_staging}/{staged_stl.name}"
-    c_output = "/work/output/" + stl_path.stem + ".gcode"
-
-    # Build the CuraEngine command.
-    # -d adds search paths for definition file resolution (inherits chain).
-    # -j loads the machine definition (geometry + start/end gcode).
-    # -g starts a mesh group, -e0 sets extruder 0 context for per-extruder
-    # settings (material_diameter etc.) that CuraEngine requires.
-    settings_str = " ".join(f'"{s}"' for s in settings)
-    inner_cmd = (
-        f"CuraEngine slice "
-        f"-d {c_staging}:{_DEFS_DIR}:/opt/cura/extruders "
-        f"-j {c_staging}/{machine_def} "
-        f"-o {c_output} "
-        f"{settings_str} "
-        f"-g -e0 {settings_str} "
-        f"-l {c_stl}"
-    )
-
-    return _run_docker_slice(
-        inner_cmd, image, output_dir, staging, stl_path.stem, overrides, machine_dims
-    )
 
 
 def slice_stl_multi(

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -121,13 +121,14 @@ def slice_plate(
     """
     # CuraEngine backend — separate execution path
     if engine == "cura":
+        import numpy as np
         import trimesh
 
         from estampo.cura import (
             build_cura_config,
             cura_docker_image,
             resolve_cura_bed_size,
-            slice_stl,
+            resolve_cura_center_is_zero,
             slice_stl_multi,
         )
 
@@ -155,72 +156,52 @@ def slice_plate(
         image = cura_docker_image(docker_version or required_version)
 
         scene = trimesh.load(str(input_3mf))
-
-        # Multi-mesh path: when parts span multiple filament slots and the
-        # scene geometry count matches the filament_ids list we can pass each
-        # mesh as a separate -g -eN group to CuraEngine, preserving the
-        # plate arrangement and extruder assignments set up by load_parts.
-        if isinstance(scene, trimesh.Scene) and filament_ids and len(set(filament_ids)) > 1:
+        if isinstance(scene, trimesh.Scene):
             meshes: list[trimesh.Trimesh] = list(scene.dump(concatenate=False))  # type: ignore[arg-type]
-            if len(meshes) == len(filament_ids):
-                import numpy as np
+        else:
+            meshes = [scene]  # type: ignore[list-item]
 
-                bed_w, bed_d = resolve_cura_bed_size(printer or "", project_dir, profiles_dir)
+        if not meshes:
+            raise EstampoError(f"No geometry found in {input_3mf}")
 
-                # Center the group on the build plate as a unit so relative
-                # positions from the arrange stage are preserved.
-                bounds = np.array([m.bounds for m in meshes])
-                group_min = bounds[:, 0, :].min(axis=0)
-                group_max = bounds[:, 1, :].max(axis=0)
-                dx = float(bed_w / 2 - (group_min[0] + group_max[0]) / 2)
-                dy = float(bed_d / 2 - (group_min[1] + group_max[1]) / 2)
-                dz = float(-group_min[2])
-
-                stl_dir = output_dir / ".cura-parts"
-                stl_dir.mkdir(exist_ok=True)
-                stl_meshes: list[tuple[int, Path]] = []
-                for i, (fid, mesh) in enumerate(zip(filament_ids, meshes)):
-                    positioned = mesh.copy()
-                    positioned.vertices[:, 0] += dx
-                    positioned.vertices[:, 1] += dy
-                    positioned.vertices[:, 2] += dz
-                    stl_path = stl_dir / f"part_{i}.stl"
-                    positioned.export(str(stl_path), file_type="stl")
-                    stl_meshes.append((fid - 1, stl_path))  # 0-based extruder
-
-                return slice_stl_multi(
-                    stl_meshes,
-                    output_dir,
-                    overrides=cura_overrides,
-                    per_extruder=cura_per_extruder,
-                    image=image,
-                    printer=printer,
-                    project_dir=project_dir,
-                    profiles_dir=profiles_dir,
-                    local=local,
-                )
-            else:
+        if filament_ids and len(filament_ids) == len(meshes):
+            extruder_ids = [fid - 1 for fid in filament_ids]
+        else:
+            if filament_ids and len(filament_ids) != len(meshes):
                 log.warning(
                     "filament_ids length (%d) does not match scene geometry count (%d) "
-                    "— falling back to single-mesh CuraEngine slice",
+                    "— assigning all meshes to extruder 0",
                     len(filament_ids),
                     len(meshes),
                 )
+            extruder_ids = [0] * len(meshes)
 
-        # Single-mesh fallback: merge all geometries into one.
-        if isinstance(scene, trimesh.Scene):
-            merged: trimesh.Trimesh = scene.to_geometry()  # type: ignore[assignment]
-        else:
-            merged = scene  # type: ignore[assignment]
-        mesh = merged
-        z_min = float(mesh.bounds[0][2])  # type: ignore[attr-defined]
-        if z_min < 0:
-            mesh.vertices[:, 2] -= z_min  # type: ignore[attr-defined]
-        stl_path = output_dir / (input_3mf.stem + ".stl")
-        mesh.export(str(stl_path), file_type="stl")
+        bed_w, bed_d = resolve_cura_bed_size(printer or "", project_dir, profiles_dir)
+        center_is_zero = resolve_cura_center_is_zero(printer or "", project_dir, profiles_dir)
+        target_x = 0.0 if center_is_zero else bed_w / 2
+        target_y = 0.0 if center_is_zero else bed_d / 2
 
-        return slice_stl(
-            stl_path,
+        bounds = np.array([m.bounds for m in meshes])
+        group_min = bounds[:, 0, :].min(axis=0)
+        group_max = bounds[:, 1, :].max(axis=0)
+        dx = float(target_x - (group_min[0] + group_max[0]) / 2)
+        dy = float(target_y - (group_min[1] + group_max[1]) / 2)
+        dz = float(-group_min[2]) if group_min[2] < 0 else 0.0
+
+        stl_dir = output_dir / ".cura-parts"
+        stl_dir.mkdir(exist_ok=True)
+        stl_meshes: list[tuple[int, Path]] = []
+        for i, (ext_idx, mesh) in enumerate(zip(extruder_ids, meshes)):
+            positioned = mesh.copy()
+            positioned.vertices[:, 0] += dx
+            positioned.vertices[:, 1] += dy
+            positioned.vertices[:, 2] += dz
+            stl_path = stl_dir / f"part_{i}.stl"
+            positioned.export(str(stl_path), file_type="stl")
+            stl_meshes.append((ext_idx, stl_path))
+
+        return slice_stl_multi(
+            stl_meshes,
             output_dir,
             overrides=cura_overrides,
             per_extruder=cura_per_extruder,

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -13,7 +13,6 @@ from estampo.cura import (
     _fetch_printer_def,
     _machine_dims_flags,
     _patch_gcode_header,
-    _place_on_bed,
     _resolve_def_chain,
     _resolve_def_name,
     _settings_dict,
@@ -25,7 +24,6 @@ from estampo.cura import (
     pin_cura_definitions,
     resolve_cura_center_is_zero,
     resolve_cura_machine_dims,
-    slice_stl,
     slice_stl_multi,
     validate_cura_settings,
 )
@@ -570,125 +568,11 @@ def test_machine_dims_flags_skips_missing_keys():
     assert flags == ["-s", "machine_width=256.0"]
 
 
-# --- slice_stl Docker execution ---
-
-
-def test_slice_stl_docker_command(tmp_path):
-    """Verify Docker command is built correctly."""
-    import json
-
-    import trimesh
-
-    mesh = trimesh.creation.box(extents=[10, 10, 10])
-    stl = tmp_path / "model.stl"
-    mesh.export(str(stl))
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
-
-    # Create a fake gcode output file so the size check passes
-    gcode_out = output_dir / "model.gcode"
-    gcode_out.write_text("G28\n" * 100)
-
-    # Create a minimal printer definition so _prepare_cura_staging resolves
-    defs_dir = tmp_path / "profiles" / "cura" / "definitions"
-    defs_dir.mkdir(parents=True)
-    (defs_dir / "test_printer.def.json").write_text(
-        json.dumps(
-            {
-                "name": "Test Printer",
-                "inherits": "fdmprinter",
-                "overrides": {
-                    "machine_width": {"default_value": 256},
-                    "machine_depth": {"default_value": 256},
-                    "machine_height": {"default_value": 256},
-                    "machine_start_gcode": {"default_value": "G28"},
-                    "machine_end_gcode": {"default_value": "M84"},
-                },
-            }
-        )
-    )
-
-    mock_result = MagicMock(returncode=0, stdout="", stderr="")
-
-    with (
-        patch("estampo.cura.subprocess.run", return_value=mock_result) as mock_run,
-        patch("estampo.ui.status"),
-    ):
-        slice_stl(
-            stl,
-            output_dir,
-            overrides={},
-            image="estampo/estampo:cura-5.12.0",
-            printer="test_printer",
-            project_dir=tmp_path,
-        )
-
-    cmd = mock_run.call_args[0][0]
-    assert cmd[0] == "docker"
-    assert "run" in cmd
-    assert "--entrypoint" in cmd
-    assert "/bin/bash" in cmd
-    assert "estampo/estampo:cura-5.12.0" in cmd
-    assert "--platform" in cmd
-    assert "linux/amd64" in cmd
-    # Volume mount for output directory
-    vol_idx = cmd.index("-v") + 1
-    assert ":/work/output" in cmd[vol_idx]
-    # Inner command uses the test definition
-    inner_cmd = cmd[-1]
-    assert "test_printer.def.json" in inner_cmd
-    assert "-g -e0" in inner_cmd
-    # #586: machine dims must be passed as -s flags so CuraEngine's bed size
-    # agrees with _place_on_bed; otherwise brim/skirt is silently dropped.
-    assert "machine_width=256" in inner_cmd
-    assert "machine_depth=256" in inner_cmd
-
-
-def test_slice_stl_docker_failure(tmp_path):
-    """Docker failure raises EstampoError."""
-    import trimesh
-
-    mesh = trimesh.creation.box(extents=[10, 10, 10])
-    stl = tmp_path / "model.stl"
-    mesh.export(str(stl))
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
-
-    mock_result = MagicMock(returncode=1, stdout="", stderr="CuraEngine error")
-
-    with (
-        patch("estampo.cura.subprocess.run", return_value=mock_result),
-        patch("estampo.ui.status"),
-        pytest.raises(EstampoError, match="CuraEngine failed"),
-    ):
-        slice_stl(stl, output_dir, overrides={}, image="estampo/estampo:cura-5.12.0")
-
-
-def test_slice_stl_no_output(tmp_path):
-    """Success but empty/missing gcode file raises EstampoError."""
-    import trimesh
-
-    mesh = trimesh.creation.box(extents=[10, 10, 10])
-    stl = tmp_path / "model.stl"
-    mesh.export(str(stl))
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
-
-    mock_result = MagicMock(returncode=0, stdout="", stderr="")
-
-    with (
-        patch("estampo.cura.subprocess.run", return_value=mock_result),
-        patch("estampo.ui.status"),
-        pytest.raises(EstampoError, match="produced no output"),
-    ):
-        slice_stl(stl, output_dir, overrides={}, image="estampo/estampo:cura-5.12.0")
-
-
 # --- slice_plate cura dispatch ---
 
 
 def test_slice_plate_cura_dispatch(tmp_path):
-    """slice_plate with engine='cura' dispatches to cura.slice_stl."""
+    """slice_plate with engine='cura' dispatches to cura.slice_stl_multi."""
     import trimesh
 
     from estampo.slicer import slice_plate
@@ -701,7 +585,7 @@ def test_slice_plate_cura_dispatch(tmp_path):
 
     output_dir = tmp_path / "output"
 
-    with patch("estampo.cura.slice_stl", return_value=output_dir) as mock_slice:
+    with patch("estampo.cura.slice_stl_multi", return_value=output_dir) as mock_slice:
         result = slice_plate(
             input_3mf,
             engine="cura",
@@ -719,6 +603,10 @@ def test_slice_plate_cura_dispatch(tmp_path):
     assert overrides_arg["layer_height"] == 0.12
     assert overrides_arg["material_type"] == "PLA"
     assert call_kwargs["image"] == "estampo/estampo:cura-5.12.0"
+    # Single-mesh scenes still use the multi path with one (ext=0, stl) entry.
+    stl_meshes_arg = mock_slice.call_args.args[0]
+    assert len(stl_meshes_arg) == 1
+    assert stl_meshes_arg[0][0] == 0
 
 
 # --- slice_stl_multi ---
@@ -782,10 +670,7 @@ def test_slice_plate_cura_multi_dispatch(tmp_path):
 
     output_dir = tmp_path / "output"
 
-    with (
-        patch("estampo.cura.slice_stl_multi", return_value=output_dir) as mock_multi,
-        patch("estampo.cura.slice_stl") as mock_single,
-    ):
+    with patch("estampo.cura.slice_stl_multi", return_value=output_dir) as mock_multi:
         result = slice_plate(
             input_3mf,
             engine="cura",
@@ -796,7 +681,6 @@ def test_slice_plate_cura_multi_dispatch(tmp_path):
 
     assert result == output_dir
     mock_multi.assert_called_once()
-    mock_single.assert_not_called()
 
     # Verify extruder indices are 0-based (filament_ids [1,2] → extruders [0,1])
     stl_meshes_arg = mock_multi.call_args[0][0]
@@ -894,32 +778,149 @@ def test_slice_stl_multi_per_extruder_in_command(tmp_path):
     assert "material_print_temperature=260" in e1_block
 
 
-def test_slice_plate_cura_single_filament_uses_slice_stl(tmp_path):
-    """slice_plate with a single filament slot falls back to slice_stl."""
+def test_slice_plate_cura_single_filament_uses_extruder_zero(tmp_path):
+    """Single-slot dispatch uses slice_stl_multi with all meshes on extruder 0."""
     import trimesh
 
     from estampo.slicer import slice_plate
 
     input_3mf = tmp_path / "plate.3mf"
-    scene = trimesh.Scene(trimesh.creation.box(extents=[10, 10, 10]))
+    mesh_a = trimesh.creation.box(extents=[10, 10, 10])
+    mesh_b = trimesh.creation.box(extents=[5, 5, 5])
+    mesh_b.vertices += [30, 0, 0]
+    scene = trimesh.Scene()
+    scene.add_geometry(mesh_a, geom_name="body")
+    scene.add_geometry(mesh_b, geom_name="cap")
     scene.export(str(input_3mf))
 
     output_dir = tmp_path / "output"
 
-    with (
-        patch("estampo.cura.slice_stl", return_value=output_dir) as mock_single,
-        patch("estampo.cura.slice_stl_multi") as mock_multi,
-    ):
+    with patch("estampo.cura.slice_stl_multi", return_value=output_dir) as mock_multi:
         slice_plate(
             input_3mf,
             engine="cura",
             output_dir=output_dir,
-            filament_ids=[1, 1],  # same slot — should not use multi path
+            filament_ids=[1, 1],
             docker_version="5.12.0",
         )
 
-    mock_single.assert_called_once()
-    mock_multi.assert_not_called()
+    mock_multi.assert_called_once()
+    stl_meshes_arg = mock_multi.call_args.args[0]
+    assert [ext for ext, _ in stl_meshes_arg] == [0, 0]
+
+
+def test_slice_plate_cura_positions_meshes_on_bed(tmp_path):
+    """slice_plate lifts meshes to Z≥0 and group-centers on the printer bed."""
+    import json
+
+    import trimesh
+
+    from estampo.slicer import slice_plate
+
+    # Minimal corner-origin printer definition with a known bed size.
+    defs = tmp_path / "profiles" / "cura" / "definitions"
+    defs.mkdir(parents=True)
+    (defs / "test_printer.def.json").write_text(
+        json.dumps(
+            {
+                "name": "Test Printer",
+                "inherits": "fdmprinter",
+                "overrides": {
+                    "machine_width": {"default_value": 200},
+                    "machine_depth": {"default_value": 200},
+                },
+            }
+        )
+    )
+
+    mesh_a = trimesh.creation.box(extents=[10, 10, 10])
+    mesh_b = trimesh.creation.box(extents=[5, 5, 5])
+    mesh_b.vertices += [30, 0, 0]
+    scene = trimesh.Scene()
+    scene.add_geometry(mesh_a, geom_name="body")
+    scene.add_geometry(mesh_b, geom_name="cap")
+    input_3mf = tmp_path / "plate.3mf"
+    scene.export(str(input_3mf))
+
+    output_dir = tmp_path / "output"
+
+    with patch("estampo.cura.slice_stl_multi", return_value=output_dir) as mock_multi:
+        slice_plate(
+            input_3mf,
+            engine="cura",
+            output_dir=output_dir,
+            printer="test_printer",
+            project_dir=tmp_path,
+            filament_ids=[1, 2],
+            docker_version="5.12.0",
+        )
+
+    stl_meshes_arg = mock_multi.call_args.args[0]
+    all_bounds = [trimesh.load(str(p), force="mesh").bounds for _, p in stl_meshes_arg]
+
+    # Group min Z is lifted to 0 (individual meshes can sit above 0 if the
+    # original scene spans Z, preserving their relative vertical offsets).
+    min_z = min(b[0][2] for b in all_bounds)
+    assert min_z == pytest.approx(0.0, abs=0.01)
+
+    # Group centroid is at bed center (corner-origin 200×200 printer)
+    min_x = min(b[0][0] for b in all_bounds)
+    max_x = max(b[1][0] for b in all_bounds)
+    min_y = min(b[0][1] for b in all_bounds)
+    max_y = max(b[1][1] for b in all_bounds)
+    assert (min_x + max_x) / 2 == pytest.approx(100.0, abs=0.1)
+    assert (min_y + max_y) / 2 == pytest.approx(100.0, abs=0.1)
+
+
+def test_slice_plate_cura_center_is_zero_printer(tmp_path):
+    """A center_is_zero printer centers meshes at (0,0), not (bed/2, bed/2)."""
+    import json
+
+    import trimesh
+
+    from estampo.slicer import slice_plate
+
+    # Printer definition with machine_center_is_zero=True
+    defs = tmp_path / "profiles" / "cura" / "definitions"
+    defs.mkdir(parents=True)
+    (defs / "center_origin_printer.def.json").write_text(
+        json.dumps(
+            {
+                "name": "Center Origin Printer",
+                "inherits": "fdmprinter",
+                "overrides": {
+                    "machine_width": {"default_value": 200},
+                    "machine_depth": {"default_value": 200},
+                    "machine_center_is_zero": {"default_value": True},
+                },
+            }
+        )
+    )
+
+    mesh = trimesh.creation.box(extents=[10, 10, 10])
+    mesh.vertices += [50, 30, 0]  # off-center
+    scene = trimesh.Scene(mesh)
+    input_3mf = tmp_path / "plate.3mf"
+    scene.export(str(input_3mf))
+
+    output_dir = tmp_path / "output"
+
+    with patch("estampo.cura.slice_stl_multi", return_value=output_dir) as mock_multi:
+        slice_plate(
+            input_3mf,
+            engine="cura",
+            output_dir=output_dir,
+            printer="center_origin_printer",
+            project_dir=tmp_path,
+            docker_version="5.12.0",
+        )
+
+    stl_meshes_arg = mock_multi.call_args.args[0]
+    placed = trimesh.load(str(stl_meshes_arg[0][1]), force="mesh")
+    cx = (placed.bounds[0][0] + placed.bounds[1][0]) / 2
+    cy = (placed.bounds[0][1] + placed.bounds[1][1]) / 2
+    assert cx == pytest.approx(0.0, abs=0.01)
+    assert cy == pytest.approx(0.0, abs=0.01)
 
 
 # --- _patch_gcode_header ---
@@ -963,84 +964,6 @@ def test_patch_gcode_header_no_match(tmp_path):
     gcode.write_text(original)
     _patch_gcode_header(gcode, "some random stderr output")
     assert gcode.read_text() == original
-
-
-# --- _place_on_bed ---
-
-
-def test_place_on_bed_shifts_negative_z(tmp_path):
-    """Mesh centered at origin (Z from -5 to +5) is shifted to Z≥0."""
-    import trimesh
-
-    mesh = trimesh.creation.box(extents=[10, 10, 10])
-    assert mesh.bounds[0][2] == pytest.approx(-5.0)
-
-    stl = tmp_path / "centered.stl"
-    mesh.export(str(stl))
-
-    staging = tmp_path / "staging"
-    staging.mkdir()
-    result = _place_on_bed(stl, staging)
-
-    placed = trimesh.load(str(result), force="mesh")
-    assert placed.bounds[0][2] == pytest.approx(0.0)
-    assert placed.bounds[1][2] == pytest.approx(10.0)
-
-
-def test_place_on_bed_already_on_bed(tmp_path):
-    """Mesh already on the bed (Z≥0) is not shifted."""
-    import trimesh
-
-    mesh = trimesh.creation.box(extents=[10, 10, 10])
-    mesh.vertices[:, 2] += 5  # shift so Z goes from 0 to 10
-
-    stl = tmp_path / "on_bed.stl"
-    mesh.export(str(stl))
-
-    staging = tmp_path / "staging"
-    staging.mkdir()
-    result = _place_on_bed(stl, staging)
-
-    placed = trimesh.load(str(result), force="mesh")
-    assert placed.bounds[0][2] == pytest.approx(0.0)
-    assert placed.bounds[1][2] == pytest.approx(10.0)
-
-
-def test_place_on_bed_corner_origin_centers_on_bed(tmp_path):
-    """center_is_zero=False → mesh centered at (bed_width/2, bed_depth/2)."""
-    import trimesh
-
-    mesh = trimesh.creation.box(extents=[10, 10, 10])  # centered at origin
-    stl = tmp_path / "part.stl"
-    mesh.export(str(stl))
-
-    staging = tmp_path / "staging"
-    staging.mkdir()
-    result = _place_on_bed(stl, staging, bed_width=200, bed_depth=200, center_is_zero=False)
-
-    placed = trimesh.load(str(result), force="mesh")
-    assert ((placed.bounds[0][0] + placed.bounds[1][0]) / 2) == pytest.approx(100.0)
-    assert ((placed.bounds[0][1] + placed.bounds[1][1]) / 2) == pytest.approx(100.0)
-
-
-def test_place_on_bed_center_origin_keeps_mesh_at_zero(tmp_path):
-    """center_is_zero=True → mesh centered at (0, 0)."""
-    import trimesh
-
-    mesh = trimesh.creation.box(extents=[10, 10, 10])
-    mesh.vertices[:, 0] += 50  # shift off-center so we can verify re-centering
-    mesh.vertices[:, 1] += 30
-
-    stl = tmp_path / "part.stl"
-    mesh.export(str(stl))
-
-    staging = tmp_path / "staging"
-    staging.mkdir()
-    result = _place_on_bed(stl, staging, bed_width=200, bed_depth=200, center_is_zero=True)
-
-    placed = trimesh.load(str(result), force="mesh")
-    assert ((placed.bounds[0][0] + placed.bounds[1][0]) / 2) == pytest.approx(0.0)
-    assert ((placed.bounds[0][1] + placed.bounds[1][1]) / 2) == pytest.approx(0.0)
 
 
 # --- resolve_cura_center_is_zero ---

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -872,6 +872,36 @@ def test_slice_plate_cura_positions_meshes_on_bed(tmp_path):
     assert (min_y + max_y) / 2 == pytest.approx(100.0, abs=0.1)
 
 
+def test_slice_plate_cura_preserves_z_when_already_above_bed(tmp_path):
+    """A mesh already at Z>0 is not shifted down — only lifted when Z<0."""
+    import trimesh
+
+    from estampo.slicer import slice_plate
+
+    # Mesh sitting at Z: 5..15 (already above bed).
+    mesh = trimesh.creation.box(extents=[10, 10, 10])
+    mesh.vertices[:, 2] += 10  # now Z: 5..15
+    scene = trimesh.Scene(mesh)
+    input_3mf = tmp_path / "plate.3mf"
+    scene.export(str(input_3mf))
+
+    output_dir = tmp_path / "output"
+
+    with patch("estampo.cura.slice_stl_multi", return_value=output_dir) as mock_multi:
+        slice_plate(
+            input_3mf,
+            engine="cura",
+            output_dir=output_dir,
+            docker_version="5.12.0",
+        )
+
+    stl_meshes_arg = mock_multi.call_args.args[0]
+    placed = trimesh.load(str(stl_meshes_arg[0][1]), force="mesh")
+    # Z range preserved (5..15), not re-lifted to 0..10.
+    assert placed.bounds[0][2] == pytest.approx(5.0, abs=0.01)
+    assert placed.bounds[1][2] == pytest.approx(15.0, abs=0.01)
+
+
 def test_slice_plate_cura_center_is_zero_printer(tmp_path):
     """A center_is_zero printer centers meshes at (0,0), not (bed/2, bed/2)."""
     import json

--- a/tests/test_engine_config_e2e.py
+++ b/tests/test_engine_config_e2e.py
@@ -293,7 +293,7 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         assert per_extruder == []
 
     def test_cura_slice_dispatch(self, tmp_path):
-        """Config with engine=cura dispatches to cura.slice_stl."""
+        """Config with engine=cura dispatches to cura.slice_stl_multi."""
         import trimesh
 
         from estampo.slicer import slice_plate
@@ -321,7 +321,7 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         )
         cfg = load_config(path)
 
-        with patch("estampo.cura.slice_stl", return_value=output_dir) as mock_slice:
+        with patch("estampo.cura.slice_stl_multi", return_value=output_dir) as mock_slice:
             result = slice_plate(
                 input_3mf,
                 engine=cfg.slicer.engine,


### PR DESCRIPTION
## Summary

- Delete the merge-into-single-STL fallback in `slice_plate`'s cura branch — always extract per-part meshes, group-center, and pass to `slice_stl_multi`.
- Delete `slice_stl` and `_place_on_bed` from `cura.py`; placement now lives at the dispatch layer where it can see the whole scene.
- Update tests to reflect the unified path; add centering/Z-lift assertions that cover what `_place_on_bed` used to verify.

### Why

The single-mesh path had a buggy duplicated `-g -e0 {settings_str}` emission (#591) and was not exercised by any working example. The multi-mesh path has been solid since ADR-008 (#603/#608/#609) and produces correct brim/skirt.

### Verification

- All pre-PR checks pass: ruff, ruff format, mypy, pytest (615 passed, 9 skipped).
- Functional repro against a 4-part plate (all PLA, single extruder) via `estampo run --local` in the cura Docker image: 215 KB G-code, 685 layer-0 moves, SKIRT markers present.
- Functional repro for a single-box scene (the case that previously hit the deleted merge path): 389 KB G-code, brim emitted.

Incidentally closes #591 by removing the buggy code path.

Closes #602

## Test plan

- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] `uv run mypy src/estampo`
- [x] `uv run pytest`
- [x] Functional slice: multi-part single-filament plate produces brim
- [x] Functional slice: single-mesh scene produces brim

🤖 Generated with [Claude Code](https://claude.com/claude-code)