### PR TITLE
Validate process/printer compatibility in `estampo validate` (#627)

### DIFF
--- a/changes/627.feature
+++ b/changes/627.feature
@@ -1,0 +1,1 @@
+``estampo validate`` now checks that the pinned process profile's ``compatible_printers`` list includes the active ``slicer.printer``, catching mismatches before the slice (which would otherwise surface as a silent OrcaSlicer exit 239).

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from estampo import EstampoError
 from estampo.config import DEFAULT_STAGES, SUPPORTED_EXTENSIONS
 
 if TYPE_CHECKING:
@@ -241,6 +242,48 @@ def _check_profile_type(name: str, engine: str, category: str) -> str | None:
         return None
 
 
+def _check_orca_process_compat(
+    printer: str, process: str, project_dir: Path, profiles_dir: str
+) -> str | None:
+    """Verify the process's ``compatible_printers`` list contains *printer*.
+
+    Loads the flattened process profile (pinned → system → bundled) and reads
+    the resolved ``compatible_printers`` list. Returns a warning string if the
+    printer is missing from the list, otherwise ``None``.
+
+    Returns ``None`` when compatibility cannot be determined (process file not
+    readable, or ``compatible_printers_condition`` is set — a dynamic Orca
+    expression we can't evaluate statically).
+    """
+    from estampo.profiles import resolve_profile_data
+
+    try:
+        data = resolve_profile_data(
+            process, "orca", "process", project_dir=project_dir, profiles_dir=profiles_dir
+        )
+    except (EstampoError, FileNotFoundError, OSError):
+        return None
+
+    if data.get("compatible_printers_condition"):
+        return None
+
+    compat = data.get("compatible_printers")
+    if not compat or not isinstance(compat, list):
+        return None
+
+    if printer in compat:
+        return None
+
+    compat_str = ", ".join(f"'{p}'" for p in compat)
+    return (
+        f"slicer.process '{process}' is not compatible with slicer.printer '{printer}'.\n"
+        f"  Process's compatible_printers: {compat_str}.\n"
+        f"  Note: this combination fails at slice time with a silent exit 239.\n"
+        f"  Fix: pick a process whose compatible_printers includes '{printer}', "
+        f"or choose a different printer."
+    )
+
+
 def validate_config(path: Path) -> ValidationResult:
     """Validate an estampo.toml and return passes and warnings.
 
@@ -341,6 +384,21 @@ def validate_config(path: Path) -> ValidationResult:
 
         if profile_ok:
             passes.append(f"Slicer profiles valid ({source})")
+
+        # Check process/printer compatibility (OrcaSlicer only).
+        # The pinned process JSON has a `compatible_printers` list. When the
+        # active printer isn't in it, OrcaSlicer rejects the slice with
+        # `run found error, return -17, exit...` which surfaces as exit 239.
+        if profile_ok and orca and active.printer and orca.process:
+            compat_warning = _check_orca_process_compat(
+                active.printer, orca.process, cfg.base_dir, cfg.slicer.profiles_dir
+            )
+            if compat_warning:
+                warnings.append(compat_warning)
+            else:
+                passes.append(
+                    f"Process '{orca.process}' compatible with printer '{active.printer}'"
+                )
     else:
         warnings.append(
             f"slicer profile names could not be validated — no {cfg.slicer.engine} "

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -501,6 +501,99 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         result = validate_config(toml)
         assert any("override keys valid" in p.lower() for p in result.passes)
 
+    def test_process_printer_compat_mismatch_warns(self, tmp_path):
+        """Process listed with an incompatible printer produces a compat warning."""
+        process_dir = tmp_path / "profiles" / "orca" / "process"
+        process_dir.mkdir(parents=True)
+        (process_dir / "HighQuality P1P.json").write_text(
+            '{"type": "process", "name": "HighQuality P1P", "layer_height": "0.12", '
+            '"compatible_printers": ["Bambu Lab P1P 0.4 nozzle"]}'
+        )
+        machine_dir = tmp_path / "profiles" / "orca" / "machine"
+        machine_dir.mkdir(parents=True)
+        (machine_dir / "Bambu Lab P1S 0.4 nozzle.json").write_text(
+            '{"type": "machine", "name": "Bambu Lab P1S 0.4 nozzle"}'
+        )
+
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[slicer.orca]
+printer = "Bambu Lab P1S 0.4 nozzle"
+process = "HighQuality P1P"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        result = validate_config(toml)
+        assert any("not compatible" in w and "exit 239" in w for w in result.warnings)
+        assert not any("Process" in p and "compatible with printer" in p for p in result.passes)
+
+    def test_process_printer_compat_match_passes(self, tmp_path):
+        """Process whose compatible_printers includes the active printer passes."""
+        process_dir = tmp_path / "profiles" / "orca" / "process"
+        process_dir.mkdir(parents=True)
+        (process_dir / "HighQuality P1S.json").write_text(
+            '{"type": "process", "name": "HighQuality P1S", "layer_height": "0.12", '
+            '"compatible_printers": ["Bambu Lab P1S 0.4 nozzle"]}'
+        )
+        machine_dir = tmp_path / "profiles" / "orca" / "machine"
+        machine_dir.mkdir(parents=True)
+        (machine_dir / "Bambu Lab P1S 0.4 nozzle.json").write_text(
+            '{"type": "machine", "name": "Bambu Lab P1S 0.4 nozzle"}'
+        )
+
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[slicer.orca]
+printer = "Bambu Lab P1S 0.4 nozzle"
+process = "HighQuality P1S"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        result = validate_config(toml)
+        assert not any("not compatible" in w for w in result.warnings)
+        assert any("compatible with printer" in p for p in result.passes)
+
+    def test_process_printer_compat_skipped_with_dynamic_condition(self, tmp_path):
+        """A compatible_printers_condition expression is dynamic — skip the check."""
+        process_dir = tmp_path / "profiles" / "orca" / "process"
+        process_dir.mkdir(parents=True)
+        (process_dir / "DynamicProcess.json").write_text(
+            '{"type": "process", "name": "DynamicProcess", "layer_height": "0.2", '
+            '"compatible_printers": ["Bambu Lab P1P 0.4 nozzle"], '
+            '"compatible_printers_condition": "nozzle_diameter[0]==0.4"}'
+        )
+        machine_dir = tmp_path / "profiles" / "orca" / "machine"
+        machine_dir.mkdir(parents=True)
+        (machine_dir / "Bambu Lab P1S 0.4 nozzle.json").write_text(
+            '{"type": "machine", "name": "Bambu Lab P1S 0.4 nozzle"}'
+        )
+
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[slicer.orca]
+printer = "Bambu Lab P1S 0.4 nozzle"
+process = "DynamicProcess"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        result = validate_config(toml)
+        assert not any("not compatible" in w for w in result.warnings)
+
     def test_override_keys_unknown_errors(self, tmp_path):
         """Unknown override keys produce errors (not just warnings)."""
         profiles = tmp_path / "profiles" / "orca" / "process"


### PR DESCRIPTION
## Summary
- \`estampo validate\` now loads the flattened process profile and checks that \`slicer.printer\` is in the process's \`compatible_printers\` list.
- Warns with the actual compatible list and a pointer to the silent-239 failure mode (companion #628 surfaces it properly too).
- OrcaSlicer only — CuraEngine uses inline settings with no compat concept.
- Skipped when \`compatible_printers_condition\` is set (dynamic Orca expression).

## Before
\`\`\`
$ estampo validate estampo.toml
  ✔ Slicer profiles valid (pinned)
  ✔ All checks passed.
$ estampo run estampo.toml
✗ Slicing failed — Docker slicer failed (exit code 239):
\`\`\`

## After
\`\`\`
$ estampo validate estampo.toml
  ⚠ slicer.process '0.12mm High Quality @BBL P1P' is not compatible with 
    slicer.printer 'Bambu Lab P1S 0.4 nozzle'.
    Process's compatible_printers: 'Bambu Lab P1P 0.4 nozzle'.
    Note: this combination fails at slice time with a silent exit 239.
    Fix: pick a process whose compatible_printers includes 'Bambu Lab P1S 0.4
    nozzle', or choose a different printer.
\`\`\`

## Test plan
- [x] New test: mismatch emits warning
- [x] New test: match emits pass
- [x] New test: \`compatible_printers_condition\` skips the check
- [x] Verified manually against \`pzfreo/orca-test\` (the repo that triggered this)
- [x] \`uv run ruff check src tests\`
- [x] \`uv run ruff format --check src tests\`
- [x] \`uv run mypy src/estampo\`
- [x] \`uv run pytest\` — 621 passed, 9 skipped

## Follow-ups
- #627 (second half): \`estampo profiles list --printer NAME\` filter — not in this PR, separate follow-up.
- #629: move engine-specific validation into the \`SlicerEngine\` protocol (tech debt).

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)