### PR TITLE
README: remove `estampo run --dry-run` — flag never existed

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ OrcaSlicer CLI is great for slicing a prepared plate. estampo builds a reproduci
 - **Arrangement** — bin-packs multiple STLs onto the build plate (OrcaSlicer CLI has no arrange step)
 - **Multi-part filament mapping** — per-part filament slot assignment and paint color preservation, injected into the 3MF metadata
 - **Reproducible builds** — pin slicer profiles into your repo + lock OrcaSlicer version in Docker = identical gcode on any machine
-- **Partial execution** — `--until plate` to inspect layout, `--only slice` to re-slice, `--dry-run` to test everything
+- **Partial execution** — `--until plate` to inspect layout, `--only slice` to re-slice
 - **Command stages** — run external tools (e.g. `bambox pack`) as pipeline stages with variable substitution
 - **Headless Docker slicing** — no GUI, no display server, works in CI, uses a specific OrcaSlicer version
 
@@ -236,9 +236,8 @@ filament = "Generic PETG-CF @base"
 Run it (see [full CLI reference](https://github.com/estampo/estampo/blob/main/docs/cli.md)):
 
 ```bash
-estampo run                   # arrange, slice and send to printer
+estampo run                   # run every stage in pipeline.stages
 estampo run --until slice     # stop after slicing
-estampo run --dry-run         # full pipeline without sending to printer
 ```
 
 The arrangement (`plate`) stage generates a `plate_preview.3mf` — open it in any 3MF viewer to check placement:
@@ -284,7 +283,6 @@ estampo validate                    # check config for issues
 estampo run                         # full pipeline
 estampo run --until plate           # stop after plating
 estampo run --only slice            # run just one stage
-estampo run --dry-run               # everything except sending to printer
 estampo profiles list               # list available slicer profiles
 estampo profiles pin                # pin profiles for reproducible builds
 ```

--- a/changes/639.misc
+++ b/changes/639.misc
@@ -1,0 +1,1 @@
+README: remove references to ``estampo run --dry-run`` — the flag was never implemented in the CLI.


### PR DESCRIPTION
## Summary

\`estampo run --dry-run\` appeared in three places in the README but was never implemented in \`src/estampo/cli.py\`. Under ADR-007 (command stages) there's also no built-in \"send to printer\" step for \`--dry-run\` to suppress — printing only happens when the user opts in with a print command stage. The flag is a legacy artifact and running any of the documented commands produced a typer error.

## Changes

- **Line 113** — dropped \`--dry-run\` from the \"Partial execution\" bullet in the OrcaSlicer-CLI comparison.
- **Lines 239–241** — Quick-start run example: removed the \`--dry-run\` line and also rewrote the comment on \`estampo run\` (was \"arrange, slice and send to printer\" — misleading; now \"run every stage in pipeline.stages\").
- **Line 286** — CLI overview block: removed the \`--dry-run\` line.

## Out of scope (tracked in #639)

- \`docs/cli.md\` still documents \`--dry-run\` (lines 115, 160).
- \`docs/code-cad.md\` still references it (line 162).
- \`scripts/record_demo.py\` types \`estampo run --dry-run\` into an asciinema session, but the script is already slated for rewrite in #480.

Closes #639

## Test plan

- [x] \`uv run ruff check src tests\` — passes
- [x] \`uv run ruff format --check src tests\` — passes
- [x] \`uv run mypy src/estampo\` — passes
- [x] \`uv run pytest\` — (run before this PR; 625 passed, 2 pre-existing failures in #633). No new failures expected from a README-only change.
- [ ] Preview rendered README on GitHub once PR opens