### PR TITLE
Docs: remove stale CuraProfile references after ADR-008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ All notable changes to this project are documented here.
 ### Features
 
 - Multi-mesh CuraEngine slicing: parts on different filament slots are passed as separate ``-g -eN`` groups, preserving plate arrangement and extruder assignments ([#405](https://github.com/estampo/estampo/pull/405))
-- Per-extruder filament profiles for CuraEngine: filament type and temperatures are set independently per AMS slot via ``CuraProfile.per_extruder`` ([#406](https://github.com/estampo/estampo/pull/406))
+- Per-extruder filament profiles for CuraEngine: filament type and temperatures are set independently per AMS slot via ``CuraProfile.per_extruder`` ([#406](https://github.com/estampo/estampo/pull/406)) *(API superseded in v0.4.0 — ``CuraProfile`` removed, see ADR-008)*
 - Pipeline stages can now run external CLI commands defined in TOML (e.g. ``bambox pack``), enabling tool integration without Python dependencies.
 
 ### Bugfixes

--- a/changes/+docs-stale-cura-refs-614.misc
+++ b/changes/+docs-stale-cura-refs-614.misc
@@ -1,0 +1,1 @@
+Remove stale ``CuraProfile`` references from docs after ADR-008: fix "squashed" → "verbatim" in ``cura.py`` def-chain docstring, rewrite ``todo-slicer.md`` CuraEngine profile-pin note, and annotate the v0.3.1 changelog entry that mentioned the removed API.

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -208,7 +208,7 @@ def _resolve_def_chain(
     ``[ultimaker2.def.json]``.
 
     Search order per definition:
-    1. Pinned (squashed) in ``profiles/cura/definitions/``
+    1. Pinned (verbatim) in ``profiles/cura/definitions/``
     2. Bundled with estampo in ``src/estampo/data/``
     """
     chain: list[Path] = []

--- a/todo-slicer.md
+++ b/todo-slicer.md
@@ -71,8 +71,10 @@ CuraEngine exists alongside OrcaSlicer.
   OrcaSlicer-style project 3MFs. `estampo init --from-3mf` is an OrcaSlicer
   convenience feature.
 
-- **Profile pin/list for CuraEngine**: CuraEngine has no extractable profile
-  chain — settings are inline in `CuraProfile`. No equivalent to OrcaSlicer's
+- **Profile pin/list for CuraEngine**: CuraEngine has no OrcaSlicer-style
+  profile chain to pin or list. Printer settings come from pinned ``.def.json``
+  files; per-slice process/filament settings are passed verbatim via
+  ``[slicer.cura.overrides]`` (see ADR-008). No equivalent to OrcaSlicer's
   printer/process/filament profile discovery.
 
 - **`auth.py` BBL client name**: This header is for Bambu Cloud API


### PR DESCRIPTION
## Summary

Three stale doc references left over from ADR-008 (``CuraProfile`` removal + verbatim def pinning):

- `src/estampo/cura.py:211` — def-chain docstring said "Pinned (squashed)"; PR #603 switched to verbatim chain copy
- `todo-slicer.md:75` — "Won't fix" note said settings are "inline in ``CuraProfile``"; class no longer exists
- `CHANGELOG.md:142` — v0.3.1 entry mentioned ``CuraProfile.per_extruder``; annotated with "API superseded in v0.4.0 — see ADR-008" rather than rewriting history

Closes #614

## Test plan
- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] `uv run mypy src/estampo`
- [x] `uv run pytest` (616 passed, 9 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)