### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project are documented here.
 
 <!-- towncrier release notes start -->
 
+## 0.4.2 — 2026-05-27
+
+### Features
+
+- Surface resolved profile names and override counts in CLI output, GitHub Actions job summary, and PR comments. ([#695](https://github.com/estampo/estampo/pull/695))
+
+### Bugfixes
+
+- Fix broken GitHub Actions workflow trigger in ai-setup-prompt.md; add build-step hint and wall_loops guidance to recipe docs. ([#697](https://github.com/estampo/estampo/pull/697))
+- Declare click and rich as explicit direct dependencies to fix missing-module crash on uv tool install estampo. ([#709](https://github.com/estampo/estampo/pull/709))
+
+### Misc
+
+- Bump ``BAMBOX_VERSION`` to 0.4.7 in ``Dockerfile`` and ``Dockerfile.cura``. ([#702](https://github.com/estampo/estampo/pull/702))
+- Document that bambox is pre-installed in the estampo Docker image (no separate install needed for CI). ([#706](https://github.com/estampo/estampo/pull/706))
+- Add note that P1S, P1P, and A1 printers use @BBL X1C process profiles. ([#707](https://github.com/estampo/estampo/pull/707))
+- Add inline comment to quick-start TOML template explaining orient = "upright" for code-CAD output. ([#708](https://github.com/estampo/estampo/pull/708))
+- Document that comment: "false" disables PR comments in the action, with an explicit example for release workflows. ([#710](https://github.com/estampo/estampo/pull/710))
+- Accept gcode_info as an alias for the gcode-info pipeline stage (TOML underscore convention). ([#711](https://github.com/estampo/estampo/pull/711))
+
+
 ## 0.4.1 — 2026-04-21
 
 ### Bugfixes

--- a/changes/695.feature
+++ b/changes/695.feature
@@ -1,1 +1,0 @@
-Surface resolved profile names and override counts in CLI output, GitHub Actions job summary, and PR comments.

--- a/changes/697.bugfix
+++ b/changes/697.bugfix
@@ -1,1 +1,0 @@
-Fix broken GitHub Actions workflow trigger in ai-setup-prompt.md; add build-step hint and wall_loops guidance to recipe docs.

--- a/changes/702.misc
+++ b/changes/702.misc
@@ -1,1 +1,0 @@
-Bump ``BAMBOX_VERSION`` to 0.4.7 in ``Dockerfile`` and ``Dockerfile.cura``.

--- a/changes/706.misc
+++ b/changes/706.misc
@@ -1,1 +1,0 @@
-Document that bambox is pre-installed in the estampo Docker image (no separate install needed for CI).

--- a/changes/707.misc
+++ b/changes/707.misc
@@ -1,1 +1,0 @@
-Add note that P1S, P1P, and A1 printers use @BBL X1C process profiles.

--- a/changes/708.misc
+++ b/changes/708.misc
@@ -1,1 +1,0 @@
-Add inline comment to quick-start TOML template explaining orient = "upright" for code-CAD output.

--- a/changes/709.bugfix
+++ b/changes/709.bugfix
@@ -1,1 +1,0 @@
-Declare click and rich as explicit direct dependencies to fix missing-module crash on uv tool install estampo.

--- a/changes/710.misc
+++ b/changes/710.misc
@@ -1,1 +1,0 @@
-Document that comment: "false" disables PR comments in the action, with an explicit example for release workflows.

--- a/changes/711.misc
+++ b/changes/711.misc
@@ -1,1 +1,0 @@
-Accept gcode_info as an alias for the gcode-info pipeline stage (TOML underscore convention).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estampo"
-version = "0.4.1"
+version = "0.4.2"
 description = "The build system for reproducible 3D prints. Define parts, slicer settings, and printer targets in code."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release v0.4.2


### Features

- Surface resolved profile names and override counts in CLI output, GitHub Actions job summary, and PR comments. ([#695](https://github.com/estampo/estampo/pull/695))

### Bugfixes

- Fix broken GitHub Actions workflow trigger in ai-setup-prompt.md; add build-step hint and wall_loops guidance to recipe docs. ([#697](https://github.com/estampo/estampo/pull/697))
- Declare click and rich as explicit direct dependencies to fix missing-module crash on uv tool install estampo. ([#709](https://github.com/estampo/estampo/pull/709))

### Misc

- Bump ``BAMBOX_VERSION`` to 0.4.7 in ``Dockerfile`` and ``Dockerfile.cura``. ([#702](https://github.com/estampo/estampo/pull/702))
- Document that bambox is pre-installed in the estampo Docker image (no separate install needed for CI). ([#706](https://github.com/estampo/estampo/pull/706))
- Add note that P1S, P1P, and A1 printers use @BBL X1C process profiles. ([#707](https://github.com/estampo/estampo/pull/707))
- Add inline comment to quick-start TOML template explaining orient = "upright" for code-CAD output. ([#708](https://github.com/estampo/estampo/pull/708))
- Document that comment: "false" disables PR comments in the action, with an explicit example for release workflows. ([#710](https://github.com/estampo/estampo/pull/710))
- Accept gcode_info as an alias for the gcode-info pipeline stage (TOML underscore convention). ([#711](https://github.com/estampo/estampo/pull/711))

---
**Merge this PR to trigger the release pipeline.**
The release workflow will auto-tag `v0.4.2`, build all artifacts, validate on TestPyPI, then publish to PyPI + Docker Hub + GHCR.