### PR TITLE
fix: accept gcode_info as alias for gcode-info pipeline stage

### DIFF
--- a/changes/711.misc
+++ b/changes/711.misc
@@ -1,0 +1,1 @@
+Accept gcode_info as an alias for the gcode-info pipeline stage (TOML underscore convention).

--- a/src/estampo/pipeline.py
+++ b/src/estampo/pipeline.py
@@ -45,6 +45,7 @@ STAGE_OUTPUTS: dict[str, list[str]] = {
     "plate": ["plate_3mf_path", "preview_path"],
     "slice": ["sliced_output_dir", "packaged_output", "gcode_stats"],
     "gcode-info": ["gcode_stats"],  # kept for backward compat
+    "gcode_info": ["gcode_stats"],  # preferred underscore form
 }
 
 # For --only mode: maps stage names to the Hamilton node overrides that must
@@ -52,6 +53,7 @@ STAGE_OUTPUTS: dict[str, list[str]] = {
 STAGE_REQUIRES: dict[str, list[tuple[str, str]]] = {
     "slice": [("plate_3mf_path", "plate 3MF file")],
     "gcode-info": [("packaged_output", "slicer output directory")],
+    "gcode_info": [("packaged_output", "slicer output directory")],
 }
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -211,6 +211,15 @@ def test_resolve_outputs_only_gcode_info():
     assert outputs == ["gcode_stats"]
 
 
+def test_resolve_outputs_only_gcode_info_underscore():
+    """resolve_outputs --only gcode_info (underscore alias) returns gcode_stats."""
+    from estampo.pipeline import resolve_outputs
+
+    stages = ["load", "arrange", "plate", "slice", "gcode_info"]
+    outputs = resolve_outputs(stages, only="gcode_info")
+    assert outputs == ["gcode_stats"]
+
+
 # --- resolve_overrides tests ---
 
 
@@ -245,6 +254,14 @@ def test_resolve_overrides_gcode_info_finds_dir(tmp_path):
     from estampo.pipeline import resolve_overrides
 
     overrides = resolve_overrides("gcode-info", tmp_path)
+    assert overrides["packaged_output"] == tmp_path
+
+
+def test_resolve_overrides_gcode_info_underscore_finds_dir(tmp_path):
+    """--only gcode_info (underscore alias) resolves packaged_output from disk."""
+    from estampo.pipeline import resolve_overrides
+
+    overrides = resolve_overrides("gcode_info", tmp_path)
     assert overrides["packaged_output"] == tmp_path
 
 


### PR DESCRIPTION
## Summary

TOML convention uses underscores, but the built-in `gcode-info` stage used a hyphen. Users naturally wrote `gcode_info` and got a confusing "unknown stage" validation error.

**Change:** Added `gcode_info` as an alias in both `STAGE_OUTPUTS` and `STAGE_REQUIRES` in `pipeline.py`, pointing to the same outputs/requirements as `gcode-info`. The hyphen form is kept for full backward compatibility — both names work.

**No renaming, no deprecation** — this is purely additive.

## Test plan

- [x] Two new tests: `test_resolve_outputs_only_gcode_info_underscore` and `test_resolve_overrides_gcode_info_underscore_finds_dir`
- [x] All 656 tests pass

Closes #711