### PR TITLE
Log CuraEngine placement inputs to diagnose #621

### DIFF
--- a/changes/+cura-placement-diagnostic.misc
+++ b/changes/+cura-placement-diagnostic.misc
@@ -1,0 +1,1 @@
+Log CuraEngine placement inputs (bed size, ``machine_center_is_zero``, group bounds, delta) to aid diagnosis of #621.

--- a/src/estampo/cura.py
+++ b/src/estampo/cura.py
@@ -390,7 +390,18 @@ def resolve_cura_center_is_zero(
             if val is None:
                 val = entry.get("value")
             if val is not None:
+                log.info(
+                    "resolve_cura_center_is_zero(%r) -> %s from %s",
+                    printer_name,
+                    bool(val),
+                    path,
+                )
                 return bool(val)
+    log.info(
+        "resolve_cura_center_is_zero(%r) -> False (default; chain=%s)",
+        printer_name,
+        [str(p) for p in chain],
+    )
     return False
 
 

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -188,6 +188,27 @@ def slice_plate(
         dy = float(target_y - (group_min[1] + group_max[1]) / 2)
         dz = float(-group_min[2]) if group_min[2] < 0 else 0.0
 
+        # Diagnostic for #621: surface inputs + delta so a single slice
+        # reveals whether a +bed/2 shift is coming from the resolver, the
+        # bed size, or from CuraEngine re-interpreting the STL.
+        log.info(
+            "cura placement: bed=(%.1f,%.1f) center_is_zero=%s "
+            "target=(%.1f,%.1f) group=(%.1f..%.1f, %.1f..%.1f) "
+            "delta=(%.2f,%.2f,%.2f)",
+            bed_w,
+            bed_d,
+            center_is_zero,
+            target_x,
+            target_y,
+            group_min[0],
+            group_max[0],
+            group_min[1],
+            group_max[1],
+            dx,
+            dy,
+            dz,
+        )
+
         stl_dir = output_dir / ".cura-parts"
         stl_dir.mkdir(exist_ok=True)
         stl_meshes: list[tuple[int, Path]] = []


### PR DESCRIPTION
## Summary

- Adds an INFO log line in `slice_plate` (cura branch) just before the translate loop, surfacing bed size, `machine_center_is_zero`, target, group bounds, and the computed delta.
- Adds an INFO log line in `resolve_cura_center_is_zero` showing which def file supplied the answer (or that the `False` default was used, with the resolved chain).
- Diagnostic-only — no behavior change, tests & types unchanged.

Per the hypothesis list in #621, one slice on P1S with these lines disambiguates which input is wrong.

Refs #621

## Test plan
- [ ] `uv run ruff check src tests` ✅ locally
- [ ] `uv run ruff format --check src tests` ✅ locally
- [ ] `uv run mypy src/estampo` ✅ locally
- [ ] `uv run pytest` ✅ locally (623 passed)
- [ ] Run a P1S slice with `-v` and confirm both log lines appear and match the observed +128 shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)