### PR TITLE
docs: remove references to nonexistent estampo run flags

### DIFF
--- a/changes/+docs-remove-dry-run-653.misc
+++ b/changes/+docs-remove-dry-run-653.misc
@@ -1,0 +1,1 @@
+Remove references to nonexistent ``estampo run --dry-run`` and other stale printer-era flags from docs.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -112,10 +112,6 @@ If `config` is omitted, estampo looks for `estampo.toml` in the current director
 | `--docker-version`  | Pin OrcaSlicer Docker image version (e.g. `2.3.1`)   |
 | `--filament-type`   | Override filament profile name                        |
 | `--filament-slot`   | AMS slot for `--filament-type` (default: 1)           |
-| `--dry-run`         | Do everything except send to printer                  |
-| `--upload-only`     | Upload gcode but don't start printing                 |
-| `--experimental`    | Enable experimental printer modes                     |
-| `--no-ams-mapping`  | Skip AMS mapping (diagnostic)                         |
 | `-v, --verbose`     | Enable debug logging with per-stage timing            |
 
 ### Pipeline stages
@@ -155,9 +151,6 @@ estampo run --only slice
 
 # Slice with a specific Docker image version
 estampo run --until slice --docker-version 2.3.1
-
-# Dry run — do everything except actually send to printer
-estampo run --dry-run
 
 # Verbose mode — shows per-stage timing
 estampo run -v

--- a/docs/code-cad.md
+++ b/docs/code-cad.md
@@ -159,5 +159,4 @@ During iteration, you often want to re-run just part of the pipeline:
 ```bash
 estampo run --until plate     # stop after arrangement (check layout)
 estampo run --only slice      # re-slice without re-arranging
-estampo run --dry-run         # full pipeline without sending to printer
 ```


### PR DESCRIPTION
## Summary

- Removes ``--dry-run`` references from ``docs/cli.md`` and ``docs/code-cad.md`` — the flag was never implemented in ``cli.py``.
- Also removes three other stale printer-era flags from the ``estampo run`` options table that do not exist in ``cli.py``: ``--upload-only``, ``--experimental``, ``--no-ams-mapping``. Same root cause as the one called out in the issue.

Surfaced in #635 and fixes #653.

## Acceptance

- ``grep -rn 'dry-run' docs/ src/`` now returns nothing.
- ``docs/cli.md`` options table matches ``estampo run --help``.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)