### PR TITLE
validate: warn when @base filament profile is used

### DIFF
--- a/changes/+warn-base-filament.bugfix
+++ b/changes/+warn-base-filament.bugfix
@@ -1,0 +1,1 @@
+Warn in ``estampo validate`` when a filament profile ending in ``@base`` is used — the generic ancestor profile lacks machine-specific calibration (pressure advance, temperatures, retraction) and causes inconsistent extrusion at high speeds. The warning lists available machine-specific variants.

--- a/src/estampo/init.py
+++ b/src/estampo/init.py
@@ -429,6 +429,29 @@ def validate_config(path: Path) -> ValidationResult:
                         f"{cfg.slicer.engine} profiles ({source}).{hint}{pin_hint}"
                     )
                     profile_ok = False
+                elif fil.endswith("@base"):
+                    # @base is the generic ancestor profile — it lacks machine-specific
+                    # calibration (pressure advance, temperatures, retraction). At high
+                    # speeds this causes inconsistent extrusion and poor surface quality.
+                    base_name = fil[: -len("@base")].rstrip()
+                    variants = sorted(
+                        f for f in known_filaments if f.startswith(base_name + " @") and f != fil
+                    )
+                    if variants:
+                        var_str = ", ".join(f"'{v}'" for v in variants[:5])
+                        more = f" (and {len(variants) - 5} more)" if len(variants) > 5 else ""
+                        hint = f"\n  Machine-specific variants: {var_str}{more}"
+                    else:
+                        hint = (
+                            f"\n  Run 'estampo profiles list --engine {cfg.slicer.engine}"
+                            f" --category filament' to find the right variant."
+                        )
+                    warnings.append(
+                        f"filament '{fil}' uses the generic '@base' profile — it lacks "
+                        f"machine-specific calibration (pressure advance, temperatures, "
+                        f"retraction). At high print speeds this causes inconsistent "
+                        f"extrusion and surface defects.{hint}"
+                    )
 
         if profile_ok:
             passes.append(f"Slicer profiles valid ({source})")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -692,6 +692,66 @@ file = "{_posix(FIXTURES / "cube_10mm.stl")}"
         assert matched, f"expected a warning for bed_type in [slicer.orca], got: {list(warnings)}"
         assert "[slicer]" in matched[0]
 
+    def test_base_filament_warns_with_variants(self, tmp_path, monkeypatch):
+        """@base filament triggers a warning listing machine-specific variants."""
+        monkeypatch.setattr(
+            "estampo.profiles.discover_profiles",
+            lambda engine: {"machine": {}, "process": {}, "filament": {}},
+        )
+        filament_dir = tmp_path / "profiles" / "orca" / "filament"
+        filament_dir.mkdir(parents=True)
+        (filament_dir / "Bambu PLA Basic @base.json").write_text(
+            '{"type": "filament", "name": "Bambu PLA Basic @base"}'
+        )
+        (filament_dir / "Bambu PLA Basic @BBL X1C.json").write_text(
+            '{"type": "filament", "name": "Bambu PLA Basic @BBL X1C"}'
+        )
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[slicer.orca]
+filaments = ["Bambu PLA Basic @base"]
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        result = validate_config(toml)
+        assert any("@base" in w and "machine-specific calibration" in w for w in result.warnings)
+        assert any("BBL X1C" in w for w in result.warnings)
+
+    def test_machine_specific_filament_no_base_warning(self, tmp_path, monkeypatch):
+        """Machine-specific filament variant does not trigger @base warning."""
+        monkeypatch.setattr(
+            "estampo.profiles.discover_profiles",
+            lambda engine: {"machine": {}, "process": {}, "filament": {}},
+        )
+        filament_dir = tmp_path / "profiles" / "orca" / "filament"
+        filament_dir.mkdir(parents=True)
+        (filament_dir / "Bambu PLA Basic @base.json").write_text(
+            '{"type": "filament", "name": "Bambu PLA Basic @base"}'
+        )
+        (filament_dir / "Bambu PLA Basic @BBL X1C.json").write_text(
+            '{"type": "filament", "name": "Bambu PLA Basic @BBL X1C"}'
+        )
+        toml = tmp_path / "estampo.toml"
+        toml.write_text(f"""
+[slicer]
+engine = "orca"
+version = "2.3.1"
+
+[slicer.orca]
+filaments = ["Bambu PLA Basic @BBL X1C"]
+
+[[parts]]
+file = "{_posix(FIXTURES / "cube_10mm.stl")}"
+""")
+        result = validate_config(toml)
+        base_warnings = [w for w in result.warnings if "@base" in w and "machine-specific" in w]
+        assert not base_warnings
+
     def test_unknown_key_typo_same_table(self, tmp_path):
         """printr → printer in [slicer.orca]."""
         toml = tmp_path / "estampo.toml"


### PR DESCRIPTION
## Summary

- Detect when a filament profile ending in `@base` is specified in `estampo.toml`
- Warn that `@base` lacks machine-specific calibration (pressure advance, temperatures, retraction)
- List available machine-specific variants from the bundled/pinned profiles so the user knows what to change to

## Why

`@base` at 200–500mm/s causes inconsistent extrusion and surface defects — most visibly as wrong-looking layer lines and failed print-in-place features. Discovered via a bad real-world print (`pzfreo/gramel` v0.1.8) where `filaments = ["Bambu PLA Basic @base"]` was specified. OrcaSlicer embedded `enable_pressure_advance = 0` (from `@base`) rather than the BBL-tuned value from `@BBL X1C`.

Bambu Studio auto-resolves `@base` → `@BBL X1C` for BBL printers. estampo uses what's explicitly specified, so this class of mistake was previously silent.

## Test plan

- `test_base_filament_warns_with_variants` — asserts warning fires and lists variants
- `test_machine_specific_filament_no_base_warning` — asserts `@BBL X1C` does not trigger the warning
- Full suite: 658 passed, 0 failed

Closes #717