### PR TITLE
Center CuraEngine meshes at (0,0) to fix +bed/2 print shift

### DIFF
--- a/changes/+cura-placement-center.bugfix
+++ b/changes/+cura-placement-center.bugfix
@@ -1,0 +1,1 @@
+Fix CuraEngine placement shifting prints by ``+bed/2`` in each axis on corner-origin printers (regression from ADR-008). STLs are now centred at ``(0, 0)`` — CuraEngine's own ``machine_center_is_zero`` convention lands the print at bed centre.

--- a/src/estampo/slicer.py
+++ b/src/estampo/slicer.py
@@ -127,8 +127,6 @@ def slice_plate(
         from estampo.cura import (
             build_cura_config,
             cura_docker_image,
-            resolve_cura_bed_size,
-            resolve_cura_center_is_zero,
             slice_stl_multi,
         )
 
@@ -176,16 +174,15 @@ def slice_plate(
                 )
             extruder_ids = [0] * len(meshes)
 
-        bed_w, bed_d = resolve_cura_bed_size(printer or "", project_dir, profiles_dir)
-        center_is_zero = resolve_cura_center_is_zero(printer or "", project_dir, profiles_dir)
-        target_x = 0.0 if center_is_zero else bed_w / 2
-        target_y = 0.0 if center_is_zero else bed_d / 2
-
+        # CuraEngine shifts input coords by +bed/2 when
+        # machine_center_is_zero=false, and passes them through when =true.
+        # Either way, centring the mesh group at (0, 0) lands the print at
+        # bed centre in the resulting G-code — see #621 for the diagnosis.
         bounds = np.array([m.bounds for m in meshes])
         group_min = bounds[:, 0, :].min(axis=0)
         group_max = bounds[:, 1, :].max(axis=0)
-        dx = float(target_x - (group_min[0] + group_max[0]) / 2)
-        dy = float(target_y - (group_min[1] + group_max[1]) / 2)
+        dx = float(-(group_min[0] + group_max[0]) / 2)
+        dy = float(-(group_min[1] + group_max[1]) / 2)
         dz = float(-group_min[2]) if group_min[2] < 0 else 0.0
 
         stl_dir = output_dir / ".cura-parts"

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -810,7 +810,12 @@ def test_slice_plate_cura_single_filament_uses_extruder_zero(tmp_path):
 
 
 def test_slice_plate_cura_positions_meshes_on_bed(tmp_path):
-    """slice_plate lifts meshes to Z≥0 and group-centers on the printer bed."""
+    """slice_plate lifts meshes to Z≥0 and group-centers at (0, 0).
+
+    CuraEngine shifts input coords by +bed/2 when machine_center_is_zero=false
+    and passes them through when =true; either way, centring the mesh at
+    (0, 0) lands the print at bed centre in the G-code (see #621).
+    """
     import json
 
     import trimesh
@@ -863,13 +868,13 @@ def test_slice_plate_cura_positions_meshes_on_bed(tmp_path):
     min_z = min(b[0][2] for b in all_bounds)
     assert min_z == pytest.approx(0.0, abs=0.01)
 
-    # Group centroid is at bed center (corner-origin 200×200 printer)
+    # Group centroid is at (0, 0) — CuraEngine adds its own +bed/2 shift.
     min_x = min(b[0][0] for b in all_bounds)
     max_x = max(b[1][0] for b in all_bounds)
     min_y = min(b[0][1] for b in all_bounds)
     max_y = max(b[1][1] for b in all_bounds)
-    assert (min_x + max_x) / 2 == pytest.approx(100.0, abs=0.1)
-    assert (min_y + max_y) / 2 == pytest.approx(100.0, abs=0.1)
+    assert (min_x + max_x) / 2 == pytest.approx(0.0, abs=0.1)
+    assert (min_y + max_y) / 2 == pytest.approx(0.0, abs=0.1)
 
 
 def test_slice_plate_cura_preserves_z_when_already_above_bed(tmp_path):


### PR DESCRIPTION
## Summary

The new ADR-008 placement in `slicer.py` centred the mesh group at `(bed_w/2, bed_d/2)` for `machine_center_is_zero=false` printers, but CuraEngine itself adds `+bed/2` to input coords under that setting (it treats the STL as centre-origin, converts to corner-origin on output). Result: a **double shift** landing the print at `(bed_w, bed_d)` — the far bed corner — instead of bed centre.

### Evidence (Bambu P1S via `~/repos/g3d`)
Resolver and Python side were innocent (diagnostic from #622):
```
resolve_cura_center_is_zero('bambox_p1s_ams') -> False from .../bambox_p1s.def.json
cura placement: bed=(256,256) center_is_zero=False target=(128,128) group=(-49..49, -10..10) delta=(128,128,0)
```
`.cura-parts/part_*.stl` had group centre (128, 128). But `plate.gcode` layer 5 had parts centred at **(256, 256)** — a +128 shift from STL input.

Forcing `-s machine_center_is_zero=true` (passthrough) pulled the layer-5 centre to **(128, 128)** — confirming CuraEngine is the one doing the shift.

### Fix
Drop the `bed/2`-when-corner-origin branch and always centre the mesh group at `(0, 0)`. CuraEngine's own convention handles the rest: shift under `false`, passthrough under `true`. Either way the G-code lands at bed centre.

Verified on the same g3d project: layer 5 now centred at **(128, 128)**, matching the pre-ADR-008 baseline from handoff §7.

Also drops the now-unused `resolve_cura_bed_size` / `resolve_cura_center_is_zero` imports in `slicer.py`. The helpers themselves remain in `cura.py` (documented public API).

Closes #621

## Test plan
- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] `uv run mypy src/estampo`
- [x] `uv run pytest` — 623 passed, 3 skipped
- [x] Real P1S slice on `~/repos/g3d`: before = `(256, 256)`, after = `(128, 128)`
- [ ] Reviewer sanity-check on a non-P1S corner-origin printer (e.g. Ultimaker 2)
- [ ] Reviewer sanity-check on a centre-origin printer (delta / `machine_center_is_zero=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)