### PR TITLE
Fix CuraEngine template resolution regression in v0.4.0b4 (#619)

### DIFF
--- a/changes/619.bugfix
+++ b/changes/619.bugfix
@@ -1,0 +1,1 @@
+Fix CuraEngine template variables like ``{material_bed_temperature_layer_0}`` no longer being resolved in v0.4.0b4. ``cura_settings.json`` now includes the extruder-0 filament temperatures (regression introduced by ADR-008 PR 2/3 when ``CuraProfile`` was dropped — the temp keys used to be written into the global settings dict and were inadvertently demoted to per-extruder only).

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -851,6 +851,7 @@ def _write_cura_settings(
     output_dir: Path,
     overrides: CuraOverrides,
     machine_dims: dict[str, float] | None = None,
+    per_extruder: CuraPerExtruder | None = None,
 ) -> Path:
     """Write CuraEngine settings to JSON for downstream command stages.
 
@@ -859,10 +860,17 @@ def _write_cura_settings(
 
     *machine_dims* adds machine geometry (width, depth, height) so that
     template variables like ``{machine_height}`` can be resolved.
+
+    *per_extruder* — extruder-0 values are merged in so that start-gcode
+    template variables like ``{material_bed_temperature_layer_0}`` and
+    ``{material_print_temperature_layer_0}`` resolve to the first
+    extruder's filament values (start gcode runs before any tool change).
     """
     settings = _settings_dict(overrides)
     if machine_dims:
         settings.update(machine_dims)
+    if per_extruder:
+        settings.update(per_extruder[0])
     settings_path = output_dir / "cura_settings.json"
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")
     log.info("Wrote CuraEngine settings: %s", settings_path)
@@ -1007,6 +1015,7 @@ def _run_docker_slice(
     output_stem: str,
     overrides: CuraOverrides,
     machine_dims: dict[str, float] | None = None,
+    per_extruder: CuraPerExtruder | None = None,
 ) -> Path:
     """Run CuraEngine via Docker, validate output, and post-process G-code.
 
@@ -1060,7 +1069,7 @@ def _run_docker_slice(
 
     _surface_cura_warnings(result.stderr)
     _patch_gcode_header(output_gcode, result.stderr)
-    _write_cura_settings(output_dir, overrides, machine_dims)
+    _write_cura_settings(output_dir, overrides, machine_dims, per_extruder)
 
     log.info("CuraEngine output: %s (%d bytes)", output_gcode, output_gcode.stat().st_size)
     return output_dir
@@ -1073,6 +1082,7 @@ def _run_local_slice(
     output_stem: str,
     overrides: CuraOverrides,
     machine_dims: dict[str, float] | None = None,
+    per_extruder: CuraPerExtruder | None = None,
 ) -> Path:
     """Run CuraEngine locally (without Docker), validate output, and post-process G-code.
 
@@ -1108,7 +1118,7 @@ def _run_local_slice(
 
     _surface_cura_warnings(result.stderr)
     _patch_gcode_header(output_gcode, result.stderr)
-    _write_cura_settings(output_dir, overrides, machine_dims)
+    _write_cura_settings(output_dir, overrides, machine_dims, per_extruder)
 
     log.info("CuraEngine output: %s (%d bytes)", output_gcode, output_gcode.stat().st_size)
     return output_dir
@@ -1180,7 +1190,9 @@ def slice_stl_multi(
             cura_args.extend(["-g", f"-e{ext_idx}"])
             cura_args.extend(_extruder_settings_list(overrides, per_extruder, ext_idx))
             cura_args.extend(["-l", str(staging / stl_path.name)])
-        return _run_local_slice(cura_args, output_dir, staging, "plate", overrides, machine_dims)
+        return _run_local_slice(
+            cura_args, output_dir, staging, "plate", overrides, machine_dims, per_extruder
+        )
 
     c_staging = "/work/output/.cura-staging"
     c_output = "/work/output/plate.gcode"
@@ -1203,7 +1215,7 @@ def slice_stl_multi(
     )
 
     return _run_docker_slice(
-        inner_cmd, image, output_dir, staging, "plate", overrides, machine_dims
+        inner_cmd, image, output_dir, staging, "plate", overrides, machine_dims, per_extruder
     )
 
 

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -1088,6 +1088,29 @@ def test_write_cura_settings_includes_machine_dims(tmp_path):
     assert data["machine_height"] == 250.0
 
 
+def test_write_cura_settings_includes_per_extruder_temps(tmp_path):
+    """Per-extruder[0] temps land in JSON so start-gcode templates resolve (#619)."""
+    import json
+
+    per_extruder = [
+        {
+            "material_type": "PLA",
+            "material_print_temperature": 220,
+            "material_print_temperature_layer_0": 220,
+            "material_bed_temperature": 60,
+            "material_bed_temperature_layer_0": 60,
+        },
+        {"material_type": "PETG"},  # extruder 1 — not written to JSON
+    ]
+    path = _write_cura_settings(tmp_path, {}, per_extruder=per_extruder)
+    data = json.loads(path.read_text())
+    assert data["material_bed_temperature_layer_0"] == 60
+    assert data["material_print_temperature_layer_0"] == 220
+    assert data["material_bed_temperature"] == 60
+    assert data["material_print_temperature"] == 220
+    assert data["material_type"] == "PLA"
+
+
 # --- resolve_cura_machine_dims ---
 
 


### PR DESCRIPTION
## Summary

Regression introduced by PR #608 (ADR-008 PR 2/3). After dropping the ``CuraProfile`` wrapper, filament-derived temperature values (``material_bed_temperature_layer_0`` etc.) are passed to CuraEngine as per-extruder ``-s`` flags but are **not** written to ``cura_settings.json``. The ``resolve_templates`` command stage reads ``cura_settings.json`` to substitute start-gcode template variables — with the keys missing, unsubstituted ``M140 S{material_bed_temperature_layer_0}`` lands in the final output and fails ``bambox validate``.

Fix: thread ``per_extruder`` into ``_write_cura_settings`` and merge index 0 (start gcode runs before any tool change, so extruder 0's values are what ``_layer_0`` templates refer to).

## Repro

User-reported via ``estampo run`` with a Bambu P1S + PLA config on v0.4.0b4:

    bambox validate estampo_output/plate.gcode.3mf
      ERROR E001: Non-numeric temperature command
      [M140 S{material_bed_temperature_layer_0} ;set bed temp]
      ERROR E005: Unsubstituted template: {material_bed_temperature_layer_0}

Closes #619

## Test plan
- [x] New regression test: ``test_write_cura_settings_includes_per_extruder_temps``
- [x] ``uv run pytest`` — 617 passed, 9 skipped
- [x] ``uv run ruff check`` / ``ruff format --check`` / ``mypy`` clean
- [ ] User verifies the fix resolves their ``bambox validate`` errors on next v0.4.0b5

🤖 Generated with [Claude Code](https://claude.com/claude-code)