### PR TITLE
Surface resolved profile names and override counts in CLI and action output

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -154,6 +154,10 @@ runs:
           LAYERS=$(python3 -c "import json; d=json.load(open('$STATS_FILE')); print(d.get('layer_count',''))" 2>/dev/null || true)
           FILAMENT_TYPES=$(python3 -c "import json; d=json.load(open('$STATS_FILE')); t=d.get('filament_types',[]); print(', '.join(t) if t else '')" 2>/dev/null || true)
           FILAMENT_CHANGES=$(python3 -c "import json; d=json.load(open('$STATS_FILE')); print(d.get('filament_changes',''))" 2>/dev/null || true)
+          MACHINE_PROFILE=$(python3 -c "import json; d=json.load(open('$STATS_FILE')); print(d.get('slicer',{}).get('machine',''))" 2>/dev/null || true)
+          PROCESS_PROFILE=$(python3 -c "import json; d=json.load(open('$STATS_FILE')); print(d.get('slicer',{}).get('process',''))" 2>/dev/null || true)
+          FILAMENT_PROFILES=$(python3 -c "import json; d=json.load(open('$STATS_FILE')); f=d.get('slicer',{}).get('filaments',[]); print(', '.join(f) if f else '')" 2>/dev/null || true)
+          OVERRIDE_COUNT=$(python3 -c "import json; d=json.load(open('$STATS_FILE')); print(d.get('slicer',{}).get('override_count',''))" 2>/dev/null || true)
         fi
 
         # Extract project name: match top-level name only (before any [section] header)
@@ -166,6 +170,10 @@ runs:
         echo "filament-changes=${FILAMENT_CHANGES}" >> "$GITHUB_OUTPUT"
         echo "gcode-path=${FULL_OUTPUT_DIR}" >> "$GITHUB_OUTPUT"
         echo "project-name=${PROJECT_NAME}" >> "$GITHUB_OUTPUT"
+        echo "machine-profile=${MACHINE_PROFILE}" >> "$GITHUB_OUTPUT"
+        echo "process-profile=${PROCESS_PROFILE}" >> "$GITHUB_OUTPUT"
+        echo "filament-profiles=${FILAMENT_PROFILES}" >> "$GITHUB_OUTPUT"
+        echo "override-count=${OVERRIDE_COUNT}" >> "$GITHUB_OUTPUT"
 
     - name: Job summary
       shell: bash
@@ -178,12 +186,20 @@ runs:
         PROJECT_NAME: ${{ steps.metrics.outputs.project-name }}
         ENGINE: ${{ steps.detect.outputs.engine }}
         VERSION: ${{ steps.detect.outputs.version }}
+        MACHINE_PROFILE: ${{ steps.metrics.outputs.machine-profile }}
+        PROCESS_PROFILE: ${{ steps.metrics.outputs.process-profile }}
+        FILAMENT_PROFILES: ${{ steps.metrics.outputs.filament-profiles }}
+        OVERRIDE_COUNT: ${{ steps.metrics.outputs.override-count }}
       run: |
         TITLE="${PROJECT_NAME:+Estampo: $PROJECT_NAME}"
         TITLE="${TITLE:-Estampo Slice Results}"
         ENGINE_LABEL="OrcaSlicer"
         if [ "$ENGINE" = "cura" ]; then
           ENGINE_LABEL="CuraEngine"
+        fi
+        PROCESS_LABEL="${PROCESS_PROFILE}"
+        if [ -n "$OVERRIDE_COUNT" ] && [ "$OVERRIDE_COUNT" != "0" ]; then
+          PROCESS_LABEL="${PROCESS_LABEL} (${OVERRIDE_COUNT} overrides)"
         fi
         {
           echo "### ${TITLE}"
@@ -195,6 +211,9 @@ runs:
           [ -n "$LAYERS" ] && echo "| Layers | ${LAYERS} |"
           [ -n "$FILAMENT_TYPES" ] && echo "| Filament type | ${FILAMENT_TYPES} |"
           [ -n "$FILAMENT_CHANGES" ] && [ "$FILAMENT_CHANGES" != "0" ] && echo "| Tool changes | ${FILAMENT_CHANGES} |"
+          [ -n "$MACHINE_PROFILE" ] && echo "| Machine profile | ${MACHINE_PROFILE} |"
+          [ -n "$PROCESS_LABEL" ] && echo "| Process profile | ${PROCESS_LABEL} |"
+          [ -n "$FILAMENT_PROFILES" ] && echo "| Filament profile | ${FILAMENT_PROFILES} |"
           echo ""
           echo "Sliced with ${ENGINE_LABEL} ${VERSION}"
         } >> "$GITHUB_STEP_SUMMARY"
@@ -218,6 +237,10 @@ runs:
         ENGINE: ${{ steps.detect.outputs.engine }}
         VERSION: ${{ steps.detect.outputs.version }}
         PROJECT_NAME: ${{ steps.metrics.outputs.project-name }}
+        MACHINE_PROFILE: ${{ steps.metrics.outputs.machine-profile }}
+        PROCESS_PROFILE: ${{ steps.metrics.outputs.process-profile }}
+        FILAMENT_PROFILES: ${{ steps.metrics.outputs.filament-profiles }}
+        OVERRIDE_COUNT: ${{ steps.metrics.outputs.override-count }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         EVENT_NAME: ${{ github.event_name }}
         WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -251,10 +274,20 @@ runs:
           const filamentTypes = process.env.FILAMENT_TYPES || '';
           const filamentChanges = process.env.FILAMENT_CHANGES || '';
           const projectName = process.env.PROJECT_NAME || '';
+          const machineProfile = process.env.MACHINE_PROFILE || '';
+          const processProfile = process.env.PROCESS_PROFILE || '';
+          const filamentProfiles = process.env.FILAMENT_PROFILES || '';
+          const overrideCount = process.env.OVERRIDE_COUNT || '';
           const runUrl = process.env.RUN_URL;
           const artifactName = `estampo-${projectName || 'output'}`;
           const title = projectName ? `Estampo: ${projectName}` : 'Estampo Slice Results';
           const marker = `<!-- estampo-slice-result-${projectName || 'default'} -->`;
+
+          const processLabel = processProfile
+            ? (overrideCount && overrideCount !== '0'
+                ? `${processProfile} (${overrideCount} overrides)`
+                : processProfile)
+            : '';
 
           const rows = [
             `| Print time | ${printTime} |`,
@@ -263,6 +296,9 @@ runs:
           if (layers) rows.push(`| Layers | ${layers} |`);
           if (filamentTypes) rows.push(`| Filament type | ${filamentTypes} |`);
           if (filamentChanges && filamentChanges !== '0') rows.push(`| Tool changes | ${filamentChanges} |`);
+          if (machineProfile) rows.push(`| Machine profile | ${machineProfile} |`);
+          if (processLabel) rows.push(`| Process profile | ${processLabel} |`);
+          if (filamentProfiles) rows.push(`| Filament profile | ${filamentProfiles} |`);
 
           const body = [
             marker,

--- a/changes/695.feature
+++ b/changes/695.feature
@@ -1,0 +1,1 @@
+Surface resolved profile names and override counts in CLI output, GitHub Actions job summary, and PR comments.

--- a/src/estampo/adapters.py
+++ b/src/estampo/adapters.py
@@ -210,11 +210,26 @@ class ProgressAdapter(NodeExecutionHook):
             ver_str = f"with {engine_name} {ver}" if ver else ""
             time_str = f" in {elapsed:.0f}s" if elapsed >= 2 else ""
             self._ok(f"Sliced {ver_str}{time_str}".rstrip(), show_elapsed=False)
-            # Show gcode filename if available
             if isinstance(result, Path):
                 gcode_files = list(result.glob("*.gcode"))
                 if gcode_files:
                     self._console.print(f"  [dim]→ {gcode_files[0].name}[/dim]")
+                slice_info_path = result / "slice_info.json"
+                if slice_info_path.exists():
+                    try:
+                        import json as _json
+
+                        info = _json.loads(slice_info_path.read_text())
+                        if machine := info.get("machine"):
+                            self._console.print(f"  [dim]Machine:  {machine}[/dim]")
+                        if process := info.get("process"):
+                            oc = info.get("override_count", 0)
+                            ov_str = f" ({oc} override{'s' if oc != 1 else ''})" if oc else ""
+                            self._console.print(f"  [dim]Process:  {process}{ov_str}[/dim]")
+                        for fil in info.get("filaments", []):
+                            self._console.print(f"  [dim]Filament: {fil}[/dim]")
+                    except (ValueError, TypeError, OSError):
+                        pass
 
         elif node_name == "packaged_output":
             self._ok("Packaged output", elapsed)

--- a/src/estampo/orca.py
+++ b/src/estampo/orca.py
@@ -282,14 +282,17 @@ def _resolve_profiles(
     docker_profile_dir: Path | None = None,
     bed_type: str | None = None,
     filament_overrides: dict[str, object] | None = None,
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str | None, dict]:
     """Resolve and flatten all profiles into tmp_dir.
 
-    Returns (settings_arg, filament_arg) — semicolon-separated paths
-    suitable for --load-settings and --load-filaments.
+    Returns (settings_arg, filament_arg, slicer_info) where settings_arg and
+    filament_arg are semicolon-separated paths for --load-settings /
+    --load-filaments, and slicer_info captures resolved names and override counts
+    for downstream display.
     """
     from estampo.profiles import resolve_profile_data
 
+    slicer_info: dict = {}
     settings = []
     if printer:
         data = resolve_profile_data(
@@ -305,8 +308,10 @@ def _resolve_profiles(
         if bed_type:
             data["curr_bed_type"] = bed_type
             log.info("Set bed type to '%s' in machine profile", bed_type)
+            slicer_info["bed_type"] = bed_type
         if machine_overrides:
             data = _apply_overrides(data, machine_overrides, printer)
+        slicer_info["machine"] = printer
         path = _write_tmp_profile(data, tmp_dir, "machine")
         settings.append(str(path))
     if process:
@@ -315,10 +320,19 @@ def _resolve_profiles(
         )
         if overrides:
             data = _apply_overrides(data, overrides, process)
+        slicer_info["process"] = process
         path = _write_tmp_profile(data, tmp_dir, "process")
         settings.append(str(path))
 
+    # Total overrides across all profile types
+    override_count = (
+        len(overrides or {}) + len(machine_overrides or {}) + len(filament_overrides or {})
+    )
+    if override_count:
+        slicer_info["override_count"] = override_count
+
     filament_arg = None
+    resolved_filament_names: list[str] = []
     if filaments:
         resolved: list[str] = []
         first_path: str | None = None
@@ -331,6 +345,7 @@ def _resolve_profiles(
                     data = _apply_overrides(data, filament_overrides, f)
                 path = _write_tmp_profile(data, tmp_dir, f"filament_{i}")
                 resolved.append(str(path))
+                resolved_filament_names.append(f)
                 if first_path is None:
                     first_path = str(path)
             elif first_path:
@@ -341,8 +356,11 @@ def _resolve_profiles(
 
         filament_arg = ";".join(resolved)
 
+    if resolved_filament_names:
+        slicer_info["filaments"] = resolved_filament_names
+
     settings_arg = ";".join(settings) if settings else None
-    return settings_arg, filament_arg
+    return settings_arg, filament_arg, slicer_info
 
 
 # ---------------------------------------------------------------------------
@@ -581,7 +599,7 @@ def orca_slice_plate(
     allow_mix_temp = bool(detected_version and detected_version >= "2.3.2")
 
     try:
-        settings_arg, filament_arg = _resolve_profiles(
+        settings_arg, filament_arg, slicer_info = _resolve_profiles(
             "orca",
             printer,
             process,
@@ -595,6 +613,9 @@ def orca_slice_plate(
             bed_type,
             filament_overrides,
         )
+
+        if slicer_info:
+            (output_dir / "slice_info.json").write_text(json.dumps(slicer_info, indent=2) + "\n")
 
         if use_docker:
             return _slice_via_docker(

--- a/src/estampo/pipeline.py
+++ b/src/estampo/pipeline.py
@@ -464,6 +464,16 @@ def gcode_stats(packaged_output: Path) -> dict:
         if info.filament_usage_g:
             stats["filament_usage_g"] = info.filament_usage_g
 
+    # Merge slicer profile info written by the engine module
+    slice_info_path = packaged_output / "slice_info.json"
+    if slice_info_path.exists():
+        try:
+            slicer_info = json.loads(slice_info_path.read_text())
+            if slicer_info:
+                stats["slicer"] = slicer_info
+        except (json.JSONDecodeError, OSError):
+            pass
+
     # Write to output dir for CI/action consumption
     stats_path = packaged_output / "stats.json"
     stats_path.write_text(json.dumps(stats, indent=2) + "\n")

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -86,7 +86,7 @@ def test_resolve_profiles_all_filaments_resolved(tmp_path):
     out = tmp_path / "out"
     out.mkdir()
 
-    _, filament_arg = _resolve_profiles(
+    _, filament_arg, _ = _resolve_profiles(
         engine="orca",
         printer=None,
         process=None,
@@ -122,7 +122,7 @@ def test_resolve_profiles_machine_overrides(tmp_path: Path):
     out = tmp_path / "out"
     out.mkdir()
 
-    settings_arg, _ = _resolve_profiles(
+    settings_arg, _, _ = _resolve_profiles(
         engine="orca",
         printer="My Printer",
         process=None,
@@ -156,7 +156,7 @@ def test_resolve_profiles_machine_overrides_scalar_broadcast(tmp_path: Path):
     out = tmp_path / "out"
     out.mkdir()
 
-    settings_arg, _ = _resolve_profiles(
+    settings_arg, _, _ = _resolve_profiles(
         engine="orca",
         printer="My Printer",
         process=None,


### PR DESCRIPTION
## Summary

- After slicing, write `slice_info.json` to the output dir with resolved machine/process/filament profile names, bed type, and total override count
- Merge that into `stats.json` under a `slicer` key so it's available to all consumers
- Show profile names and override count in the CLI terminal output after the slicing checkmark
- Add profile rows to the GitHub Actions job summary table and PR comment

## CLI output (new)

```
✔ Sliced with OrcaSlicer 2.3.1 in 5s
  → plate_1.gcode
  Machine:  Bambu Lab P1S 0.4 nozzle
  Process:  0.20mm Strength @BBL X1C (11 overrides)
  Filament: Bambu PETG-CF @BBL X1C 0.4 nozzle
```

## PR comment (new rows)

| Machine profile | Bambu Lab P1S 0.4 nozzle |
| Process profile | 0.20mm Strength @BBL X1C (11 overrides) |
| Filament profile | Bambu PETG-CF @BBL X1C 0.4 nozzle |

## Notes

- `slice_info.json` is written by `orca.py` only; `pipeline.py` reads it generically, so CuraEngine can add the same file when needed without touching pipeline logic
- PR comment still only fires on `pull_request` or `workflow_run` events with `comment: true` (default) — unchanged behaviour

## Test plan

- [ ] 654 existing tests pass (no regressions)
- [ ] `test_resolve_profiles_*` tests updated to unpack 3-tuple return value
- [ ] `test_sliced_output_dir_*` adapter tests pass (TypeError from mock path now caught)

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)