### PR TITLE
Bump bundled bambox to 0.4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG ORCA_VERSION=2.3.1
 # ---------------------------------------------------------------------------
 FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
 
-ARG BAMBOX_VERSION=0.4.4
+ARG BAMBOX_VERSION=0.4.5
 ARG BAMBU_SLICER_VERSION=02.05.00.00
 ARG BNL_TOKEN=""
 
@@ -58,7 +58,7 @@ RUN curl -fSL -o /out/cert/slicer_base64.cer \
 # ---------------------------------------------------------------------------
 FROM estampo/orca-base:${ORCA_VERSION}
 
-ARG BAMBOX_VERSION=0.4.4
+ARG BAMBOX_VERSION=0.4.5
 
 LABEL org.opencontainers.image.description="estampo with OrcaSlicer ${ORCA_VERSION}"
 

--- a/Dockerfile.cura
+++ b/Dockerfile.cura
@@ -16,7 +16,7 @@ ARG CURA_VERSION=5.12.0
 # ---------------------------------------------------------------------------
 FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
 
-ARG BAMBOX_VERSION=0.4.4
+ARG BAMBOX_VERSION=0.4.5
 ARG BAMBU_SLICER_VERSION=02.05.00.00
 ARG BNL_TOKEN=""
 
@@ -59,7 +59,7 @@ RUN curl -fSL -o /out/cert/slicer_base64.cer \
 # ---------------------------------------------------------------------------
 FROM estampo/cura-base:${CURA_VERSION}
 
-ARG BAMBOX_VERSION=0.4.4
+ARG BAMBOX_VERSION=0.4.5
 
 USER root
 

--- a/changes/+bambox-0.4.5.misc
+++ b/changes/+bambox-0.4.5.misc
@@ -1,0 +1,1 @@
+Bump bundled ``bambox`` to ``0.4.5`` in both Docker images (``Dockerfile``, ``Dockerfile.cura``) so the ``:orca-2.3.1`` and ``:cura-5.12.0`` floating tags ship the latest bambox release. Version-pinned tags like ``:orca-2.3.1-0.4.0`` remain on bambox 0.4.4, as intended.


### PR DESCRIPTION
## Summary
- Bump `ARG BAMBOX_VERSION` from 0.4.4 → 0.4.5 in both `Dockerfile` and `Dockerfile.cura`.
- Affects both the `bambox-bridge` binary download and the `uv pip install bambox==${BAMBOX_VERSION}` step.

## What rebuilds on merge
`publish-docker.yml` will rebuild and push the floating Docker tags (and GHCR mirrors):
- `estampo/estampo:orca-2.3.1`
- `estampo/estampo:cura-5.12.0`

## What does NOT rebuild
Version-pinned release tags (e.g. `estampo/estampo:orca-2.3.1-0.4.0`) are only pushed by `release.yml`. Users pinned to those tags stay on bambox 0.4.4 — pinned tags are immutable by design. Bambox 0.4.5 reaches pin-to-release users via the next estampo release.

## Test plan
- [x] `release-readiness.yml` on main has exercised the Docker + bambox bundling path green after recent merges (`docker-pack-test` job)
- [ ] On merge, confirm `publish-docker.yml` rebuilds and pushes the floating tags successfully
- [ ] Optional: `docker run --rm estampo/estampo:orca-2.3.1 bambox --version` returns 0.4.5 after the image hits Docker Hub

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)