### PR TITLE
Surface Orca stdout on slice failure (fixes silent exit 239)

### DIFF
--- a/changes/626.bugfix
+++ b/changes/626.bugfix
@@ -1,0 +1,1 @@
+Surface OrcaSlicer stdout on slice failure so the real error (e.g. ``process not compatible with printer`` producing silent exit 239) reaches the user.

--- a/src/estampo/orca.py
+++ b/src/estampo/orca.py
@@ -250,9 +250,13 @@ def _slice_via_docker(
     staged_input.unlink(missing_ok=True)
 
     if result.returncode != 0:
-        log.error("Docker slicer stderr:\n%s", result.stderr)
+        # OrcaSlicer writes its `[error] ... run found error, return -N, exit...`
+        # diagnostics to stdout, not stderr. Surface both so the user can see
+        # the real cause (e.g. incompatible process/printer → exit 239).
+        combined = (result.stdout + "\n" + result.stderr).strip()
+        log.error("Docker slicer output:\n%s", combined)
         raise RuntimeError(
-            f"Docker slicer failed (exit code {result.returncode}):\n{result.stderr[:500]}"
+            f"Docker slicer failed (exit code {result.returncode}):\n{combined[-500:]}"
         )
 
     log.info("Docker slicer stdout:\n%s", result.stdout)
@@ -480,8 +484,9 @@ def _slice_local(
         )
 
     if result.returncode != 0:
-        log.error("Slicer stderr:\n%s", result.stderr)
-        raise RuntimeError(f"Slicer failed (exit code {result.returncode}):\n{result.stderr[:500]}")
+        combined = (result.stdout + "\n" + result.stderr).strip()
+        log.error("Slicer output:\n%s", combined)
+        raise RuntimeError(f"Slicer failed (exit code {result.returncode}):\n{combined[-500:]}")
 
     log.info("Slicer stdout:\n%s", result.stdout)
     log.info("Slicing complete. Output in %s", output_dir)

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -446,6 +446,29 @@ def test_slice_via_docker_failure(tmp_path):
             )
 
 
+def test_slice_via_docker_surfaces_stdout_on_failure(tmp_path):
+    """OrcaSlicer writes errors to stdout (e.g. 'run found error, return -17').
+
+    The failure message must include stdout so users can diagnose issues like
+    incompatible process/printer pairings (surfaces as silent exit 239).
+    """
+    input_3mf = tmp_path / "plate.3mf"
+    input_3mf.write_text("fake")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    profile_dir = output_dir / ".profiles"
+    profile_dir.mkdir()
+
+    stdout = (
+        "[2026-04-19 19:18:01.332] [error]   run 2310: process not compatible with printer.\n"
+        "run found error, return -17, exit..."
+    )
+    mock_result = MagicMock(returncode=239, stdout=stdout, stderr="")
+    with patch("estampo.orca.subprocess.run", return_value=mock_result):
+        with pytest.raises(RuntimeError, match="process not compatible with printer"):
+            _slice_via_docker(input_3mf, output_dir, profile_dir, None, None, "estampo:latest")
+
+
 # --- slice_plate integration ---
 
 


### PR DESCRIPTION
## Summary
- OrcaSlicer writes its real error messages (including the final `run found error, return -N, exit...`) to **stdout**, not stderr.
- \`orca.py\` was logging only stderr on non-zero exit, so failures appeared as a bare exit code — e.g. exit **239** (from \`return -17\`) with empty error text.
- Now combines stdout+stderr in both the Docker and local code paths and includes the trailing 500 chars in the exception message.

## Repro before this PR
\`\`\`
ERROR: Docker slicer stderr:

✗ Slicing failed — Docker slicer failed (exit code 239):
\`\`\`

## After this PR
\`\`\`
✗ Slicing failed — Docker slicer failed (exit code 239):
[error]   run 2310: process not compatible with printer.
run found error, return -17, exit...
\`\`\`

## Test plan
- [x] New test \`test_slice_via_docker_surfaces_stdout_on_failure\` asserts stdout content is in the raised \`RuntimeError\`
- [x] \`uv run ruff check src tests\`
- [x] \`uv run ruff format --check src tests\`
- [x] \`uv run mypy src/estampo\`
- [x] \`uv run pytest\` (618 passed, 9 skipped)

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)