### PR TITLE
Document uv install and Python 3.11–3.13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ If you mostly want interactive print setup in a GUI, use OrcaSlicer or Cura dire
 
 ## Quick start
 
-**Prerequisites:** Python 3.11+ and [Docker](https://docs.docker.com/get-docker/). Docker is
-central to estampo — it runs the slicer (OrcaSlicer or CuraEngine) in a container with a pinned
+**Prerequisites:** Python 3.11, 3.12, or 3.13 (3.14 is not yet supported) and [Docker](https://docs.docker.com/get-docker/).
+Docker is central to estampo — it runs the slicer (OrcaSlicer or CuraEngine) in a container with a pinned
 version so every machine produces identical G-code. A locally installed slicer can be used as a
 fallback but is not recommended.
 
@@ -185,6 +185,8 @@ fallback but is not recommended.
 pip install estampo
 # or, to install as an isolated CLI tool:
 pipx install estampo
+# or, with uv:
+uv tool install estampo
 ```
 
 Generate a config with the interactive wizard, or dump a commented template:

--- a/changes/624.misc
+++ b/changes/624.misc
@@ -1,0 +1,1 @@
+README: show ``uv tool install estampo`` alongside pip/pipx, and specify Python 3.11–3.13 support (3.14 is not yet tested).


### PR DESCRIPTION
## Summary

- README Quick start: add `uv tool install estampo` alongside `pip` / `pipx` so uv users don't have to translate the command.
- README prerequisites: change "Python 3.11+" to "Python 3.11, 3.12, or 3.13 (3.14 is not yet supported)". The classifiers in `pyproject.toml` and the CI matrix in `.github/workflows/ci.yml` already reflect this — the README was the outlier.
- `docs/ai-setup-prompt.md` already lists uv as Option C, so no change there — the README now matches.

Out of scope: tightening `requires-python = ">=3.11"` to `>=3.11,<3.14`. That's a separate policy decision and can be a follow-up if we want to actually block 3.14 installs.

Closes #624

## Test plan

- [x] `uv run ruff check src tests` — passes
- [x] `uv run ruff format --check src tests` — passes
- [x] `uv run mypy src/estampo` — passes
- [x] `uv run pytest` — 623 passed, 3 skipped
- [ ] Eyeball the rendered README on GitHub once the PR opens