### PR TITLE
Refresh BED_TYPES to match OrcaSlicer 2.3.1 enum

### DIFF
--- a/changes/+bed-types-orca-2-3-1.bugfix
+++ b/changes/+bed-types-orca-2-3-1.bugfix
@@ -1,0 +1,1 @@
+Refresh the bed-type list surfaced by ``estampo info`` and the ``estampo init`` wizard to match OrcaSlicer 2.3.1, adding the previously missing ``Textured Cool Plate`` and ``Supertack Plate`` values.

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -16,7 +16,17 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-BED_TYPES = ["Cool Plate", "Engineering Plate", "High Temp Plate", "Textured PEI Plate"]
+# Source of truth: BedType enum + curr_bed_type enum_values in OrcaSlicer
+# libslic3r/PrintConfig.{hpp,cpp}. Order must match the enum so menu indexes
+# are stable. Update when bumping the pinned Orca version.
+BED_TYPES = [
+    "Cool Plate",
+    "Engineering Plate",
+    "High Temp Plate",
+    "Textured PEI Plate",
+    "Textured Cool Plate",
+    "Supertack Plate",
+]
 
 # ---------------------------------------------------------------------------
 # Template
@@ -37,7 +47,7 @@ padding = 5.0           # gap between parts in mm
 [slicer]
 engine = "orca"                            # "orca" (OrcaSlicer) or "cura" (CuraEngine)
 # version = "2.3.1"                        # pin slicer version for reproducibility
-# bed_type = "Textured PEI Plate"          # or: Cool Plate, Engineering Plate, High Temp Plate
+# bed_type = "Textured PEI Plate"          # run `estampo info` for the full list
 
 # OrcaSlicer profile chain:
 [slicer.orca]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,7 @@ import pytest
 
 from estampo.cli import main
 from estampo.init import (
+    BED_TYPES,
     ValidationResult,
     _build_toml,
     _check_cura_template_gcode,
@@ -97,6 +98,20 @@ def _mock_ui_inputs(monkeypatch, inputs):
 # ---------------------------------------------------------------------------
 # Template tests
 # ---------------------------------------------------------------------------
+
+
+class TestBedTypes:
+    def test_matches_orca_2_3_1_enum(self):
+        # Source: libslic3r/PrintConfig.cpp curr_bed_type enum_values @ v2.3.1.
+        # Order matters: it's the enum ordinal order and the wizard menu order.
+        assert BED_TYPES == [
+            "Cool Plate",
+            "Engineering Plate",
+            "High Temp Plate",
+            "Textured PEI Plate",
+            "Textured Cool Plate",
+            "Supertack Plate",
+        ]
 
 
 class TestTemplate:


### PR DESCRIPTION
## Summary

- Add the two plate types that ship in OrcaSlicer 2.3.x but were missing from the hardcoded list: **Textured Cool Plate** and **Supertack Plate**.
- Source of truth is the `curr_bed_type` `enum_values` block in `libslic3r/PrintConfig.cpp` — order preserved so the `estampo init` wizard menu indexes stay stable.
- Add a pinning test in `TestBedTypes` so the next Orca bump surfaces as a test diff rather than silent drift.
- Template comment no longer spells out a partial list — it points users at `estampo info`.

Does not touch the structural wart (`bed_types` is really per-printer / per-engine) — that's tracked in #657 as a follow-up.

Closes #656

## Test plan

- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] `uv run mypy src/estampo`
- [x] `uv run pytest` — all pass except the three pre-existing `test_process_printer_compat_*` failures tracked in #633 (unrelated)
- [x] `uv run estampo info` shows all six plate types

🤖 Generated with [Claude Code](https://claude.com/claude-code)