### PR TITLE
chore: bump bambox to 0.6.1 + remove dead cloud-bridge stage

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -123,7 +123,6 @@ jobs:
             ghcr.io/${{ github.repository }}:orca-${{ matrix.orca-version }}
           build-args: |
             ORCA_VERSION=${{ matrix.orca-version }}
-            BNL_TOKEN=${{ secrets.BNL_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -198,6 +197,5 @@ jobs:
             ghcr.io/${{ github.repository }}:cura-${{ matrix.cura-version }}
           build-args: |
             CURA_VERSION=${{ matrix.cura-version }}
-            BNL_TOKEN=${{ secrets.BNL_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -89,7 +89,6 @@ jobs:
         run: |
           docker build --platform linux/amd64 \
             --build-arg ORCA_VERSION=${{ matrix.orca_version }} \
-            --build-arg BNL_TOKEN=${{ secrets.BNL_TOKEN }} \
             -t estampo/estampo:orca-${{ matrix.orca_version }}-test .
 
       - name: Save image as artifact
@@ -364,7 +363,6 @@ jobs:
           docker build --platform linux/amd64 \
             -f Dockerfile.cura \
             --build-arg CURA_VERSION=${{ matrix.cura_version }} \
-            --build-arg BNL_TOKEN=${{ secrets.BNL_TOKEN }} \
             -t estampo/estampo:cura-${{ matrix.cura_version }}-test .
 
       - name: Save image as artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,6 @@ jobs:
           tags: estampo/estampo:orca-${{ matrix.orca-version }}
           build-args: |
             ORCA_VERSION=${{ matrix.orca-version }}
-            BNL_TOKEN=${{ secrets.BNL_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -242,7 +241,6 @@ jobs:
           tags: estampo/estampo:cura-${{ matrix.cura-version }}
           build-args: |
             CURA_VERSION=${{ matrix.cura-version }}
-            BNL_TOKEN=${{ secrets.BNL_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -43,7 +43,6 @@ jobs:
         run: |
           docker build \
             --build-arg ORCA_VERSION=${{ inputs.version }} \
-            --build-arg BNL_TOKEN=${{ secrets.BNL_TOKEN }} \
             -t estampo/estampo:orca-${{ inputs.version }} .
 
       - name: Generate plate and slice
@@ -80,7 +79,6 @@ jobs:
           docker build --platform linux/amd64 \
             -f Dockerfile.cura \
             --build-arg CURA_VERSION=${{ inputs.version }} \
-            --build-arg BNL_TOKEN=${{ secrets.BNL_TOKEN }} \
             -t estampo/estampo:cura-${{ inputs.version }} .
 
       - name: Generate plate and slice

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,62 +11,13 @@
 ARG ORCA_VERSION=2.3.1
 
 # ---------------------------------------------------------------------------
-# Fetch stage: bambox-bridge binary + libbambu_networking.so + TLS cert
-# ---------------------------------------------------------------------------
-FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
-
-ARG BAMBOX_VERSION=0.4.7
-ARG BAMBU_SLICER_VERSION=02.05.00.00
-ARG BNL_TOKEN=""
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl python3 unzip ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Download pre-built bambox-bridge binary from GitHub release
-RUN curl -fSL -o /usr/local/bin/bambox-bridge \
-        "https://github.com/estampo/bambox/releases/download/v${BAMBOX_VERSION}/bambox-bridge-linux-x86_64" \
-    && chmod +x /usr/local/bin/bambox-bridge
-
-# Fetch libbambu_networking.so (Bambu API → private cache fallback)
-RUN mkdir -p /out/lib /out/cert \
-    && (PLUGIN_URL=$(curl -fsSL \
-        -H "User-Agent: BambuStudio/${BAMBU_SLICER_VERSION}" \
-        -H "X-BBL-OS-Type: linux" \
-        "https://api.bambulab.com/v1/iot-service/api/slicer/resource?slicer/plugins/cloud=${BAMBU_SLICER_VERSION}" \
-        | python3 -c "import sys,json; r=json.load(sys.stdin)['resources']; print([x for x in r if 'plugins' in x['type']][0]['url'])") \
-    && curl -fsSL -o /tmp/plugins.zip "$PLUGIN_URL" \
-    && unzip -j /tmp/plugins.zip libbambu_networking.so -d /out/lib/ \
-    && echo "Fetched libbambu_networking.so from Bambu API") \
-    || (echo "Bambu API failed, falling back to private cache..." \
-    && curl -fsSL \
-        -H "Authorization: token ${BNL_TOKEN}" \
-        -H "Accept: application/octet-stream" \
-        -o /out/lib/libbambu_networking.so \
-        "https://api.github.com/repos/estampo/bnl/releases/assets/$(curl -fsSL \
-            -H "Authorization: token ${BNL_TOKEN}" \
-            "https://api.github.com/repos/estampo/bnl/releases/tags/v${BAMBU_SLICER_VERSION}" \
-            | python3 -c "import sys,json; print([a for a in json.load(sys.stdin)['assets'] if a['name']=='libbambu_networking.so'][0]['id'])")" \
-    && echo "Fetched libbambu_networking.so from private cache")
-
-# TLS certificate for Bambu Cloud MQTT
-RUN curl -fSL -o /out/cert/slicer_base64.cer \
-       "https://raw.githubusercontent.com/bambulab/BambuStudio/master/resources/cert/slicer_base64.cer"
-
-# ---------------------------------------------------------------------------
 # Main image
 # ---------------------------------------------------------------------------
 FROM estampo/orca-base:${ORCA_VERSION}
 
-ARG BAMBOX_VERSION=0.4.7
+ARG BAMBOX_VERSION=0.6.1
 
 LABEL org.opencontainers.image.description="estampo with OrcaSlicer ${ORCA_VERSION}"
-
-# bambox-bridge + libbambu_networking.so + TLS cert
-COPY --from=bridge-fetcher /usr/local/bin/bambox-bridge /usr/local/bin/bambox-bridge
-COPY --from=bridge-fetcher /out/lib/libbambu_networking.so /usr/lib/libbambu_networking.so
-COPY --from=bridge-fetcher /out/cert/slicer_base64.cer /tmp/bambu_agent/cert/slicer_base64.cer
-ENV BAMBU_LIB_PATH=/usr/lib/libbambu_networking.so
 
 # Install uv (fast Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/Dockerfile.cura
+++ b/Dockerfile.cura
@@ -12,64 +12,15 @@
 ARG CURA_VERSION=5.12.0
 
 # ---------------------------------------------------------------------------
-# Fetch stage: bambox-bridge binary + libbambu_networking.so + TLS cert
-# ---------------------------------------------------------------------------
-FROM --platform=linux/amd64 debian:bookworm-slim AS bridge-fetcher
-
-ARG BAMBOX_VERSION=0.4.7
-ARG BAMBU_SLICER_VERSION=02.05.00.00
-ARG BNL_TOKEN=""
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl python3 unzip ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Download pre-built bambox-bridge binary from GitHub release
-RUN curl -fSL -o /usr/local/bin/bambox-bridge \
-        "https://github.com/estampo/bambox/releases/download/v${BAMBOX_VERSION}/bambox-bridge-linux-x86_64" \
-    && chmod +x /usr/local/bin/bambox-bridge
-
-# Fetch libbambu_networking.so (Bambu API → private cache fallback)
-RUN mkdir -p /out/lib /out/cert \
-    && (PLUGIN_URL=$(curl -fsSL \
-        -H "User-Agent: BambuStudio/${BAMBU_SLICER_VERSION}" \
-        -H "X-BBL-OS-Type: linux" \
-        "https://api.bambulab.com/v1/iot-service/api/slicer/resource?slicer/plugins/cloud=${BAMBU_SLICER_VERSION}" \
-        | python3 -c "import sys,json; r=json.load(sys.stdin)['resources']; print([x for x in r if 'plugins' in x['type']][0]['url'])") \
-    && curl -fsSL -o /tmp/plugins.zip "$PLUGIN_URL" \
-    && unzip -j /tmp/plugins.zip libbambu_networking.so -d /out/lib/ \
-    && echo "Fetched libbambu_networking.so from Bambu API") \
-    || (echo "Bambu API failed, falling back to private cache..." \
-    && curl -fsSL \
-        -H "Authorization: token ${BNL_TOKEN}" \
-        -H "Accept: application/octet-stream" \
-        -o /out/lib/libbambu_networking.so \
-        "https://api.github.com/repos/estampo/bnl/releases/assets/$(curl -fsSL \
-            -H "Authorization: token ${BNL_TOKEN}" \
-            "https://api.github.com/repos/estampo/bnl/releases/tags/v${BAMBU_SLICER_VERSION}" \
-            | python3 -c "import sys,json; print([a for a in json.load(sys.stdin)['assets'] if a['name']=='libbambu_networking.so'][0]['id'])")" \
-    && echo "Fetched libbambu_networking.so from private cache")
-
-# TLS certificate for Bambu Cloud MQTT
-RUN curl -fSL -o /out/cert/slicer_base64.cer \
-       "https://raw.githubusercontent.com/bambulab/BambuStudio/master/resources/cert/slicer_base64.cer"
-
-# ---------------------------------------------------------------------------
 # Main image
 # ---------------------------------------------------------------------------
 FROM estampo/cura-base:${CURA_VERSION}
 
-ARG BAMBOX_VERSION=0.4.7
+ARG BAMBOX_VERSION=0.6.1
 
 USER root
 
 LABEL org.opencontainers.image.description="estampo with CuraEngine ${CURA_VERSION}"
-
-# bambox-bridge + libbambu_networking.so + TLS cert
-COPY --from=bridge-fetcher /usr/local/bin/bambox-bridge /usr/local/bin/bambox-bridge
-COPY --from=bridge-fetcher /out/lib/libbambu_networking.so /usr/lib/libbambu_networking.so
-COPY --from=bridge-fetcher /out/cert/slicer_base64.cer /tmp/bambu_agent/cert/slicer_base64.cer
-ENV BAMBU_LIB_PATH=/usr/lib/libbambu_networking.so
 
 # Install uv (fast Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/changes/+bump-bambox-0.6.1.misc
+++ b/changes/+bump-bambox-0.6.1.misc
@@ -1,0 +1,1 @@
+Bump bundled ``bambox`` to 0.6.1 in both Docker images. bambox 0.5.0 removed its cloud-printing bridge (now in ``estampo/boo-cloud``), so the ``bambox-bridge`` binary is no longer published — the ``bridge-fetcher`` stage (bridge binary, ``libbambu_networking.so``, Bambu TLS cert) and its ``BNL_TOKEN`` build-arg plumbing are removed from ``Dockerfile`` and ``Dockerfile.cura``.


### PR DESCRIPTION
Bumps bundled `bambox` from `0.4.7` to `0.6.1` (latest) in both Docker images — and removes the now-broken cloud-bridge plumbing.

## Why this is more than a pin bump

bambox **0.5.0** extracted all cloud-printing code into the separate `estampo/boo-cloud` project:

> Extract cloud printing into a separate `boo-cloud` project; remove `bridge.py`, `credentials.py`, `auth.py` and all cloud CLI commands… Bridge now lives in estampo/boo-cloud.

Consequently the `bambox-bridge-linux-x86_64` release asset is **no longer published** (v0.6.1 ships only the `.whl`). A naive pin bump breaks both Docker builds — the `bridge-fetcher` stage's `curl -fSL … bambox-bridge-linux-x86_64` would 404.

This is also consistent with **ADR-005** (estampo is printer-agnostic; Bambu cloud code does not belong in the estampo image).

## Changes

- `BAMBOX_VERSION` `0.4.7` → `0.6.1` (pip install still works; 0.6.1 adds `extract_print_info()`, otherwise license/dedup cleanup)
- Remove the `bridge-fetcher` stage (bridge binary, `libbambu_networking.so`, Bambu TLS cert) + its `COPY`/`ENV BAMBU_LIB_PATH` refs from `Dockerfile` and `Dockerfile.cura`
- Drop the now-unused `BNL_TOKEN` build-arg from the `release`, `publish-docker`, `slice`, and `release-readiness` workflows

The separate **cloud-bridge image** (`Dockerfile.cloud-bridge`, `build-docker.sh cloud-bridge` target) still uses `BNL_TOKEN` and is intentionally left untouched.

## Checks (all pass locally)
- `ruff check` ✅
- `ruff format --check` ✅
- `mypy src/estampo` ✅
- `pytest` ✅ (658 passed, 9 skipped)
- All `.github/workflows/*.yml` parse ✅

> ⚠️ I could not build the Docker images locally (docker-in-docker isn't available in this sandbox). The `release-readiness` CI does a real Docker build + slice — worth confirming that goes green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
