### PR TITLE
AI setup prompt: verify with full run, not --until slice

### DIFF
--- a/changes/635.misc
+++ b/changes/635.misc
@@ -1,0 +1,1 @@
+AI setup prompt: verify with ``estampo run`` instead of ``estampo run --until slice`` so assistants exercise the mandatory ``pack`` stage for Bambu printers.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -494,8 +494,12 @@ estampo validate
 # 2. Pin profiles for reproducibility
 estampo profiles pin
 
-# 3. Test slice — catches profile and override issues
-estampo run --until slice
+# 3. Full run — executes every pipeline stage, including pack. Nothing is sent
+#    to a printer; the artifact is a file on disk. Use --until slice only when
+#    you want to skip pack deliberately (e.g. debugging the slicer step in
+#    isolation) — it will NOT catch misconfiguration of the pack stage that
+#    Bambu printers require.
+estampo run
 ```
 
 `estampo validate` exits non-zero if any override keys are invalid. Fix all


### PR DESCRIPTION
## Summary

The \"Verifying the config\" section told assistants to run \`estampo run --until slice\`. For Bambu Lab printers, \`--until slice\` stops before the \`pack\` stage — the exact stage the prompt elsewhere calls \"not optional\". A broken \`bambox\` command or missing \`docker = true\` flag on the \`[pack]\` table would pass verification unnoticed.

A user reported an external AI assistant (following the prompt) proposing \`estampo run --until slice\` as the local verification step and noting it hadn't exercised pack. This PR fixes the prompt so the default verify recipe actually runs the full pipeline.

## Change

- \`docs/ai-setup-prompt.md\`: step 3 of \"Verifying the config\" → \`estampo run\` (full pipeline). \`--until slice\` is kept in the comment as a deliberate debugging tool, with a note that it will NOT catch pack-stage misconfiguration.

Closes #635

## Out of scope (flagged in the issue body)

- README mentions \`estampo run --dry-run\` but no such flag exists in \`cli.py\` — separate docs/CLI mismatch, tracked in #635.
- Prompt could say more about installing a dev/pre-release version locally (users on \`0.4.0b4.dev\` hit PyPI friction). Deferred so this PR stays focused.

## Test plan

- [x] \`uv run ruff check src tests\` — passes
- [x] \`uv run ruff format --check src tests\` — passes
- [x] \`uv run mypy src/estampo\` — passes
- [x] \`uv run pytest\` — 625 passed, 3 skipped, 2 pre-existing failures in \`test_process_printer_compat_*\` (tracked in #633, unrelated to this change)
- [ ] Re-paste updated prompt into an AI assistant with a Bambu-flavored project and confirm it runs the full pipeline for verification