### PR TITLE
AI setup prompt: make STEP-as-direct-input explicit

### DIFF
--- a/changes/631.misc
+++ b/changes/631.misc
@@ -1,0 +1,1 @@
+AI setup prompt: make it explicit that STEP files are loaded natively (via build123d) so assistants no longer advise users to pre-convert STEP to STL/3MF.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -100,7 +100,7 @@ printer = "bambox_p1s"
 filaments = ["PLA"]
 
 [[parts]]
-file = "model.stl"
+file = "model.stl"       # .stl, .3mf, or .step / .stp — all three are accepted directly
 
 # Add overrides to tune print settings:
 # [slicer.orca.overrides]
@@ -108,6 +108,10 @@ file = "model.stl"
 # sparse_infill_density = "20%"
 # wall_loops = "3"
 ```
+
+**STEP files are loaded natively** — estampo uses [build123d](https://github.com/gumyr/build123d) to
+convert STEP to a mesh at the start of the pipeline. Do **not** tell the user to pre-convert STEP
+to STL/3MF; point a `[[parts]]` entry directly at the `.step` or `.stp` file.
 
 #### Additional config features
 
@@ -142,7 +146,7 @@ These are optional — skip them for simple setups:
   inlay = "Bambu PLA Basic @BBL X1C"
   ```
 - **`estampo profiles pin`** — copies referenced profiles into a local `profiles/` directory for reproducible builds across machines.
-- **Code-CAD workflow** — estampo works with OpenSCAD, build123d, and CadQuery. Generate STL/3MF from code-CAD scripts, then configure estampo to slice the output.
+- **Code-CAD workflow** — estampo works with OpenSCAD, build123d, and CadQuery. Either emit STL/3MF from the code-CAD script, or emit STEP and let estampo load it directly via build123d — no pre-conversion required.
 
 ### Discovering available profiles
 
@@ -297,11 +301,12 @@ estampo init --workflow-only
 ```
 This requires an existing `estampo.toml` — it will error if the config file is missing.
 
-#### Projects with build scripts (STEP/code-CAD)
+#### Projects with build scripts (code-CAD)
 
-If the project generates STL/3MF files from STEP files, OpenSCAD, build123d, or
-CadQuery via a build script, and the generated files are `.gitignore`d, the CI
-runner won't have them. Add a build step before the estampo action:
+If the project generates mesh files (STL, 3MF, or STEP) from OpenSCAD,
+build123d, or CadQuery via a build script, and the generated files are
+`.gitignore`d, the CI runner won't have them. Add a build step before the
+estampo action. (If the STEP files are committed to the repo, skip this — estampo loads STEP directly.)
 
 ```yaml
     steps:


### PR DESCRIPTION
## Summary

A user reported an AI assistant (given the current [ai-setup-prompt.md](https://github.com/estampo/estampo/blob/main/docs/ai-setup-prompt.md)) told them:

> slicers consume STL or 3MF, not STEP. You just had me remove STL export. So estampo will need mesh files — options are: (a) re-add STL export, or (b) keep STEP as the source of truth and have the build script also emit 3MF for slicing.

That advice is wrong — estampo loads STEP natively via build123d in the \`load\` stage (\`src/estampo/loader.py:165\` \`_load_step\`).

The prompt was misleading in three spots:
- Line 103 — the only \`[[parts]]\` example was \`file = \"model.stl\"\`, no STEP.
- Line 145 — code-CAD bullet said \"Generate STL/3MF from code-CAD scripts\", implying conversion is required.
- Line 300 — CI build-scripts section header was \`(STEP/code-CAD)\` and the body conflated STEP files with build-script outputs.

This PR fixes all three and adds an explicit \"STEP files are loaded natively\" callout right under the config example so downstream AIs don't re-derive the wrong conclusion.

Closes #631

## Test plan

- [x] \`uv run ruff check src tests\` — passes
- [x] \`uv run ruff format --check src tests\` — passes
- [x] \`uv run mypy src/estampo\` — passes
- [x] \`uv run pytest\` — 625 passed, 3 skipped, 2 failing (both failures are pre-existing on \`main\`, in \`test_process_printer_compat_*\` from #627/#630 — unrelated to this change; flagged separately)
- [ ] Re-paste the updated prompt into an AI assistant with a STEP-only project and confirm it no longer recommends pre-conversion