### PR TITLE
Warn on unknown TOML keys in estampo validate (#646)

### DIFF
--- a/changes/+validate-unknown-keys.feature
+++ b/changes/+validate-unknown-keys.feature
@@ -1,0 +1,1 @@
+``estampo validate`` now warns on unknown TOML keys (e.g. a misplaced ``build_plate`` under ``[slicer.orca]``), with "did you mean?" hints and cross-table suggestions when a key belongs in a neighbouring section.

--- a/src/estampo/config.py
+++ b/src/estampo/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import difflib
 import logging
 import tomllib
 from dataclasses import dataclass, field
@@ -16,6 +17,37 @@ log = logging.getLogger(__name__)
 VALID_ORIENTS = {"flat", "upright", "side", "upside-down"}
 VALID_ENGINES = ("orca", "cura")
 SUPPORTED_EXTENSIONS = {".stl", ".3mf", ".step", ".stp", ".obj"}
+
+# Known keys per TOML table — used by detect_unknown_keys() to flag typos
+# (e.g. "build_plate" under [slicer.orca]) that would otherwise be silently
+# dropped by ``.get(...)``-based parsers. Keep these in sync with the
+# dataclass fields and parser ``raw.get(...)`` calls above / below.
+_TOP_LEVEL_KEYS = {"name", "output_dir", "pipeline", "plate", "slicer", "parts", "filaments"}
+_PIPELINE_KEYS = {"stages"}
+_PLATE_KEYS = {"size", "padding"}
+_SLICER_KEYS = {"engine", "version", "bed_type", "profiles_dir", "orca", "cura"}
+_SLICER_ORCA_KEYS = {
+    "printer",
+    "process",
+    "filaments",
+    "slots",
+    "overrides",
+    "machine_overrides",
+    "filament_overrides",
+}
+_SLICER_CURA_KEYS = {"printer", "overrides", "filaments"}
+_PART_KEYS = {
+    "file",
+    "copies",
+    "orient",
+    "rotate",
+    "filament",
+    "scale",
+    "object",
+    "sequence",
+    "filaments",
+}
+_COMMAND_STAGE_KEYS = {"command", "output", "docker", "image"}
 
 
 @dataclass
@@ -487,3 +519,124 @@ def load_config(path: Path) -> EstampoConfig:
         filaments=filament_aliases,
         pipeline=pipeline,
     )
+
+
+def _warn_unknown_keys(
+    raw: dict,
+    known: set[str],
+    table: str,
+    parent: tuple[set[str], str] | None = None,
+) -> list[str]:
+    """Return warnings for keys in *raw* that aren't in *known*.
+
+    If *parent* is given as ``(parent_keys, parent_label)``, an unknown key
+    that matches (exactly or fuzzily) a parent-table key produces a
+    "did you mean … in [parent]?" hint — this catches keys that are real
+    but placed in the wrong TOML table (e.g. ``bed_type`` under
+    ``[slicer.orca]`` when it belongs under ``[slicer]``).
+    """
+    warnings: list[str] = []
+    label = f"[{table}]" if table else "top-level config"
+    known_list = sorted(known)
+    for key in raw:
+        if key in known:
+            continue
+
+        if parent:
+            parent_keys, parent_label = parent
+            if key in parent_keys:
+                warnings.append(
+                    f"Unknown key '{key}' in {label} — did you mean to set it in [{parent_label}]?"
+                )
+                continue
+
+        close = difflib.get_close_matches(key, known_list, n=1, cutoff=0.6)
+        if close:
+            warnings.append(f"Unknown key '{key}' in {label}. Did you mean '{close[0]}'?")
+            continue
+
+        if parent:
+            parent_keys, parent_label = parent
+            close_parent = difflib.get_close_matches(key, sorted(parent_keys), n=1, cutoff=0.5)
+            if close_parent:
+                warnings.append(
+                    f"Unknown key '{key}' in {label}. "
+                    f"Did you mean '{close_parent[0]}' in [{parent_label}]?"
+                )
+                continue
+
+        warnings.append(f"Unknown key '{key}' in {label}.")
+    return warnings
+
+
+def detect_unknown_keys(raw: dict) -> list[str]:
+    """Return warnings for unknown keys in any recognised TOML table.
+
+    Covers top-level, ``[pipeline]``, ``[plate]``, ``[slicer]``,
+    ``[slicer.orca]``, ``[slicer.cura]``, each ``[[parts]]`` entry, and
+    user-defined command-stage tables (e.g. ``[pack]``).
+
+    ``[slicer.orca]`` / ``[slicer.cura]`` additionally check against
+    ``[slicer]``'s keys so a misplaced ``bed_type`` (or similar) gets a
+    pointer to the right table rather than a silent drop.
+
+    Unknown top-level tables that aren't in ``_TOP_LEVEL_KEYS`` but **are**
+    listed in ``pipeline.stages`` are treated as user-defined command
+    stages and are not flagged.
+    """
+    from estampo.pipeline import STAGE_OUTPUTS
+
+    warnings: list[str] = []
+
+    pipeline_raw = raw.get("pipeline", {})
+    if isinstance(pipeline_raw, dict):
+        stages = pipeline_raw.get("stages", [])
+    else:
+        stages = []
+    command_stage_names = {s for s in stages if isinstance(s, str) and s and s not in STAGE_OUTPUTS}
+
+    warnings.extend(_warn_unknown_keys(raw, _TOP_LEVEL_KEYS | command_stage_names, ""))
+
+    if isinstance(pipeline_raw, dict):
+        warnings.extend(_warn_unknown_keys(pipeline_raw, _PIPELINE_KEYS, "pipeline"))
+
+    plate_raw = raw.get("plate")
+    if isinstance(plate_raw, dict):
+        warnings.extend(_warn_unknown_keys(plate_raw, _PLATE_KEYS, "plate"))
+
+    slicer_raw = raw.get("slicer")
+    if isinstance(slicer_raw, dict):
+        warnings.extend(_warn_unknown_keys(slicer_raw, _SLICER_KEYS, "slicer"))
+        orca_raw = slicer_raw.get("orca")
+        if isinstance(orca_raw, dict):
+            warnings.extend(
+                _warn_unknown_keys(
+                    orca_raw,
+                    _SLICER_ORCA_KEYS,
+                    "slicer.orca",
+                    parent=(_SLICER_KEYS, "slicer"),
+                )
+            )
+        cura_raw = slicer_raw.get("cura")
+        if isinstance(cura_raw, dict):
+            warnings.extend(
+                _warn_unknown_keys(
+                    cura_raw,
+                    _SLICER_CURA_KEYS,
+                    "slicer.cura",
+                    parent=(_SLICER_KEYS, "slicer"),
+                )
+            )
+
+    parts_raw = raw.get("parts", [])
+    if isinstance(parts_raw, list):
+        for i, p in enumerate(parts_raw):
+            if isinstance(p, dict):
+                warnings.extend(_warn_unknown_keys(p, _PART_KEYS, f"parts[{i}]"))
+
+    for stage_name in command_stage_names:
+        stage_raw = raw.get(stage_name)
+        if isinstance(stage_raw, dict):
+            warnings.extend(_warn_unknown_keys(stage_raw, _COMMAND_STAGE_KEYS, stage_name))
+
+    return warnings

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -290,13 +290,19 @@ def validate_config(path: Path) -> ValidationResult:
     Raises EstampoError for hard errors (via load_config).
     Returns a ValidationResult with passes and warnings.
     """
-    from estampo.config import load_config
+    import tomllib
+
+    from estampo.config import detect_unknown_keys, load_config
     from estampo.pipeline import STAGE_OUTPUTS
     from estampo.profiles import discover_profile_names, validate_override_keys
 
     cfg = load_config(path)
     passes: list[str] = []
     warnings: list[str] = []
+
+    with open(path, "rb") as f:
+        raw_toml = tomllib.load(f)
+    warnings.extend(detect_unknown_keys(raw_toml))
 
     # Check slicer version pinning
     if not cfg.slicer.version:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -618,6 +618,152 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         assert result.errors is not None
         assert any("bogus_setting" in e for e in result.errors)
 
+    def test_unknown_key_orca_build_plate_points_to_slicer(self, tmp_path):
+        """bed_type misplaced under [slicer.orca] as build_plate — should
+        hint to set it in [slicer]."""
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[slicer.orca]
+printer = "Bambu Lab P1S 0.4 nozzle"
+process = "0.12mm Fine @BBL X1C"
+filaments = ["Generic PLA @base"]
+build_plate = "Textured PEI Plate"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        warnings = validate_config(toml)
+        matched = [w for w in warnings if "build_plate" in w]
+        assert matched, f"expected a warning for build_plate, got: {list(warnings)}"
+        assert "bed_type" in matched[0]
+        assert "[slicer]" in matched[0]
+
+    def test_unknown_key_orca_exact_parent_match(self, tmp_path):
+        """bed_type placed directly under [slicer.orca] — exact match on
+        parent table key, should point to [slicer]."""
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[slicer.orca]
+printer = "Bambu Lab P1S 0.4 nozzle"
+bed_type = "Textured PEI Plate"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        warnings = validate_config(toml)
+        matched = [w for w in warnings if "bed_type" in w and "[slicer.orca]" in w]
+        assert matched, f"expected a warning for bed_type in [slicer.orca], got: {list(warnings)}"
+        assert "[slicer]" in matched[0]
+
+    def test_unknown_key_typo_same_table(self, tmp_path):
+        """printr → printer in [slicer.orca]."""
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[slicer.orca]
+printr = "Bambu Lab P1S 0.4 nozzle"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        warnings = validate_config(toml)
+        matched = [w for w in warnings if "printr" in w]
+        assert matched, f"expected a warning for printr, got: {list(warnings)}"
+        assert "'printer'" in matched[0]
+
+    def test_unknown_key_parts_typo(self, tmp_path):
+        """copys → copies in [[parts]]."""
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+copys = 2
+""")
+        warnings = validate_config(toml)
+        matched = [w for w in warnings if "copys" in w]
+        assert matched, f"expected a warning for copys, got: {list(warnings)}"
+        assert "'copies'" in matched[0]
+
+    def test_unknown_key_command_stage_typo(self, tmp_path):
+        """dcker → docker in a user-defined command-stage table."""
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[pipeline]
+stages = ["slice", "pack"]
+
+[pack]
+command = "bambox repack {{gcode}} -o {{output}}"
+output = "packed.gcode.3mf"
+dcker = true
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        warnings = validate_config(toml)
+        matched = [w for w in warnings if "dcker" in w]
+        assert matched, f"expected a warning for dcker, got: {list(warnings)}"
+        assert "'docker'" in matched[0]
+
+    def test_declared_command_stage_not_flagged(self, tmp_path):
+        """A top-level table whose name is listed in pipeline.stages is a
+        user-defined command stage, not an unknown key."""
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[pipeline]
+stages = ["slice", "pack"]
+
+[pack]
+command = "bambox repack {{gcode}} -o {{output}}"
+output = "packed.gcode.3mf"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        warnings = validate_config(toml)
+        assert not any("'pack'" in w and "Unknown" in w for w in warnings)
+
+    def test_unknown_top_level_key(self, tmp_path):
+        """A top-level key not in the allow-list and not a declared command
+        stage is flagged."""
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+outpt_dir = "./build"
+
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        warnings = validate_config(toml)
+        matched = [w for w in warnings if "outpt_dir" in w]
+        assert matched, f"expected a warning for outpt_dir, got: {list(warnings)}"
+        assert "'output_dir'" in matched[0]
+
 
 # ---------------------------------------------------------------------------
 # Closest match helper


### PR DESCRIPTION
## Summary

- `estampo validate` now detects unknown keys in every recognised TOML table and surfaces them as warnings instead of silently dropping them.
- Parent-table-aware: a misplaced `bed_type` under `[slicer.orca]` (or the typo that prompted this — `build_plate`) points the user at `[slicer]` instead of firing a generic unknown-key warning.
- User-defined command-stage tables are recognised (via `pipeline.stages`) and themselves validated — e.g. `dcker = true` gets `did you mean 'docker'?`.

## Why

Parsers use `raw.get(...)` to pull fields, which silently drops keys outside the expected set. The user's report:

```toml
[slicer.orca]
build_plate = "Textured PEI Plate"
```

produced no error, no warning — the config parsed clean, the slice ran with the default plate, and the mismatch was only discoverable by inspecting G-code output (where `curr_bed_type` would be wrong).

## How

- `detect_unknown_keys()` in `config.py` walks the raw TOML dict, comparing each table's keys against a per-table allow-list, and returns warnings with `difflib.get_close_matches` "did you mean?" hints.
- Parent awareness: `[slicer.orca]` and `[slicer.cura]` also check against `[slicer]`'s keys, so `bed_type` placed in the nested table gets pointed back up.
- Command-stage detection: any top-level table whose name is listed in `pipeline.stages` but isn't a built-in stage is treated as a user-defined command stage and validated against `{command, output, docker, image}`.
- Wired into `validate_config()` so the warnings show up alongside existing profile / path / plate checks.

## Test plan

- [x] 7 new tests in `tests/test_init.py::TestValidate`:
  - `test_unknown_key_orca_build_plate_points_to_slicer` — the exact scenario from the issue
  - `test_unknown_key_orca_exact_parent_match` — `bed_type` under `[slicer.orca]`
  - `test_unknown_key_typo_same_table` — `printr` → `printer`
  - `test_unknown_key_parts_typo` — `copys` → `copies`
  - `test_unknown_key_command_stage_typo` — `dcker` → `docker`
  - `test_declared_command_stage_not_flagged` — `[pack]` from `pipeline.stages` doesn't warn
  - `test_unknown_top_level_key` — `outpt_dir` → `output_dir`
- [x] `uv run ruff check src tests` — pass
- [x] `uv run ruff format --check src tests` — pass
- [x] `uv run mypy src/estampo` — pass
- [x] `uv run pytest` — 632 passed (2 pre-existing failures unrelated to this PR — `test_process_printer_compat_*` fail on `main` too, env-dependent, see #633)

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)