### PR TITLE
Make CuraEngine profile-pin requirement obvious to new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ git add profiles/              # commit to lock them
 
 Combined with a pinned `version` in `[slicer]` (which locks the Docker image), the same config always produces the same gcode.
 
+> **CuraEngine: pin non-bundled printers.** If your config uses a printer definition that isn't shipped with estampo (e.g. `bambox_p1s`), `estampo profiles pin` is **required**, not optional — the definition only exists inside the Docker image. Without it, `estampo run --local` fails and a teammate who clones the repo gets an empty `profiles/` directory. `estampo init` will remind you when you pick a non-bundled CuraEngine printer.
+
 ### CI/CD example
 
 Automate slicing in GitHub Actions — push a commit, get G-code as a build artifact with print metrics on your PR:

--- a/changes/618.misc
+++ b/changes/618.misc
@@ -1,0 +1,1 @@
+Make the CuraEngine profile-pin requirement obvious: wizard emits an explicit "run ``estampo profiles pin``" hint when a non-bundled printer is picked, README + ``[slicer.cura]`` docs call it out, and ``ai-setup-prompt.md`` surfaces the guidance next to the config creation flow.

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -208,6 +208,26 @@ means no profiles are available locally. Run `estampo profiles pin` to extract
 them from the Docker image. Profiles are also resolved at runtime via Docker,
 so this warning is non-blocking.
 
+### Pinning profiles for reproducibility
+
+After creating the config, pin the referenced slicer profiles into the project
+so builds are reproducible across machines and CI — regardless of what's
+installed locally:
+
+```bash
+estampo profiles pin
+```
+
+This extracts profiles from the Docker image (using the `slicer.version` in your
+config), squashes the inheritance chain, and writes standalone definition files
+to `profiles/`. **Commit the `profiles/` directory to git.**
+
+For CuraEngine configs using custom printer definitions (e.g. `bambox_p1s`),
+pinning is **required for non-bundled printers** — the definition file only
+exists inside the Docker image and is not bundled in the pip package. Without
+pinning, `estampo run --local` will fail, and teammates who clone the repo
+will see an empty `profiles/` directory.
+
 ### Common override recipes
 
 Choose overrides based on the print goals:
@@ -494,25 +514,6 @@ user's printer. When suggesting or modifying overrides:
 - **`estampo validate` checks config correctness, not print safety.** A config
   that passes validation can still produce unsafe G-code if the override values
   are wrong for the hardware.
-
-### Pinning profiles for reproducibility
-
-After creating the config, pin the referenced slicer profiles into the project
-so builds are reproducible across machines and CI — regardless of what's
-installed locally:
-
-```bash
-estampo profiles pin
-```
-
-This extracts profiles from the Docker image (using the `slicer.version` in your
-config), squashes the inheritance chain, and writes standalone definition files
-to `profiles/`. **Commit the `profiles/` directory to git.**
-
-For CuraEngine configs using custom printer definitions (e.g. `bambox_p1s`),
-pinning is especially important — the definition file only exists inside the
-Docker image and is not bundled in the pip package. Without pinning, local
-slicing (`--local`) will fail.
 
 ### Verifying the config
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -148,6 +148,11 @@ CuraEngine-specific settings — printer definition and overrides.
 | `filaments` | `[string]` | —       | Filament/material profile names  |
 | `overrides` | `{k = v}`  | —       | Flat key-value setting overrides |
 
+> **Pin non-bundled printers.** If `printer` names a definition that isn't
+> shipped with estampo (e.g. `bambox_p1s`), run `estampo profiles pin` and
+> commit the `profiles/` directory. Otherwise `estampo run --local` will
+> fail and teammates cloning the repo won't have the definition file.
+
 ### `[slicer.orca.overrides]` / `[slicer.cura.overrides]`
 
 Key-value pairs applied on top of the engine's default settings:

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -1356,6 +1356,7 @@ def run_wizard(output: Path | None = None) -> str:
                     continue
             dest.write_text(toml)
             ui.success(f"Wrote {dest}")
+            _emit_cura_pin_hint(engine, printer_profile, dest.parent)
             return toml
 
         if answer in ("q", "quit"):
@@ -1365,6 +1366,30 @@ def run_wizard(output: Path | None = None) -> str:
         # Go back — re-run wizard from the top
         ui.console.print()
         return run_wizard(output=output)
+
+
+def _emit_cura_pin_hint(engine: str, printer: str | None, project_dir: Path) -> None:
+    """Tell the user to run ``estampo profiles pin`` if the chosen Cura def
+    is only reachable via Docker.
+
+    Without pinning, ``estampo run --local`` fails and teammates who clone
+    the repo get an empty ``profiles/`` directory.
+    """
+    if engine != "cura" or not printer:
+        return
+
+    from estampo import ui
+
+    if _check_cura_def_reachable(printer, project_dir, "profiles") is None:
+        return
+
+    ui.console.print()
+    ui.warn(
+        f"Printer '{printer}' is not bundled with estampo — its definition "
+        f"only exists inside the Docker image."
+    )
+    ui.info("Next: run 'estampo profiles pin' and commit the profiles/ directory")
+    ui.info("      so local slicing and clean clones slice identically.")
 
 
 def _is_bambu_printer(printer: str) -> bool:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,7 @@ from estampo.init import (
     _build_toml,
     _check_cura_template_gcode,
     _closest_match,
+    _emit_cura_pin_hint,
     _is_bambu_printer,
     _validate_override,
     build_config_toml,
@@ -1153,6 +1154,59 @@ class TestIsBambuPrinter:
 
     def test_empty_string(self):
         assert _is_bambu_printer("") is False
+
+
+# ---------------------------------------------------------------------------
+# _emit_cura_pin_hint
+# ---------------------------------------------------------------------------
+
+
+class TestEmitCuraPinHint:
+    def test_skips_orca_engine(self, tmp_path, monkeypatch):
+        """No hint for OrcaSlicer configs — pinning flow is different."""
+        calls = []
+        monkeypatch.setattr("estampo.ui.warn", lambda msg: calls.append(("warn", msg)))
+        monkeypatch.setattr("estampo.ui.info", lambda msg: calls.append(("info", msg)))
+
+        _emit_cura_pin_hint("orca", "Bambu Lab P1S 0.4 nozzle", tmp_path)
+
+        assert calls == []
+
+    def test_skips_when_printer_missing(self, tmp_path, monkeypatch):
+        """No hint if the wizard never resolved a printer."""
+        calls = []
+        monkeypatch.setattr("estampo.ui.warn", lambda msg: calls.append(("warn", msg)))
+        monkeypatch.setattr("estampo.ui.info", lambda msg: calls.append(("info", msg)))
+
+        _emit_cura_pin_hint("cura", None, tmp_path)
+
+        assert calls == []
+
+    def test_skips_when_def_reachable(self, tmp_path, monkeypatch):
+        """No hint when the cura def is already pinned or bundled."""
+        calls = []
+        monkeypatch.setattr("estampo.ui.warn", lambda msg: calls.append(("warn", msg)))
+        monkeypatch.setattr("estampo.ui.info", lambda msg: calls.append(("info", msg)))
+        monkeypatch.setattr("estampo.init._check_cura_def_reachable", lambda *a, **kw: None)
+
+        _emit_cura_pin_hint("cura", "bambox_p1s", tmp_path)
+
+        assert calls == []
+
+    def test_emits_next_step_when_unreachable(self, tmp_path, monkeypatch):
+        """Warns and prints a next-step hint when the def is Docker-only."""
+        calls = []
+        monkeypatch.setattr("estampo.ui.warn", lambda msg: calls.append(("warn", msg)))
+        monkeypatch.setattr("estampo.ui.info", lambda msg: calls.append(("info", msg)))
+        monkeypatch.setattr(
+            "estampo.init._check_cura_def_reachable",
+            lambda *a, **kw: "def unreachable",
+        )
+
+        _emit_cura_pin_hint("cura", "bambox_p1s", tmp_path)
+
+        assert any(kind == "warn" and "bambox_p1s" in msg for kind, msg in calls)
+        assert any(kind == "info" and "estampo profiles pin" in msg for kind, msg in calls)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Wizard**: after writing the config, the CuraEngine flow now warns and emits an explicit "run ``estampo profiles pin``" next-step hint when the chosen printer definition isn't reachable locally (reuses the existing ``_check_cura_def_reachable`` logic).
- **README**: adds a CuraEngine-specific pinning callout right after the generic ``## Reproducibility`` section.
- **``docs/config.md``**: notes the pin-required rule in the ``[slicer.cura]`` section, where users who skip the wizard land.
- **``docs/ai-setup-prompt.md``**: moves the pinning section up next to the config-creation flow (was ~300 lines later, after Safety), and rewords "especially important" as "required for non-bundled printers".

Closes #618

## Test plan
- [x] ``uv run ruff check src tests`` — passes
- [x] ``uv run ruff format --check src tests`` — passes
- [x] ``uv run mypy src/estampo`` — passes
- [x] ``uv run pytest`` — 650 passed, 9 skipped (4 new tests for ``_emit_cura_pin_hint``)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)