### PR TITLE
Bump BAMBOX_VERSION to 0.4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG ORCA_VERSION=2.3.1
 # ---------------------------------------------------------------------------
 FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
 
-ARG BAMBOX_VERSION=0.4.5
+ARG BAMBOX_VERSION=0.4.7
 ARG BAMBU_SLICER_VERSION=02.05.00.00
 ARG BNL_TOKEN=""
 
@@ -58,7 +58,7 @@ RUN curl -fSL -o /out/cert/slicer_base64.cer \
 # ---------------------------------------------------------------------------
 FROM estampo/orca-base:${ORCA_VERSION}
 
-ARG BAMBOX_VERSION=0.4.5
+ARG BAMBOX_VERSION=0.4.7
 
 LABEL org.opencontainers.image.description="estampo with OrcaSlicer ${ORCA_VERSION}"
 

--- a/Dockerfile.cura
+++ b/Dockerfile.cura
@@ -16,7 +16,7 @@ ARG CURA_VERSION=5.12.0
 # ---------------------------------------------------------------------------
 FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
 
-ARG BAMBOX_VERSION=0.4.5
+ARG BAMBOX_VERSION=0.4.7
 ARG BAMBU_SLICER_VERSION=02.05.00.00
 ARG BNL_TOKEN=""
 
@@ -59,7 +59,7 @@ RUN curl -fSL -o /out/cert/slicer_base64.cer \
 # ---------------------------------------------------------------------------
 FROM estampo/cura-base:${CURA_VERSION}
 
-ARG BAMBOX_VERSION=0.4.5
+ARG BAMBOX_VERSION=0.4.7
 
 USER root
 

--- a/changes/702.misc
+++ b/changes/702.misc
@@ -1,0 +1,1 @@
+Bump ``BAMBOX_VERSION`` to 0.4.7 in ``Dockerfile`` and ``Dockerfile.cura``.


### PR DESCRIPTION
Bumps `BAMBOX_VERSION` from 0.4.5 → 0.4.7 in both `Dockerfile` and `Dockerfile.cura`.

bambox 0.4.7 includes all the Bambu Connect compatibility fixes: auto-detection of machine from OrcaSlicer settings, correct key ordering in metadata files, `plate_1.json` `bed_type` normalisation, and the auto-detection fix for the CLI default machine flag.

Closes #701
Closes #702