### PR TITLE
Fix compat tests that fail with host OrcaSlicer installed

### DIFF
--- a/changes/+test-compat-host-orca.bugfix
+++ b/changes/+test-compat-host-orca.bugfix
@@ -1,0 +1,1 @@
+Fix two ``test_init`` compat tests that were failing locally when OrcaSlicer was installed on the host.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -517,8 +517,14 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         result = validate_config(toml)
         assert any("override keys valid" in p.lower() for p in result.passes)
 
-    def test_process_printer_compat_mismatch_warns(self, tmp_path):
+    def test_process_printer_compat_mismatch_warns(self, tmp_path, monkeypatch):
         """Process listed with an incompatible printer produces a compat warning."""
+        # Force the pinned source so a host-installed OrcaSlicer doesn't shadow
+        # the tmp_path profiles (see issue #633).
+        monkeypatch.setattr(
+            "estampo.profiles.discover_profiles",
+            lambda engine: {"machine": {}, "process": {}, "filament": {}},
+        )
         process_dir = tmp_path / "profiles" / "orca" / "process"
         process_dir.mkdir(parents=True)
         (process_dir / "HighQuality P1P.json").write_text(
@@ -548,8 +554,14 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         assert any("not compatible" in w and "exit 239" in w for w in result.warnings)
         assert not any("Process" in p and "compatible with printer" in p for p in result.passes)
 
-    def test_process_printer_compat_match_passes(self, tmp_path):
+    def test_process_printer_compat_match_passes(self, tmp_path, monkeypatch):
         """Process whose compatible_printers includes the active printer passes."""
+        # Force the pinned source so a host-installed OrcaSlicer doesn't shadow
+        # the tmp_path profiles (see issue #633).
+        monkeypatch.setattr(
+            "estampo.profiles.discover_profiles",
+            lambda engine: {"machine": {}, "process": {}, "filament": {}},
+        )
         process_dir = tmp_path / "profiles" / "orca" / "process"
         process_dir.mkdir(parents=True)
         (process_dir / "HighQuality P1S.json").write_text(


### PR DESCRIPTION
## Summary
- Two `test_init` compat tests pass in CI but fail locally on macOS/Linux hosts that have OrcaSlicer installed.
- `discover_profile_names` prefers the system source over the test's seeded pinned profiles, so `profile_ok` flips false and the compat check the tests exercise never runs.
- Monkeypatch `estampo.profiles.discover_profiles` to return empty in the two affected tests, so resolution deterministically falls through to the pinned source regardless of what's installed on the host.

Closes #633

## Test plan
- [x] `uv run pytest tests/test_init.py -v` — 94 passed
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run mypy src/estampo` — clean
- [x] Verified fix under simulated host-installed Orca (patched `discover_profiles` to return populated dict) — both tests now pass where they previously failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)