### PR TITLE
CuraEngine pack: forward Bambu machine key to bambox (-m)

### DIFF
--- a/changes/+cura-bambox-machine-flag.bugfix
+++ b/changes/+cura-bambox-machine-flag.bugfix
@@ -1,0 +1,1 @@
+CuraEngine → ``bambox pack``: forward the printer as ``-m <machine>`` so the packed .gcode.3mf has a valid ``printer_model_id`` and ``bambox validate`` no longer emits W001.

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -1046,8 +1046,13 @@ def _wizard_pick_command_stages(
                 "docker": True,
             }
             stages.append("pack")
+            machine = _bambox_machine_key(printer_profile)
+            machine_flag = f" -m {machine}" if machine else ""
             command_stages["pack"] = {
-                "command": ("bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf"),
+                "command": (
+                    f"bambox pack {{sliced_dir}}/plate.gcode{machine_flag} "
+                    "-o {output_dir}/plate.gcode.3mf"
+                ),
                 "output": "{output_dir}/plate.gcode.3mf",
                 "docker": True,
             }
@@ -1398,6 +1403,31 @@ def _is_bambu_printer(printer: str) -> bool:
     return any(kw in lower for kw in ("bambu", "bbl", "bambox"))
 
 
+def _bambox_machine_key(printer: str) -> str | None:
+    """Map a Bambu printer profile name to a ``bambox --machine`` key.
+
+    Used to forward the printer identity to ``bambox pack`` so the resulting
+    .gcode.3mf has ``printer_model_id`` set (see issue #685). Returns ``None``
+    when the model can't be derived; caller should omit the ``-m`` flag.
+    """
+    lower = printer.lower()
+    # Order matters: check more specific patterns first.
+    for pattern, key in (
+        ("a1 mini", "a1mini"),
+        ("a1mini", "a1mini"),
+        ("p1s", "p1s"),
+        ("p1p", "p1p"),
+        ("x1e", "x1e"),
+        ("x1c", "x1c"),
+        ("x1 carbon", "x1c"),
+        ("x1", "x1"),
+        ("a1", "a1"),
+    ):
+        if pattern in lower:
+            return key
+    return None
+
+
 def _build_toml(
     *,
     project_name: str | None = None,
@@ -1543,11 +1573,20 @@ def build_config_toml(
                 "docker": True,
             }
         effective_stages.append("pack")
+        if engine == "cura":
+            machine = _bambox_machine_key(printer)
+            machine_flag = f" -m {machine}" if machine else ""
+            pack_cmd = (
+                f"bambox pack {{sliced_dir}}/plate.gcode{machine_flag} "
+                "-o {output_dir}/plate.gcode.3mf"
+            )
+            pack_output = "{output_dir}/plate.gcode.3mf"
+        else:
+            pack_cmd = "bambox repack {sliced_3mf}"
+            pack_output = "{sliced_3mf}"
         command_stages["pack"] = {
-            "command": ("bambox pack {sliced_dir}/plate.gcode -o {output_dir}/plate.gcode.3mf")
-            if engine == "cura"
-            else "bambox repack {sliced_3mf}",
-            "output": "{output_dir}/plate.gcode.3mf" if engine == "cura" else "{sliced_3mf}",
+            "command": pack_cmd,
+            "output": pack_output,
             "docker": True,
         }
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,6 +8,7 @@ from estampo.cli import main
 from estampo.init import (
     BED_TYPES,
     ValidationResult,
+    _bambox_machine_key,
     _build_toml,
     _check_cura_template_gcode,
     _closest_match,
@@ -1157,6 +1158,29 @@ class TestIsBambuPrinter:
 
 
 # ---------------------------------------------------------------------------
+# _bambox_machine_key
+# ---------------------------------------------------------------------------
+
+
+class TestBamboxMachineKey:
+    def test_cura_def_id(self):
+        assert _bambox_machine_key("bambox_p1s") == "p1s"
+        assert _bambox_machine_key("bambox_p1s_ams") == "p1s"
+
+    def test_orca_profile_name(self):
+        assert _bambox_machine_key("Bambu Lab P1S 0.4 nozzle") == "p1s"
+        assert _bambox_machine_key("Bambu Lab P1P 0.4 nozzle") == "p1p"
+        assert _bambox_machine_key("Bambu Lab A1 0.4 nozzle") == "a1"
+        assert _bambox_machine_key("Bambu Lab A1 mini 0.4 nozzle") == "a1mini"
+        assert _bambox_machine_key("Bambu Lab X1 Carbon 0.4 nozzle") == "x1c"
+        assert _bambox_machine_key("Bambu Lab X1E 0.4 nozzle") == "x1e"
+
+    def test_unknown_returns_none(self):
+        assert _bambox_machine_key("Ultimaker 2") is None
+        assert _bambox_machine_key("") is None
+
+
+# ---------------------------------------------------------------------------
 # _emit_cura_pin_hint
 # ---------------------------------------------------------------------------
 
@@ -1444,6 +1468,8 @@ class TestBuildConfigTomlCommandStages:
         assert "resolve_templates" in toml
         assert "cura-p1s resolve" in toml
         assert "bambox pack" in toml
+        # --machine flag forwarded so bambox derives printer_model_id (#685)
+        assert "-m p1s" in toml
         assert '"resolve_templates", "pack"' in toml
         assert "docker = true" in toml
 


### PR DESCRIPTION
## Summary
- `estampo init` auto-generates a `bambox pack` stage for CuraEngine + Bambu printers, but passes no printer info. Resulting .gcode.3mf has empty `printer_model_id`, so `bambox validate` emits W001.
- Add a small `_bambox_machine_key` helper mapping Bambu printer profile names (Orca-style or Cura def ID) to bambox machine keys (`p1s`, `p1p`, `a1`, `a1mini`, `x1`, `x1c`, `x1e`).
- Inject `-m <key>` into the auto-generated pack command for CuraEngine. bambox 0.4.6+ auto-derives `printer_model_id` from `-m`. Omit the flag for unrecognised printers (preserves current behaviour, no regressions).
- Orca `bambox repack` path already handles this via estampo/bambox#213 — unchanged here.

Closes #685

## Test plan
- [x] Added `TestBamboxMachineKey` unit tests (Cura def IDs, Orca profile names, unknown returns None)
- [x] Updated `TestBuildConfigTomlCommandStages::test_cura_bambu_adds_resolve_and_pack` to assert `-m p1s` is in the rendered TOML
- [x] `uv run pytest` — 654 passed, 9 skipped
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run mypy src/estampo` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)