### PR TITLE
Fix release.yml detect-release race via commit-subject parsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,24 +18,27 @@ jobs:
       is_release: ${{ steps.check.outputs.is_release }}
       version: ${{ steps.check.outputs.version }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Check if this is a release PR merge
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SHA="${{ github.sha }}"
-          echo "Checking commit $SHA for associated release PR..."
+          SUBJECT=$(git log -1 --format=%s "$SHA")
+          echo "Commit subject: ${SUBJECT}"
 
-          # Find merged PRs associated with this commit whose head branch
-          # matches the release/vX.Y.Z pattern created by prepare-release.
-          # This API call must succeed — if it fails, the job fails rather
-          # than silently skipping a release.
-          BRANCHES=$(gh api "repos/${{ github.repository }}/commits/${SHA}/pulls" \
-            --jq '.[].head.ref')
-          echo "Associated PR branches: ${BRANCHES:-<none>}"
-
-          VERSION=$(echo "$BRANCHES" \
-            | grep -oP '^release/v\K\d+\.\d+\.\d+((a|b|rc)\d+)?$' \
+          # Parse the merge-commit subject rather than querying the
+          # commits→PRs API. GitHub's PR-association endpoint is
+          # eventually consistent and can return [] immediately after a
+          # merge, silently skipping the release (see #616). Merge commits
+          # from the "Merge pull request" button are deterministic:
+          #   "Merge pull request #613 from estampo/release/v0.4.0b4"
+          VERSION=$(echo "$SUBJECT" \
+            | grep -oP '^Merge pull request #\d+ from [^/]+/release/v\K\d+\.\d+\.\d+((a|b|rc)\d+)?$' \
             | head -1 || true)
 
           if [[ -n "$VERSION" ]]; then
@@ -48,6 +51,11 @@ jobs:
               echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
               echo "::notice::Detected release PR merge for v${VERSION}"
             fi
+          elif [[ "$SUBJECT" =~ ^Merge\ pull\ request\ #[0-9]+\ from\ [^/]+/release/ ]]; then
+            # Commit looks like a release PR merge but the version
+            # doesn't parse — fail loud rather than silently skip.
+            echo "::error::Commit subject looks like a release PR merge but the branch does not match 'release/vX.Y.Z[abrc]N?': ${SUBJECT}"
+            exit 1
           else
             echo "is_release=false" >> "$GITHUB_OUTPUT"
           fi

--- a/changes/616.bugfix
+++ b/changes/616.bugfix
@@ -1,0 +1,1 @@
+Fix ``release.yml`` silently skipping the publish pipeline when the GitHub commits→PR API hasn't yet associated the merge commit with the release PR. ``detect-release`` now parses the merge-commit subject (deterministic) instead of relying on eventually-consistent API data, and fails loud if a release-like commit can't be parsed.


### PR DESCRIPTION
## Summary

``detect-release`` was calling ``gh api repos/…/commits/$SHA/pulls`` to find the release PR branch. That API is eventually consistent — immediately after a merge it can return ``[]``, causing the job to silently set ``is_release=false`` and skip the entire publish pipeline. This happened for v0.4.0b4 (run 24630266631).

Parse the merge-commit subject instead. GitHub's "Merge pull request" button produces deterministic subjects like:

    Merge pull request #613 from estampo/release/v0.4.0b4

Also fail loud (not silently skip) when the subject looks like a release PR merge but the version regex doesn't match — catches mistyped release branches.

Closes #616

## Test plan
- [x] Regex tested locally against representative subjects (stable/alpha/beta/rc, non-release merges, malformed versions)
- [x] ``uv run ruff check`` / ``ruff format --check`` / ``mypy`` clean
- [ ] Verified on the next real release (v0.4.0b5 or v0.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)