### PR TITLE
init: drop (experimental) suffix from CuraEngine label

### DIFF
--- a/changes/663.misc
+++ b/changes/663.misc
@@ -1,0 +1,1 @@
+Drop the ``(experimental)`` suffix from the CuraEngine label in ``estampo init``; CuraEngine has bundled printer definitions, E2E tests, and example projects and is no longer experimental.

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -1220,7 +1220,7 @@ def run_wizard(output: Path | None = None) -> str:
         existing_engine = existing_pre.engine
 
     engines = ["orca", "cura"]
-    engine_labels = {"orca": "OrcaSlicer", "cura": "CuraEngine (experimental)"}
+    engine_labels = {"orca": "OrcaSlicer", "cura": "CuraEngine"}
     default_engine = existing_engine or "orca"
     default_idx = engines.index(default_engine) + 1 if default_engine in engines else 1
     ui.info("Select slicer engine:")


### PR DESCRIPTION
## Summary
- Change the engine label in the ``estampo init`` wizard from ``CuraEngine (experimental)`` to ``CuraEngine``. CuraEngine now has bundled printer definitions, E2E tests, and an example project (``examples/cura-p1s``) — the ``experimental`` marker no longer matches reality and discourages adoption.
- Scope is exactly one line in ``src/estampo/init.py``; no other user-facing \"cura is experimental\" strings remain in code or docs.

Closes #663

## Test plan
- [x] ``uv run ruff check src tests`` — passes
- [x] ``uv run ruff format --check src tests`` — passes
- [x] ``uv run mypy src/estampo`` — passes
- [x] ``uv run pytest tests/test_init.py`` — passes (90 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)