### PR TITLE
docs: cli.md + config.md accuracy fixes

### DIFF
--- a/changes/+docs-cli-config-accuracy-661.misc
+++ b/changes/+docs-cli-config-accuracy-661.misc
@@ -1,0 +1,1 @@
+docs: fix inaccuracies in ``docs/cli.md`` and ``docs/config.md`` — remove references to the removed ``print`` pipeline stage, fix wizard step numbering, repair a broken markdown fence, make ``--docker-version`` engine-agnostic, and align override value-type guidance with the examples (natural TOML types).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,12 +29,12 @@ a config without the wizard. Use `--printer` and `--process` for OrcaSlicer.
 
 **Interactive wizard** (default when non-interactive flags are omitted):
 1. Discovers installed slicer profiles (printer, process, filament) with search/filter
-3. Detects printer capabilities from the selected machine profile (plate size, multi-material support)
-4. Queries AMS tray contents in the background and auto-suggests matching filament profiles
-5. Auto-discovers CAD files (STL, 3MF, STEP) in the current directory
-6. Prompts for per-part copies, orientation, and filament slot assignment
-7. Detects installed OrcaSlicer version and offers to pin it for reproducibility
-8. Previews the generated TOML before writing
+2. Detects printer capabilities from the selected machine profile (plate size, multi-material support)
+3. Queries AMS tray contents in the background and auto-suggests matching filament profiles
+4. Auto-discovers CAD files (STL, 3MF, STEP) in the current directory
+5. Prompts for per-part copies, orientation, and filament slot assignment
+6. Detects installed OrcaSlicer version and offers to pin it for reproducibility
+7. Previews the generated TOML before writing
 
 ### Examples
 
@@ -109,7 +109,7 @@ If `config` is omitted, estampo looks for `estampo.toml` in the current director
 | `--only STAGE`      | Run only this stage (fails if prerequisites missing)  |
 | `--scale FACTOR`    | Scale all parts (multiplies per-part scale)           |
 | `--local`           | Force local slicer (fail if not installed)            |
-| `--docker-version`  | Pin OrcaSlicer Docker image version (e.g. `2.3.1`)   |
+| `--docker-version`  | Pin slicer Docker image version (e.g. `2.3.1` for OrcaSlicer, `5.12.0` for CuraEngine) |
 | `--filament-type`   | Override filament profile name                        |
 | `--filament-slot`   | AMS slot for `--filament-type` (default: 1)           |
 | `-v, --verbose`     | Enable debug logging with per-stage timing            |
@@ -125,7 +125,6 @@ The default pipeline runs these stages in order:
 | `plate`     | Export arranged plate as 3MF (+ preview)           | `plate.3mf`, `plate_preview.3mf` |
 | `slice`     | Slice via OrcaSlicer or CuraEngine (Docker or local) | gcode in output dir     |
 | `gcode-info`| Parse print time and filament usage from gcode     | Stats summary             |
-| `print`     | *(deprecated)* Send sliced gcode to printer        | Print job                 |
 
 In addition to built-in stages, you can define **command stages** — custom
 pipeline stages that run external CLI tools. See the
@@ -140,7 +139,7 @@ stages = ["load", "arrange", "plate", "slice", "gcode-info"]
 ### Examples
 
 ```bash
-# Full pipeline: arrange, slice, and print (uses ./estampo.toml)
+# Full pipeline: load → arrange → plate → slice (uses ./estampo.toml)
 estampo run
 
 # Stop after plating (no slicer needed)

--- a/docs/config.md
+++ b/docs/config.md
@@ -91,7 +91,6 @@ stages = ["load", "arrange", "plate", "slice", "gcode-info", "pack"]
 >
 > Credentials are managed by bambox: run `bambox login` to authenticate,
 > credentials are saved to `~/.config/bambox/credentials.toml`.
-```
 
 ## `[plate]`
 
@@ -248,11 +247,7 @@ filament = "Generic PETG-CF @base"
 sequence = 2
 ```
 
-Both objects come from the same 3MF, so estampo guarantees identical bed positioning. Run each sequence separately:
-
-```bash
-estampo run estampo.toml --only print   # after slicing sequence 1
-```
+Both objects come from the same 3MF, so estampo guarantees identical bed positioning.
 
 ## Command stages
 
@@ -322,42 +317,42 @@ Choose overrides based on your print goals:
 **Strong functional part (PETG):**
 ```toml
 [slicer.orca.overrides]
-wall_loops = "5"
+wall_loops = 5
 sparse_infill_density = "40%"
 sparse_infill_pattern = "gyroid"
-top_shell_layers = "6"
-bottom_shell_layers = "6"
+top_shell_layers = 6
+bottom_shell_layers = 6
 ```
 
 **Fast draft:**
 ```toml
 [slicer.orca.overrides]
 sparse_infill_density = "10%"
-wall_loops = "2"
-enable_support = "0"
+wall_loops = 2
+enable_support = 0
 ```
 
 **Smooth top surface:**
 ```toml
 [slicer.orca.overrides]
-ironing_type = "top surface only"
-top_shell_layers = "6"
+ironing_type = "topmost"
+top_shell_layers = 6
 ```
 
 **Dimensional accuracy (engineering parts):**
 ```toml
 [slicer.orca.overrides]
-xy_hole_compensation = "0.1"
-xy_contour_compensation = "-0.05"
-outer_wall_speed = "30"
+xy_hole_compensation = 0.1
+xy_contour_compensation = -0.05
+outer_wall_speed = 30
 ```
 
 **Tree supports for complex overhangs:**
 ```toml
 [slicer.orca.overrides]
-enable_support = "1"
+enable_support = 1
 support_type = "tree(auto)"
-support_threshold_angle = "45"
+support_threshold_angle = 45
 ```
 
 ## Important rules
@@ -367,8 +362,9 @@ support_threshold_angle = "45"
   unknown keys with "did you mean?" suggestions.
 - **Do not force slicer settings** that conflict with the printer's machine
   profile (e.g. `use_relative_e_distances`). Let the profile chain decide.
-- **Use string values** for OrcaSlicer overrides — they are passed as CLI
-  arguments: `layer_height = "0.2"`, not `layer_height = 0.2`.
+- **Values use their natural TOML type** — `enable_support = 1` (int),
+  `layer_height = 0.2` (float), `curr_bed_type = "Textured PEI Plate"`
+  (string). estampo handles conversion to the slicer CLI format.
 - **Pin the slicer version** in `[slicer].version` for reproducible builds.
 - **OrcaSlicer and CuraEngine use different setting names** for the same
   concepts. See the [AI setup prompt](ai-setup-prompt.md) for a mapping table.


### PR DESCRIPTION
## Summary

- Renumber the ``estampo init`` wizard steps (was ``1, 3, 4, 5, 6, 7, 8`` — step 2 was missing).
- Remove references to a non-existent ``print`` pipeline stage from ``docs/cli.md`` (Pipeline stages table + example comment) and from the sequential-printing example in ``docs/config.md`` (``estampo run --only print``). Built-in stages per ``src/estampo/pipeline.py`` are only ``load, arrange, plate, slice, gcode-info``.
- Make ``--docker-version`` description engine-agnostic (applies to CuraEngine too).
- Repair broken markdown fence after the deprecated ``[printer]`` blockquote in ``docs/config.md`` — the stray ``` was closing a non-existent code block and corrupting downstream rendering.
- Align override value-type guidance with actual examples: use natural TOML types (ints, floats, strings), not string-only. Update the common-recipe snippets to match. Also fix ``ironing_type = "top surface only"`` to a value listed in the docs table (``topmost``).

Closes #661

## Test plan

- [x] ``grep -rn '"print".*stage\|--only print\|deprecated.*print' docs/`` returns nothing referring to a ``print`` pipeline stage
- [x] ``uv run ruff check docs`` passes
- [ ] Render ``docs/config.md`` on GitHub and confirm no spurious code-block break after the ``[printer]`` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)