### PR TITLE
Add supplement for Orca CLI keys missing from profile extraction (#649)

### DIFF
--- a/changes/+orca-validator-cli-keys.bugfix
+++ b/changes/+orca-validator-cli-keys.bugfix
@@ -1,0 +1,1 @@
+``estampo validate`` no longer flags valid OrcaSlicer override keys that default to an "off" value in libslic3r and never appear in shipped BBL profiles — e.g. ``brim_type`` (the companion to ``brim_width``), ``enable_support``, ``support_type``, ``enable_prime_tower``, ``timelapse_type``. Typos of these keys still produce "did you mean?" hints.

--- a/src/estampo/profiles.py
+++ b/src/estampo/profiles.py
@@ -441,16 +441,51 @@ def validate_override_keys(
     return warnings
 
 
+# OrcaSlicer keys that exist in libslic3r's PrintConfig but never appear in
+# any shipped BBL profile — typically because they default to an "off" value
+# in C++ code (e.g. brim_type = no_brim) and no profile needs to override
+# them. ``scripts/extract_settings.py`` scrapes profiles, so these are
+# missed. Without this supplement the validator flags them as unknown and
+# users (or AI agents) drop them, producing silently wrong slices — e.g.
+# setting ``brim_width = 5`` with no ``brim_type`` gives no brim. See #649
+# for the proper fix (enumerate from OrcaSlicer source rather than
+# profiles); this list is an interim override.
+_ORCA_CLI_ONLY_KEYS: set[str] = {
+    # Brim — default brim_type is "no_brim", so it's in zero profiles
+    "brim_type",
+    "brim_ears_max_angle",
+    "brim_ears_detection_length",
+    # Support — default is off, so only profiles that enable it set these
+    "enable_support",
+    "support_type",
+    "support_style",
+    "support_threshold_angle",
+    # Prime tower / wipe tower — default off
+    "enable_prime_tower",
+    "wipe_tower",
+    # Timelapse — default off
+    "timelapse_type",
+}
+
+
 def _load_engine_settings(engine: str) -> set[str]:
-    """Load known setting keys from bundled settings JSON."""
+    """Load known setting keys from bundled settings JSON.
+
+    OrcaSlicer results are augmented with ``_ORCA_CLI_ONLY_KEYS`` — keys
+    that are real CLI overrides but don't appear in any shipped profile
+    (the extractor only sees keys that show up in profile JSON).
+    """
     settings_file = Path(__file__).parent / "data" / f"{engine}-settings.json"
-    if not settings_file.exists():
-        return set()
-    try:
-        data = json.loads(settings_file.read_text())
-        return {s["key"] for s in data.get("settings", [])}
-    except (json.JSONDecodeError, KeyError, OSError):
-        return set()
+    keys: set[str] = set()
+    if settings_file.exists():
+        try:
+            data = json.loads(settings_file.read_text())
+            keys = {s["key"] for s in data.get("settings", [])}
+        except (json.JSONDecodeError, KeyError, OSError):
+            pass
+    if engine == "orca":
+        keys |= _ORCA_CLI_ONLY_KEYS
+    return keys
 
 
 def _cross_engine_map() -> dict[str, str]:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1016,6 +1016,40 @@ def test_validate_override_keys_cross_engine_orca_in_cura():
     assert "wall_line_count" in warnings[0]
 
 
+def test_validate_override_keys_orca_cli_only_brim_type():
+    """brim_type is a real Orca key but not in any shipped profile (#649) —
+    the validator should not flag it."""
+    warnings = validate_override_keys(
+        {"brim_type": "outer_only"},
+        engine="orca",
+        process=None,
+    )
+    assert warnings == []
+
+
+def test_validate_override_keys_orca_cli_only_support_enable():
+    """enable_support is a real Orca key that defaults off (#649) — should
+    not warn."""
+    warnings = validate_override_keys(
+        {"enable_support": "1"},
+        engine="orca",
+        process=None,
+    )
+    assert warnings == []
+
+
+def test_validate_override_keys_typo_of_cli_only_still_warns():
+    """Typos of CLI-only keys still produce a warning with a hint pointing
+    at the real key."""
+    warnings = validate_override_keys(
+        {"brim_typ": "outer_only"},
+        engine="orca",
+        process=None,
+    )
+    assert len(warnings) == 1
+    assert "brim_type" in warnings[0]
+
+
 def test_validate_override_keys_cross_engine_cura_in_orca():
     """Using CuraEngine key in OrcaSlicer config should suggest the OrcaSlicer equivalent."""
     warnings = validate_override_keys(


### PR DESCRIPTION
## Summary

`validate_override_keys` was flagging real OrcaSlicer override keys (e.g. `brim_type`) as unknown because the source-of-truth, `src/estampo/data/orca-settings.json`, is built by scraping keys out of shipped BBL profiles — missing everything that defaults to its "off" value in libslic3r and isn't overridden anywhere.

User-visible consequence: an AI agent set `brim_width = 5` to fix warping, also (correctly) added `brim_type = "outer_only"`, the validator told it that key was bogus, it obediently dropped it, the print came out with no brim.

## Fix

Union a curated `_ORCA_CLI_ONLY_KEYS` set into `_load_engine_settings()` for `engine == "orca"`. Initial supplement covers the obvious default-off classes:

- Brim — `brim_type`, `brim_ears_max_angle`, `brim_ears_detection_length`
- Support — `enable_support`, `support_type`, `support_style`, `support_threshold_angle`
- Prime/wipe tower — `enable_prime_tower`, `wipe_tower`
- Timelapse — `timelapse_type`

Typos still fuzzy-match against the full (supplement-inclusive) set, so `brim_typ` suggests `brim_type`.

## Why a supplement and not source extraction

Tried `orca-slicer --export-settings` — it needs a loaded project and didn't write a file for a no-project invocation, and `--help` only lists meta-flags, not print options. Enumerating from `libslic3r/PrintConfig.cpp` at the pinned version is the proper fix but needs CI tooling work. Filed **#651** for that; this PR is the narrow fix to unbreak the user-visible bug.

## Test plan

- [x] 3 new tests in `tests/test_profiles.py`:
  - `test_validate_override_keys_orca_cli_only_brim_type` — the user's exact scenario
  - `test_validate_override_keys_orca_cli_only_support_enable` — another default-off key
  - `test_validate_override_keys_typo_of_cli_only_still_warns` — `brim_typ` → `brim_type`
- [x] `uv run ruff check src tests` — pass
- [x] `uv run ruff format --check src tests` — pass
- [x] `uv run mypy src/estampo` — pass
- [x] `uv run pytest` — 646 passed (2 pre-existing failures unrelated to this PR — `test_process_printer_compat_*`, see #633)

Closes #649 (interim fix; #651 tracks the source-based extraction replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)